### PR TITLE
Review followups after the controller/service refactor

### DIFF
--- a/lib/Controller/PadController.php
+++ b/lib/Controller/PadController.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace OCA\EtherpadNextcloud\Controller;
 
+use OCA\EtherpadNextcloud\Exception\ControllerBadRequestException;
+use OCA\EtherpadNextcloud\Exception\UnauthorizedRequestException;
 use OCA\EtherpadNextcloud\Service\BindingService;
 use OCA\EtherpadNextcloud\Service\PadCreationService;
 use OCA\EtherpadNextcloud\Service\PadInitializationService;
@@ -45,16 +47,8 @@ class PadController extends Controller {
 
 	#[\OCP\AppFramework\Http\Attribute\NoAdminRequired]
 	public function create(string $file, string $accessMode = BindingService::ACCESS_PROTECTED): DataResponse {
-		$user = $this->requireUser();
-		if ($user instanceof DataResponse) {
-			return $user;
-		}
-		if (!$this->isValidAccessMode($accessMode)) {
-			return $this->invalidAccessModeResponse();
-		}
-
-		return $this->errors->run(
-			fn(): array => $this->padCreationService->create($user->getUID(), $file, $accessMode),
+		return $this->runForUser(
+			fn(IUser $user): array => $this->padCreationService->create($user->getUID(), $file, $this->requireAccessMode($accessMode)),
 			fn(array $result): DataResponse => new DataResponse($this->padResponses->withViewerUrl($result)),
 			[
 				'invalid_argument' => 'Invalid file path.',
@@ -67,20 +61,13 @@ class PadController extends Controller {
 
 	#[\OCP\AppFramework\Http\Attribute\NoAdminRequired]
 	public function createByParent(int $parentFolderId, string $name, string $accessMode = BindingService::ACCESS_PROTECTED): DataResponse {
-		$user = $this->requireUser();
-		if ($user instanceof DataResponse) {
-			return $user;
-		}
-		$fileIdError = $this->requirePositiveInt($parentFolderId, 'Invalid parentFolderId.');
-		if ($fileIdError instanceof DataResponse) {
-			return $fileIdError;
-		}
-		if (!$this->isValidAccessMode($accessMode)) {
-			return $this->invalidAccessModeResponse();
-		}
-
-		return $this->errors->run(
-			fn(): array => $this->padCreationService->createInParent($user->getUID(), $parentFolderId, $name, $accessMode),
+		return $this->runForUser(
+			fn(IUser $user): array => $this->padCreationService->createInParent(
+				$user->getUID(),
+				$this->requirePositiveInt($parentFolderId, 'Invalid parentFolderId.'),
+				$name,
+				$this->requireAccessMode($accessMode),
+			),
 			fn(array $result): DataResponse => new DataResponse($this->padResponses->withViewerAndEmbedUrls($result)),
 			[
 				'invalid_argument' => 'Invalid pad name.',
@@ -94,13 +81,8 @@ class PadController extends Controller {
 
 	#[\OCP\AppFramework\Http\Attribute\NoAdminRequired]
 	public function createFromUrl(string $file, string $padUrl): DataResponse {
-		$user = $this->requireUser();
-		if ($user instanceof DataResponse) {
-			return $user;
-		}
-
-		return $this->errors->run(
-			fn(): array => $this->padCreationService->createFromUrl($user->getUID(), $file, $padUrl),
+		return $this->runForUser(
+			fn(IUser $user): array => $this->padCreationService->createFromUrl($user->getUID(), $file, $padUrl),
 			fn(array $result): DataResponse => new DataResponse($this->padResponses->withViewerUrl($result)),
 			[
 				'invalid_argument' => 'Invalid input.',
@@ -113,13 +95,8 @@ class PadController extends Controller {
 
 	#[\OCP\AppFramework\Http\Attribute\NoAdminRequired]
 	public function open(string $file): DataResponse {
-		$user = $this->requireUser();
-		if ($user instanceof DataResponse) {
-			return $user;
-		}
-
-		return $this->errors->run(
-			fn(): array => $this->padOpenService->openByPath($user->getUID(), $user->getDisplayName(), $file),
+		return $this->runForUser(
+			fn(IUser $user): array => $this->padOpenService->openByPath($user->getUID(), $user->getDisplayName(), $file),
 			fn(array $result): DataResponse => $this->padResponses->openResponse($result),
 			[
 				'invalid_argument' => 'Invalid file path.',
@@ -131,17 +108,8 @@ class PadController extends Controller {
 
 	#[\OCP\AppFramework\Http\Attribute\NoAdminRequired]
 	public function openById(int $fileId): DataResponse {
-		$user = $this->requireUser();
-		if ($user instanceof DataResponse) {
-			return $user;
-		}
-		$fileIdError = $this->requireFileId($fileId);
-		if ($fileIdError instanceof DataResponse) {
-			return $fileIdError;
-		}
-
-		return $this->errors->run(
-			fn(): array => $this->padOpenService->openById($user->getUID(), $user->getDisplayName(), $fileId),
+		return $this->runForUser(
+			fn(IUser $user): array => $this->padOpenService->openById($user->getUID(), $user->getDisplayName(), $this->requireFileId($fileId)),
 			fn(array $result): DataResponse => $this->padResponses->openResponse($result),
 			[
 				'not_found' => 'Cannot open selected .pad file.',
@@ -152,19 +120,14 @@ class PadController extends Controller {
 
 	#[\OCP\AppFramework\Http\Attribute\NoAdminRequired]
 	public function initialize(string $file): DataResponse {
-		$user = $this->requireUser();
-		if ($user instanceof DataResponse) {
-			return $user;
-		}
-
-		return $this->errors->run(
-			fn(): array => $this->padInitializationService->initializeByPath($user->getUID(), $file),
+		return $this->runForUser(
+			fn(IUser $user): array => $this->padInitializationService->initializeByPath($user->getUID(), $file),
 			fn(array $result): DataResponse => new DataResponse($result),
 			[
 				'invalid_argument' => 'Invalid file path.',
 				'not_found' => 'Cannot open selected .pad file.',
 				'generic' => 'Pad initialization failed.',
-					'on_throwable' => fn(\Throwable $e) => $this->logError('Pad frontmatter initialization failed in API initialize', [
+				'on_throwable' => fn(\Throwable $e) => $this->logError('Pad frontmatter initialization failed in API initialize', [
 					'file' => $file,
 					'exception' => $e,
 				]),
@@ -174,22 +137,13 @@ class PadController extends Controller {
 
 	#[\OCP\AppFramework\Http\Attribute\NoAdminRequired]
 	public function initializeById(int $fileId): DataResponse {
-		$user = $this->requireUser();
-		if ($user instanceof DataResponse) {
-			return $user;
-		}
-		$fileIdError = $this->requireFileId($fileId);
-		if ($fileIdError instanceof DataResponse) {
-			return $fileIdError;
-		}
-
-		return $this->errors->run(
-			fn(): array => $this->padInitializationService->initializeById($user->getUID(), $fileId),
+		return $this->runForUser(
+			fn(IUser $user): array => $this->padInitializationService->initializeById($user->getUID(), $this->requireFileId($fileId)),
 			fn(array $result): DataResponse => new DataResponse($result),
 			[
 				'not_found' => 'Cannot open selected .pad file.',
 				'generic' => 'Pad initialization failed.',
-					'on_throwable' => fn(\Throwable $e) => $this->logError('Pad frontmatter initialization failed in API initialize-by-id', [
+				'on_throwable' => fn(\Throwable $e) => $this->logError('Pad frontmatter initialization failed in API initialize-by-id', [
 					'fileId' => $fileId,
 					'exception' => $e,
 				]),
@@ -200,17 +154,8 @@ class PadController extends Controller {
 	#[\OCP\AppFramework\Http\Attribute\NoAdminRequired]
 	#[\OCP\AppFramework\Http\Attribute\NoCSRFRequired]
 	public function metaById(int $fileId): DataResponse {
-		$user = $this->requireUser();
-		if ($user instanceof DataResponse) {
-			return $user;
-		}
-		$fileIdError = $this->requireFileId($fileId);
-		if ($fileIdError instanceof DataResponse) {
-			return $fileIdError;
-		}
-
-		return $this->errors->run(
-			fn(): array => $this->padMetadataService->metaById($user->getUID(), $fileId),
+		return $this->runForUser(
+			fn(IUser $user): array => $this->padMetadataService->metaById($user->getUID(), $this->requireFileId($fileId)),
 			fn(array $data): DataResponse => new DataResponse(
 				($data['is_pad'] ?? false) === true
 					? $this->padResponses->withViewerAndEmbedUrls($data)
@@ -226,13 +171,8 @@ class PadController extends Controller {
 	#[\OCP\AppFramework\Http\Attribute\NoAdminRequired]
 	#[\OCP\AppFramework\Http\Attribute\NoCSRFRequired]
 	public function resolveById(int $fileId = 0, string $file = ''): DataResponse {
-		$user = $this->requireUser();
-		if ($user instanceof DataResponse) {
-			return $user;
-		}
-
-		return $this->errors->run(
-			fn(): array => $this->padMetadataService->resolve($user->getUID(), $fileId, $file),
+		return $this->runForUser(
+			fn(IUser $user): array => $this->padMetadataService->resolve($user->getUID(), $fileId, $file),
 			fn(array $data): DataResponse => new DataResponse(
 				($data['is_pad'] ?? false) === true
 					? $this->padResponses->withViewerUrl($data)
@@ -247,20 +187,11 @@ class PadController extends Controller {
 
 	#[\OCP\AppFramework\Http\Attribute\NoAdminRequired]
 	public function syncById(int $fileId): DataResponse {
-		$user = $this->requireUser();
-		if ($user instanceof DataResponse) {
-			return $user;
-		}
-		$fileIdError = $this->requireFileId($fileId);
-		if ($fileIdError instanceof DataResponse) {
-			return $fileIdError;
-		}
-
 		$forceParam = (string)$this->request->getParam('force', '0');
 		$force = in_array(strtolower($forceParam), ['1', 'true', 'yes'], true);
 
-		return $this->errors->run(
-			fn(): array => $this->padSyncService->syncById($user->getUID(), $fileId, $force),
+		return $this->runForUser(
+			fn(IUser $user): array => $this->padSyncService->syncById($user->getUID(), $this->requireFileId($fileId), $force),
 			fn(array $result): DataResponse => new DataResponse($result),
 			[
 				'not_found' => 'Cannot resolve file path for file ID.',
@@ -272,17 +203,8 @@ class PadController extends Controller {
 	#[\OCP\AppFramework\Http\Attribute\NoAdminRequired]
 	#[\OCP\AppFramework\Http\Attribute\NoCSRFRequired]
 	public function syncStatusById(int $fileId): DataResponse {
-		$user = $this->requireUser();
-		if ($user instanceof DataResponse) {
-			return $user;
-		}
-		$fileIdError = $this->requireFileId($fileId);
-		if ($fileIdError instanceof DataResponse) {
-			return $fileIdError;
-		}
-
-		return $this->errors->run(
-			fn(): array => $this->padSyncService->syncStatusById($user->getUID(), $fileId),
+		return $this->runForUser(
+			fn(IUser $user): array => $this->padSyncService->syncStatusById($user->getUID(), $this->requireFileId($fileId)),
 			fn(array $result): DataResponse => new DataResponse($result),
 			[
 				'not_found' => 'Cannot read selected .pad file.',
@@ -293,19 +215,14 @@ class PadController extends Controller {
 
 	#[\OCP\AppFramework\Http\Attribute\NoAdminRequired]
 	public function trash(string $file): DataResponse {
-		$user = $this->requireUser();
-		if ($user instanceof DataResponse) {
-			return $user;
-		}
-
-		return $this->errors->run(
-			fn(): array => $this->padLifecycleOperations->trashByPath($user->getUID(), $file),
+		return $this->runForUser(
+			fn(IUser $user): array => $this->padLifecycleOperations->trashByPath($user->getUID(), $file),
 			fn(array $result): DataResponse => $this->padResponses->lifecycleResponse($result),
 			[
 				'invalid_argument' => 'Invalid file path.',
 				'not_found' => 'Pad file not found.',
 				'generic' => 'Trash failed.',
-					'on_throwable' => fn(\Throwable $e) => $this->logError('Pad trash API failed', [
+				'on_throwable' => fn(\Throwable $e) => $this->logError('Pad trash API failed', [
 					'file' => $file,
 					'exception' => $e,
 				]),
@@ -315,19 +232,14 @@ class PadController extends Controller {
 
 	#[\OCP\AppFramework\Http\Attribute\NoAdminRequired]
 	public function restore(string $file): DataResponse {
-		$user = $this->requireUser();
-		if ($user instanceof DataResponse) {
-			return $user;
-		}
-
-		return $this->errors->run(
-			fn(): array => $this->padLifecycleOperations->restoreByPath($user->getUID(), $file),
+		return $this->runForUser(
+			fn(IUser $user): array => $this->padLifecycleOperations->restoreByPath($user->getUID(), $file),
 			fn(array $result): DataResponse => $this->padResponses->lifecycleResponse($result),
 			[
 				'invalid_argument' => 'Invalid file path.',
 				'not_found' => 'Pad file not found.',
 				'generic' => 'Restore failed.',
-					'on_throwable' => fn(\Throwable $e) => $this->logError('Pad restore API failed', [
+				'on_throwable' => fn(\Throwable $e) => $this->logError('Pad restore API failed', [
 					'file' => $file,
 					'exception' => $e,
 				]),
@@ -335,31 +247,43 @@ class PadController extends Controller {
 		);
 	}
 
-	private function requireUser(): IUser|DataResponse {
+	/**
+	 * @param callable(IUser): mixed $action
+	 * @param callable(mixed): DataResponse $success
+	 * @param array<string,mixed> $options
+	 */
+	private function runForUser(callable $action, callable $success, array $options = []): DataResponse {
+		return $this->errors->run(
+			fn(): mixed => $action($this->requireUser()),
+			$success,
+			$options,
+		);
+	}
+
+	private function requireUser(): IUser {
 		$user = $this->userSession->getUser();
 		if ($user === null) {
-			return new DataResponse(['message' => 'Authentication required.'], Http::STATUS_UNAUTHORIZED);
+			throw new UnauthorizedRequestException('Authentication required.');
 		}
 		return $user;
 	}
 
-	private function requireFileId(int $fileId): ?DataResponse {
+	private function requireFileId(int $fileId): int {
 		return $this->requirePositiveInt($fileId, 'Invalid file ID.');
 	}
 
-	private function requirePositiveInt(int $value, string $message): ?DataResponse {
+	private function requirePositiveInt(int $value, string $message): int {
 		if ($value <= 0) {
-			return new DataResponse(['message' => $message], Http::STATUS_BAD_REQUEST);
+			throw new ControllerBadRequestException($message);
 		}
-		return null;
+		return $value;
 	}
 
-	private function isValidAccessMode(string $accessMode): bool {
-		return in_array($accessMode, [BindingService::ACCESS_PUBLIC, BindingService::ACCESS_PROTECTED], true);
-	}
-
-	private function invalidAccessModeResponse(): DataResponse {
-		return new DataResponse(['message' => 'Invalid accessMode. Use public or protected.'], Http::STATUS_BAD_REQUEST);
+	private function requireAccessMode(string $accessMode): string {
+		if (!in_array($accessMode, [BindingService::ACCESS_PUBLIC, BindingService::ACCESS_PROTECTED], true)) {
+			throw new ControllerBadRequestException('Invalid accessMode. Use public or protected.');
+		}
+		return $accessMode;
 	}
 
 	/** @param array<string,mixed> $context */

--- a/lib/Controller/PadController.php
+++ b/lib/Controller/PadController.php
@@ -64,7 +64,7 @@ class PadController extends Controller {
 		return $this->runForUser(
 			fn(IUser $user): array => $this->padCreationService->createInParent(
 				$user->getUID(),
-				$this->requirePositiveInt($parentFolderId, 'Invalid parentFolderId.'),
+				$this->requireParentFolderId($parentFolderId),
 				$name,
 				$this->requireAccessMode($accessMode),
 			),
@@ -270,6 +270,10 @@ class PadController extends Controller {
 
 	private function requireFileId(int $fileId): int {
 		return $this->requirePositiveInt($fileId, 'Invalid file ID.');
+	}
+
+	private function requireParentFolderId(int $parentFolderId): int {
+		return $this->requirePositiveInt($parentFolderId, 'Invalid parentFolderId.');
 	}
 
 	private function requirePositiveInt(int $value, string $message): int {

--- a/lib/Controller/PadControllerErrorMapper.php
+++ b/lib/Controller/PadControllerErrorMapper.php
@@ -10,10 +10,12 @@ declare(strict_types=1);
 namespace OCA\EtherpadNextcloud\Controller;
 
 use OCA\EtherpadNextcloud\Exception\BindingException;
+use OCA\EtherpadNextcloud\Exception\ControllerBadRequestException;
 use OCA\EtherpadNextcloud\Exception\EtherpadClientException;
 use OCA\EtherpadNextcloud\Exception\PadFileAlreadyExistsException;
 use OCA\EtherpadNextcloud\Exception\PadFileFormatException;
 use OCA\EtherpadNextcloud\Exception\PadParentFolderNotWritableException;
+use OCA\EtherpadNextcloud\Exception\UnauthorizedRequestException;
 use OCA\EtherpadNextcloud\Service\PadResponseService;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataResponse;
@@ -49,6 +51,14 @@ class PadControllerErrorMapper {
 	public function run(callable $action, callable $success, array $options = []): DataResponse {
 		try {
 			return $success($action());
+		} catch (UnauthorizedRequestException $e) {
+			return new DataResponse([
+				'message' => $e->getMessage() !== '' ? $e->getMessage() : 'Authentication required.',
+			], Http::STATUS_UNAUTHORIZED);
+		} catch (ControllerBadRequestException $e) {
+			return new DataResponse([
+				'message' => $e->getMessage() !== '' ? $e->getMessage() : 'Invalid input.',
+			], Http::STATUS_BAD_REQUEST);
 		} catch (\InvalidArgumentException $e) {
 			$configuredMessage = isset($options['invalid_argument'])
 				? (string)$options['invalid_argument']

--- a/lib/Controller/PublicViewerController.php
+++ b/lib/Controller/PublicViewerController.php
@@ -12,6 +12,7 @@ namespace OCA\EtherpadNextcloud\Controller;
 
 use OCA\EtherpadNextcloud\Exception\BindingException;
 use OCA\EtherpadNextcloud\Exception\EtherpadClientException;
+use OCA\EtherpadNextcloud\Exception\MissingBindingException;
 use OCA\EtherpadNextcloud\Exception\PadFileFormatException;
 use OCA\EtherpadNextcloud\Service\BindingService;
 use OCA\EtherpadNextcloud\Service\EtherpadClient;
@@ -221,7 +222,7 @@ class PublicViewerController extends PublicShareController {
 			return 'The selected .pad file has an invalid format.';
 		}
 		if ($error instanceof BindingException) {
-			if (trim($message) === 'No binding exists for this file.') {
+			if ($error instanceof MissingBindingException) {
 				return 'The selected .pad file is a copied file without an active pad binding. Please open the original shared .pad file.';
 			}
 			return 'Pad binding is inconsistent. Please contact the share owner.';

--- a/lib/Exception/ControllerBadRequestException.php
+++ b/lib/Exception/ControllerBadRequestException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Copyright (c) 2026 Jacob Bühler
+ */
+
+namespace OCA\EtherpadNextcloud\Exception;
+
+class ControllerBadRequestException extends \InvalidArgumentException {
+}

--- a/lib/Exception/MissingBindingException.php
+++ b/lib/Exception/MissingBindingException.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * Copyright (c) 2026 Jacob Bühler
+ */
+
+namespace OCA\EtherpadNextcloud\Exception;
+
+final class MissingBindingException extends BindingException {
+}

--- a/lib/Exception/PadFileLockRetryExhaustedException.php
+++ b/lib/Exception/PadFileLockRetryExhaustedException.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Copyright (c) 2026 Jacob Bühler
+ */
+
+namespace OCA\EtherpadNextcloud\Exception;
+
+use OCP\Lock\LockedException;
+
+class PadFileLockRetryExhaustedException extends \RuntimeException {
+	public function __construct(
+		private int $retryAttempts,
+		private LockedException $lockedException,
+	) {
+		parent::__construct($lockedException->getMessage(), (int)$lockedException->getCode(), $lockedException);
+	}
+
+	public function getRetryAttempts(): int {
+		return $this->retryAttempts;
+	}
+
+	public function getLockedException(): LockedException {
+		return $this->lockedException;
+	}
+}

--- a/lib/Exception/UnauthorizedRequestException.php
+++ b/lib/Exception/UnauthorizedRequestException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Copyright (c) 2026 Jacob Bühler
+ */
+
+namespace OCA\EtherpadNextcloud\Exception;
+
+class UnauthorizedRequestException extends \RuntimeException {
+}

--- a/lib/Service/BindingService.php
+++ b/lib/Service/BindingService.php
@@ -11,6 +11,7 @@ namespace OCA\EtherpadNextcloud\Service;
 
 use OCA\EtherpadNextcloud\Exception\BindingException;
 use OCA\EtherpadNextcloud\Exception\BindingStateConflictException;
+use OCA\EtherpadNextcloud\Exception\MissingBindingException;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
 use Psr\Log\LoggerInterface;
@@ -175,7 +176,7 @@ class BindingService {
 		$this->assertAccessMode($accessMode);
 		$binding = $this->findByFileId($fileId);
 		if ($binding === null) {
-			throw new BindingException('No binding exists for this file.');
+			throw new MissingBindingException('No binding exists for this file.');
 		}
 		if ((string)$binding['pad_id'] !== $padId) {
 			throw new BindingException('Binding pad ID mismatch.');

--- a/lib/Service/EtherpadClient.php
+++ b/lib/Service/EtherpadClient.php
@@ -130,6 +130,10 @@ class EtherpadClient {
 		return $this->sendPinnedPublicGetRequest($url, $resolved['host'], $resolved['port'], $resolved['resolved_ips']);
 	}
 
+	public function assertPublicPadAvailable(string $padUrl): void {
+		$this->getPublicTextFromPadUrl($padUrl);
+	}
+
 	/** @return array{origin:string,pad_id:string,pad_url:string} */
 	public function normalizeAndValidateExternalPublicPadUrl(string $padUrl): array {
 		$resolved = $this->resolveAndValidateExternalPublicPadUrl($padUrl);

--- a/lib/Service/PadCreationService.php
+++ b/lib/Service/PadCreationService.php
@@ -179,8 +179,7 @@ class PadCreationService {
 			}
 
 			$bindingPadId = $this->rollbackService->buildExternalBindingPadId($external['origin'], $external['pad_id'], $fileId);
-			// Validate that the target behaves like a public Etherpad pad before persisting binding.
-			$this->etherpadClient->getPublicTextFromPadUrl($external['pad_url']);
+			$this->etherpadClient->assertPublicPadAvailable($external['pad_url']);
 			$content = $this->padFileService->buildInitialDocument(
 				$fileId,
 				$bindingPadId,

--- a/lib/Service/PadCreationService.php
+++ b/lib/Service/PadCreationService.php
@@ -37,57 +37,64 @@ class PadCreationService {
 		$padId = '';
 		$fileCreated = false;
 
-		try {
-			$fileNode = $this->padFileCreator->createUserFile($uid, $path);
-			$fileCreated = true;
-			$fileId = (int)$fileNode->getId();
-			if ($fileId <= 0) {
-				throw new \RuntimeException('Could not resolve new file ID.');
-			}
-			$padId = $this->padBootstrapService->provisionPadId($accessMode);
-			$padUrl = $this->etherpadClient->buildPadUrl($padId);
+		return $this->withCreateRollback(
+			function () use ($uid, $path, $accessMode, &$padId, &$fileCreated): array {
+				$fileNode = $this->padFileCreator->createUserFile($uid, $path);
+				$fileCreated = true;
+				$fileId = (int)$fileNode->getId();
+				if ($fileId <= 0) {
+					throw new \RuntimeException('Could not resolve new file ID.');
+				}
+				$padId = $this->padBootstrapService->provisionPadId($accessMode);
+				$padUrl = $this->etherpadClient->buildPadUrl($padId);
 
-			$content = $this->padFileService->buildInitialDocument(
-				$fileId,
-				$padId,
-				$accessMode,
-				'',
-				$padUrl
-			);
-			$fileNode->putContent($content);
+				$content = $this->padFileService->buildInitialDocument(
+					$fileId,
+					$padId,
+					$accessMode,
+					'',
+					$padUrl
+				);
+				$fileNode->putContent($content);
 
-			$this->bindingService->createBinding($fileId, $padId, $accessMode);
+				$this->bindingService->createBinding($fileId, $padId, $accessMode);
 
-			return [
-				'file' => $path,
-				'file_id' => $fileId,
-				'pad_id' => $padId,
-				'access_mode' => $accessMode,
-				'pad_url' => $padUrl,
-			];
-		} catch (BindingException $e) {
-			$this->logger->warning('Pad create hit existing binding', [
-				'app' => 'etherpad_nextcloud',
-				'file' => $path,
-				'accessMode' => $accessMode,
-				'padId' => $padId,
-				'exception' => $e,
-			]);
-			$this->rollbackService->rollbackFailedCreate($uid, $path, $padId, $fileCreated);
-			throw $e;
-		} catch (\Throwable $e) {
-			if (!($e instanceof PadFileAlreadyExistsException)) {
-				$this->logger->error('Pad creation failed', [
-					'app' => 'etherpad_nextcloud',
+				return [
 					'file' => $path,
-					'accessMode' => $accessMode,
-					'padId' => $padId,
-					'exception' => $e,
-				]);
-			}
-			$this->rollbackService->rollbackFailedCreate($uid, $path, $padId, $fileCreated);
-			throw $e;
-		}
+					'file_id' => $fileId,
+					'pad_id' => $padId,
+					'access_mode' => $accessMode,
+					'pad_url' => $padUrl,
+				];
+			},
+			function () use ($uid, $path, &$padId, &$fileCreated): void {
+				$this->rollbackService->rollbackFailedCreate($uid, $path, $padId, $fileCreated);
+			},
+			function (\Throwable $e) use ($path, $accessMode, &$padId): ?array {
+				if ($e instanceof BindingException) {
+					return [
+						'message' => 'Pad create hit existing binding',
+						'context' => [
+							'file' => $path,
+							'accessMode' => $accessMode,
+							'padId' => $padId,
+						],
+					];
+				}
+
+				return null;
+			},
+			function () use ($path, $accessMode, &$padId): array {
+				return [
+					'message' => 'Pad creation failed',
+					'context' => [
+						'file' => $path,
+						'accessMode' => $accessMode,
+						'padId' => $padId,
+					],
+				];
+			},
+		);
 	}
 
 	/**
@@ -104,62 +111,69 @@ class PadCreationService {
 		$fileCreated = false;
 		$path = '';
 
-		try {
-			$fileNode = $this->padFileCreator->createUserFileInFolder($parentFolder, $fileName);
-			$fileCreated = true;
-			$path = $this->userNodeResolver->toUserAbsolutePath($uid, $fileNode);
-			$fileId = (int)$fileNode->getId();
-			if ($fileId <= 0) {
-				throw new \RuntimeException('Could not resolve new file ID.');
-			}
+		return $this->withCreateRollback(
+			function () use ($uid, $parentFolder, $parentFolderId, $fileName, $accessMode, &$path, &$padId, &$fileCreated): array {
+				$fileNode = $this->padFileCreator->createUserFileInFolder($parentFolder, $fileName);
+				$fileCreated = true;
+				$path = $this->userNodeResolver->toUserAbsolutePath($uid, $fileNode);
+				$fileId = (int)$fileNode->getId();
+				if ($fileId <= 0) {
+					throw new \RuntimeException('Could not resolve new file ID.');
+				}
 
-			$padId = $this->padBootstrapService->provisionPadId($accessMode);
-			$padUrl = $this->etherpadClient->buildPadUrl($padId);
-			$content = $this->padFileService->buildInitialDocument(
-				$fileId,
-				$padId,
-				$accessMode,
-				'',
-				$padUrl
-			);
-			$fileNode->putContent($content);
-			$this->bindingService->createBinding($fileId, $padId, $accessMode);
+				$padId = $this->padBootstrapService->provisionPadId($accessMode);
+				$padUrl = $this->etherpadClient->buildPadUrl($padId);
+				$content = $this->padFileService->buildInitialDocument(
+					$fileId,
+					$padId,
+					$accessMode,
+					'',
+					$padUrl
+				);
+				$fileNode->putContent($content);
+				$this->bindingService->createBinding($fileId, $padId, $accessMode);
 
-			return [
-				'file' => $path,
-				'file_id' => $fileId,
-				'parent_folder_id' => $parentFolderId,
-				'pad_id' => $padId,
-				'access_mode' => $accessMode,
-				'pad_url' => $padUrl,
-			];
-		} catch (BindingException $e) {
-			$this->logger->warning('Pad creation by parent hit existing binding', [
-				'app' => 'etherpad_nextcloud',
-				'parentFolderId' => $parentFolderId,
-				'padName' => $name,
-				'path' => $path,
-				'accessMode' => $accessMode,
-				'padId' => $padId,
-				'exception' => $e,
-			]);
-			$this->rollbackService->rollbackFailedCreate($uid, $path, $padId, $fileCreated);
-			throw $e;
-		} catch (\Throwable $e) {
-			if (!($e instanceof PadFileAlreadyExistsException)) {
-				$this->logger->error('Pad creation by parent failed', [
-					'app' => 'etherpad_nextcloud',
-					'parentFolderId' => $parentFolderId,
-					'padName' => $name,
-					'path' => $path,
-					'accessMode' => $accessMode,
-					'padId' => $padId,
-					'exception' => $e,
-				]);
-			}
-			$this->rollbackService->rollbackFailedCreate($uid, $path, $padId, $fileCreated);
-			throw $e;
-		}
+				return [
+					'file' => $path,
+					'file_id' => $fileId,
+					'parent_folder_id' => $parentFolderId,
+					'pad_id' => $padId,
+					'access_mode' => $accessMode,
+					'pad_url' => $padUrl,
+				];
+			},
+			function () use ($uid, &$path, &$padId, &$fileCreated): void {
+				$this->rollbackService->rollbackFailedCreate($uid, $path, $padId, $fileCreated);
+			},
+			function (\Throwable $e) use ($parentFolderId, $name, $accessMode, &$path, &$padId): ?array {
+				if ($e instanceof BindingException) {
+					return [
+						'message' => 'Pad creation by parent hit existing binding',
+						'context' => [
+							'parentFolderId' => $parentFolderId,
+							'padName' => $name,
+							'path' => $path,
+							'accessMode' => $accessMode,
+							'padId' => $padId,
+						],
+					];
+				}
+
+				return null;
+			},
+			function () use ($parentFolderId, $name, $accessMode, &$path, &$padId): array {
+				return [
+					'message' => 'Pad creation by parent failed',
+					'context' => [
+						'parentFolderId' => $parentFolderId,
+						'padName' => $name,
+						'path' => $path,
+						'accessMode' => $accessMode,
+						'padId' => $padId,
+					],
+				];
+			},
+		);
 	}
 
 	/**
@@ -170,67 +184,113 @@ class PadCreationService {
 		$external = $this->etherpadClient->normalizeAndValidateExternalPublicPadUrl($padUrl);
 		$fileCreated = false;
 
-		try {
-			$fileNode = $this->padFileCreator->createUserFile($uid, $path);
-			$fileCreated = true;
-			$fileId = (int)$fileNode->getId();
-			if ($fileId <= 0) {
-				throw new \RuntimeException('Could not resolve new file ID.');
-			}
+		return $this->withCreateRollback(
+			function () use ($uid, $path, $external, &$fileCreated): array {
+				$fileNode = $this->padFileCreator->createUserFile($uid, $path);
+				$fileCreated = true;
+				$fileId = (int)$fileNode->getId();
+				if ($fileId <= 0) {
+					throw new \RuntimeException('Could not resolve new file ID.');
+				}
 
-			$bindingPadId = $this->rollbackService->buildExternalBindingPadId($external['origin'], $external['pad_id'], $fileId);
-			$this->etherpadClient->assertPublicPadAvailable($external['pad_url']);
-			$content = $this->padFileService->buildInitialDocument(
-				$fileId,
-				$bindingPadId,
-				BindingService::ACCESS_PUBLIC,
-				'',
-				$external['pad_url'],
-				[
-					'pad_origin' => $external['origin'],
-					'remote_pad_id' => $external['pad_id'],
-				]
-			);
-			$fileNode->putContent($content);
+				$bindingPadId = $this->rollbackService->buildExternalBindingPadId($external['origin'], $external['pad_id'], $fileId);
+				$this->etherpadClient->assertPublicPadAvailable($external['pad_url']);
+				$content = $this->padFileService->buildInitialDocument(
+					$fileId,
+					$bindingPadId,
+					BindingService::ACCESS_PUBLIC,
+					'',
+					$external['pad_url'],
+					[
+						'pad_origin' => $external['origin'],
+						'remote_pad_id' => $external['pad_id'],
+					]
+				);
+				$fileNode->putContent($content);
 
-			$this->bindingService->createBinding($fileId, $bindingPadId, BindingService::ACCESS_PUBLIC);
+				$this->bindingService->createBinding($fileId, $bindingPadId, BindingService::ACCESS_PUBLIC);
 
-			return [
-				'file' => $path,
-				'file_id' => $fileId,
-				'pad_id' => $bindingPadId,
-				'access_mode' => BindingService::ACCESS_PUBLIC,
-				'pad_url' => $external['pad_url'],
-			];
-		} catch (BindingException $e) {
-			$this->logger->warning('External pad URL already linked', [
-				'app' => 'etherpad_nextcloud',
-				'file' => $path,
-				'origin' => $external['origin'],
-				'remotePadId' => $external['pad_id'],
-				'exception' => $e,
-			]);
-			$this->rollbackService->rollbackExternalCreate($uid, $path, $fileCreated);
-			throw $e;
-		} catch (EtherpadClientException $e) {
-			$this->logger->warning('External pad URL validation failed', [
-				'app' => 'etherpad_nextcloud',
-				'file' => $path,
-				'padUrl' => $padUrl,
-				'exception' => $e,
-			]);
-			$this->rollbackService->rollbackExternalCreate($uid, $path, $fileCreated);
-			throw $e;
-		} catch (\Throwable $e) {
-			if (!($e instanceof PadFileAlreadyExistsException)) {
-				$this->logger->error('External pad create failed', [
-					'app' => 'etherpad_nextcloud',
+				return [
 					'file' => $path,
-					'padUrl' => $padUrl,
-					'exception' => $e,
-				]);
+					'file_id' => $fileId,
+					'pad_id' => $bindingPadId,
+					'access_mode' => BindingService::ACCESS_PUBLIC,
+					'pad_url' => $external['pad_url'],
+				];
+			},
+			function () use ($uid, $path, &$fileCreated): void {
+				$this->rollbackService->rollbackExternalCreate($uid, $path, $fileCreated);
+			},
+			function (\Throwable $e) use ($path, $padUrl, $external): ?array {
+				if ($e instanceof BindingException) {
+					return [
+						'message' => 'External pad URL already linked',
+						'context' => [
+							'file' => $path,
+							'origin' => $external['origin'],
+							'remotePadId' => $external['pad_id'],
+						],
+					];
+				}
+
+				if ($e instanceof EtherpadClientException) {
+					return [
+						'message' => 'External pad URL validation failed',
+						'context' => [
+							'file' => $path,
+							'padUrl' => $padUrl,
+						],
+					];
+				}
+
+				return null;
+			},
+			function () use ($path, $padUrl): array {
+				return [
+					'message' => 'External pad create failed',
+					'context' => [
+						'file' => $path,
+						'padUrl' => $padUrl,
+					],
+				];
+			},
+		);
+	}
+
+	/**
+	 * @template T
+	 * @param callable():T $action
+	 * @param callable():void $rollback
+	 * @param callable(\Throwable):?array{message:string,context:array<string,mixed>} $warningFor
+	 * @param callable():array{message:string,context:array<string,mixed>} $errorFor
+	 * @return T
+	 */
+	private function withCreateRollback(
+		callable $action,
+		callable $rollback,
+		callable $warningFor,
+		callable $errorFor,
+	): mixed {
+		try {
+			return $action();
+		} catch (\Throwable $e) {
+			$warning = $warningFor($e);
+			if ($warning !== null) {
+				$this->logger->warning($warning['message'], array_merge(
+					['app' => 'etherpad_nextcloud'],
+					$warning['context'],
+					['exception' => $e],
+				));
+			} elseif (!($e instanceof PadFileAlreadyExistsException)) {
+				$error = $errorFor();
+				$this->logger->error($error['message'], array_merge(
+					['app' => 'etherpad_nextcloud'],
+					$error['context'],
+					['exception' => $e],
+				));
 			}
-			$this->rollbackService->rollbackExternalCreate($uid, $path, $fileCreated);
+
+			$rollback();
 			throw $e;
 		}
 	}

--- a/lib/Service/PadFileLockRetryService.php
+++ b/lib/Service/PadFileLockRetryService.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace OCA\EtherpadNextcloud\Service;
 
+use OCA\EtherpadNextcloud\Exception\PadFileLockRetryExhaustedException;
 use OCP\Files\File;
 use OCP\Lock\LockedException;
 
@@ -46,18 +47,24 @@ class PadFileLockRetryService {
 		return (string)$node->getContent();
 	}
 
-	public function putContentWithSyncLockRetry(File $node, string $content, int &$lockRetries): void {
+	public function putContentWithSyncLockRetry(File $node, string $content): int {
+		$lockRetries = 0;
 		foreach (self::SYNC_LOCK_RETRY_DELAYS_US as $delay) {
 			try {
 				$node->putContent($content);
-				return;
+				return $lockRetries;
 			} catch (LockedException) {
 				$this->sleep($delay);
 				$lockRetries++;
 			}
 		}
 
-		$node->putContent($content);
+		try {
+			$node->putContent($content);
+			return $lockRetries;
+		} catch (LockedException $e) {
+			throw new PadFileLockRetryExhaustedException($lockRetries, $e);
+		}
 	}
 
 	private function sleep(int $delay): void {

--- a/lib/Service/PadInitializationService.php
+++ b/lib/Service/PadInitializationService.php
@@ -15,6 +15,9 @@ use OCP\Files\File;
 use OCP\Files\NotFoundException;
 
 class PadInitializationService {
+	public const STATUS_ALREADY_INITIALIZED = 'already_initialized';
+	public const STATUS_INITIALIZED = 'initialized';
+
 	public function __construct(
 		private PadFileService $padFileService,
 		private PadPathService $padPaths,
@@ -64,7 +67,7 @@ class PadInitializationService {
 			$parsed = $this->padFileService->parsePadFile($content);
 			$meta = $parsed['frontmatter'];
 			return [
-				'status' => 'already_initialized',
+				'status' => self::STATUS_ALREADY_INITIALIZED,
 				'file' => $path,
 				'file_id' => $fileId,
 				'pad_id' => (string)$meta['pad_id'],
@@ -82,7 +85,7 @@ class PadInitializationService {
 		$meta = $parsed['frontmatter'];
 
 		return [
-			'status' => 'initialized',
+			'status' => self::STATUS_INITIALIZED,
 			'file' => $path,
 			'file_id' => $fileId,
 			'pad_id' => (string)$meta['pad_id'],

--- a/lib/Service/PadLifecycleOperationService.php
+++ b/lib/Service/PadLifecycleOperationService.php
@@ -12,8 +12,6 @@ namespace OCA\EtherpadNextcloud\Service;
 use OCP\Files\NotFoundException;
 
 class PadLifecycleOperationService {
-	public const RESULT_SKIPPED = LifecycleService::RESULT_SKIPPED;
-
 	public function __construct(
 		private PadPathService $padPaths,
 		private UserNodeResolver $userNodeResolver,

--- a/lib/Service/PadMetadataService.php
+++ b/lib/Service/PadMetadataService.php
@@ -26,7 +26,7 @@ class PadMetadataService {
 	}
 
 	/**
-	 * @return array<string,mixed>
+	 * @return array{is_pad:false,file_id:int,name:string,path:string}|array{is_pad:true,is_pad_mime:bool,file_id:int,name:string,path:string,access_mode:string,is_external:bool,pad_id:string,pad_url:string,public_open_url:string}
 	 * @throws NotFoundException
 	 * @throws LockedException
 	 */
@@ -36,7 +36,7 @@ class PadMetadataService {
 		return $this->buildMeta($node, $absolutePath);
 	}
 
-	/** @return array<string,mixed> */
+	/** @return array{is_pad:false,file_id?:int,path?:string}|array{is_pad:true,is_pad_mime:bool,file_id:int,path:string,access_mode:string,is_external:bool,public_open_url:string} */
 	public function resolve(string $uid, int $fileId = 0, string $file = ''): array {
 		$resolvedFileId = $fileId;
 		if ($resolvedFileId > 0) {
@@ -73,7 +73,7 @@ class PadMetadataService {
 	}
 
 	/**
-	 * @return array<string,mixed>
+	 * @return array{is_pad:false,file_id:int,name:string,path:string}|array{is_pad:true,is_pad_mime:bool,file_id:int,name:string,path:string,access_mode:string,is_external:bool,pad_id:string,pad_url:string,public_open_url:string}
 	 * @throws LockedException
 	 */
 	private function buildMeta(File $node, string $absolutePath): array {
@@ -107,7 +107,7 @@ class PadMetadataService {
 		];
 	}
 
-	/** @return array<string,mixed> */
+	/** @return array{is_pad:true,is_pad_mime:bool,file_id:int,path:string,access_mode:string,is_external:bool,public_open_url:string} */
 	private function buildResolve(File $node, int $fileId, string $absolutePath): array {
 		$metadata = $this->readPadMetadata($node, $fileId, $absolutePath, false, 'Pad resolve metadata parse skipped');
 

--- a/lib/Service/PadOpenService.php
+++ b/lib/Service/PadOpenService.php
@@ -31,7 +31,7 @@ class PadOpenService {
 	}
 
 	/**
-	 * @return array<string,mixed>
+	 * @return array{file:string,file_id:int,pad_id:string,access_mode:string,pad_url:string,is_external:bool,original_pad_url:string,snapshot_text:string,url:string,cookie_header:string}
 	 * @throws NotFoundException
 	 */
 	public function openByPath(string $uid, string $displayName, string $file): array {
@@ -45,7 +45,7 @@ class PadOpenService {
 	}
 
 	/**
-	 * @return array<string,mixed>
+	 * @return array{file:string,file_id:int,pad_id:string,access_mode:string,pad_url:string,is_external:bool,original_pad_url:string,snapshot_text:string,url:string,cookie_header:string}
 	 * @throws NotFoundException
 	 */
 	public function openById(string $uid, string $displayName, int $fileId): array {
@@ -55,7 +55,7 @@ class PadOpenService {
 	}
 
 	/**
-	 * @return array<string,mixed>
+	 * @return array{file:string,file_id:int,pad_id:string,access_mode:string,pad_url:string,is_external:bool,original_pad_url:string,snapshot_text:string,url:string,cookie_header:string}
 	 * @throws BindingException
 	 * @throws EtherpadClientException
 	 * @throws LockedException
@@ -101,7 +101,7 @@ class PadOpenService {
 		}
 	}
 
-	/** @return array<string,mixed> */
+	/** @return array{file:string,file_id:int,pad_id:string,access_mode:string,pad_url:string,is_external:bool,original_pad_url:string,snapshot_text:string,url:string,cookie_header:string} */
 	private function buildOpenContext(
 		string $uid,
 		string $displayName,
@@ -137,6 +137,8 @@ class PadOpenService {
 			$url = $openContext['url'];
 			$cookieHeader = $this->padSessionService->buildSetCookieHeader($openContext['cookie']);
 		} else {
+			// Public pads intentionally open without an Etherpad session so
+			// Nextcloud user identity is not shared unless protected access needs it.
 			$url = $effectivePadUrl;
 		}
 

--- a/lib/Service/PadOpenService.php
+++ b/lib/Service/PadOpenService.php
@@ -91,7 +91,7 @@ class PadOpenService {
 				$snapshotText
 			);
 		} catch (LockedException $e) {
-			$this->logger->warning('Pad open deferred because .pad file is locked', [
+			$this->logger->info('Pad open deferred because .pad file is locked', [
 				'app' => 'etherpad_nextcloud',
 				'fileId' => (int)$node->getId(),
 				'path' => $absolutePath,

--- a/lib/Service/PadResponseService.php
+++ b/lib/Service/PadResponseService.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace OCA\EtherpadNextcloud\Service;
 
 use OCA\EtherpadNextcloud\Exception\BindingException;
+use OCA\EtherpadNextcloud\Exception\MissingBindingException;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\IURLGenerator;
@@ -42,7 +43,7 @@ class PadResponseService {
 
 	/** @param array<string,mixed> $data */
 	public function lifecycleResponse(array $data): DataResponse {
-		$status = ($data['status'] ?? '') === PadLifecycleOperationService::RESULT_SKIPPED
+		$status = ($data['status'] ?? '') === LifecycleService::RESULT_SKIPPED
 			? Http::STATUS_CONFLICT
 			: Http::STATUS_OK;
 		return new DataResponse($data, $status);
@@ -67,12 +68,7 @@ class PadResponseService {
 
 	public function bindingErrorMessage(BindingException $e): string {
 		$message = trim($e->getMessage());
-		if ($message === 'No binding exists for this file.') {
-			/*
-			 * Usually means a .pad file was copied without its DB binding. Keep
-			 * this string in sync with BindingService and translate it to
-			 * user-facing guidance here.
-			 */
+		if ($e instanceof MissingBindingException) {
 			return 'This .pad file is not linked to a managed pad. It looks like a copied .pad file. Open the original .pad file or create a new pad.';
 		}
 		return $message;

--- a/lib/Service/PadSessionService.php
+++ b/lib/Service/PadSessionService.php
@@ -29,7 +29,7 @@ class PadSessionService {
 		$validUntil = time() + $safeTtlSeconds;
 		$authorId = $this->resolveCachedAuthorId($uid);
 		if ($authorId !== '') {
-			$this->syncAuthorDisplayNameIfNeeded($uid, $authorId, $effectiveDisplayName);
+			$authorId = $this->syncAuthorMapping($uid, $authorId, $effectiveDisplayName);
 			try {
 				$sessionId = $this->etherpadClient->createSession($groupId, $authorId, $validUntil);
 				return [
@@ -43,7 +43,7 @@ class PadSessionService {
 
 		$authorId = $this->etherpadClient->createAuthorIfNotExistsFor('nc:' . $uid, $effectiveDisplayName);
 		$this->rememberAuthorId($uid, $authorId);
-		$this->syncAuthorDisplayNameIfNeeded($uid, $authorId, $effectiveDisplayName);
+		$this->rememberAuthorName($uid, $effectiveDisplayName);
 		$sessionId = $this->etherpadClient->createSession($groupId, $authorId, $validUntil);
 		return [
 			'url' => $this->etherpadClient->buildPadUrl($padId),
@@ -148,28 +148,33 @@ class PadSessionService {
 		return $host;
 	}
 
-	private function syncAuthorDisplayNameIfNeeded(string $uid, string $authorId, string $displayName): void {
+	private function syncAuthorMapping(string $uid, string $authorId, string $displayName): string {
 		$trimmedName = trim($displayName);
 		if ($trimmedName === '') {
-			return;
+			return $authorId;
 		}
 
+		try {
+			$syncedAuthorId = $this->etherpadClient->createAuthorIfNotExistsFor('nc:' . $uid, $trimmedName);
+		} catch (\Throwable) {
+			// Do not fail pad open if author name syncing is temporarily unavailable.
+			return $authorId;
+		}
+
+		if ($syncedAuthorId !== '' && $syncedAuthorId !== $authorId) {
+			$this->rememberAuthorId($uid, $syncedAuthorId);
+			$authorId = $syncedAuthorId;
+		}
 		$lastSyncedName = trim((string)$this->config->getUserValue(
 			$uid,
 			'etherpad_nextcloud',
 			self::USER_CONFIG_AUTHOR_NAME_KEY,
 			''
 		));
-		if ($lastSyncedName === $trimmedName) {
-			return;
-		}
-
-		try {
-			$this->etherpadClient->setAuthorName($authorId, $trimmedName);
+		if ($lastSyncedName !== $trimmedName) {
 			$this->rememberAuthorName($uid, $trimmedName);
-		} catch (\Throwable) {
-			// Do not fail pad open if author renaming is unavailable.
 		}
+		return $authorId;
 	}
 
 	private function resolveCachedAuthorId(string $uid): string {

--- a/lib/Service/PadSyncService.php
+++ b/lib/Service/PadSyncService.php
@@ -11,6 +11,7 @@ namespace OCA\EtherpadNextcloud\Service;
 
 use OCA\EtherpadNextcloud\Exception\BindingException;
 use OCA\EtherpadNextcloud\Exception\EtherpadClientException;
+use OCA\EtherpadNextcloud\Exception\PadFileLockRetryExhaustedException;
 use OCA\EtherpadNextcloud\Exception\PadFileFormatException;
 use OCP\Files\File;
 use OCP\Files\NotFoundException;
@@ -63,31 +64,15 @@ class PadSyncService {
 			$this->bindingService->assertConsistentMapping($fileId, $padId, $accessMode);
 
 			if ($isExternal) {
-				return $this->syncExternalPad($node, $fileId, $padId, $padUrl, (string)$currentContent, $force, $lockRetries);
+				return $this->syncExternalPad($node, $fileId, $padId, $padUrl, (string)$currentContent, $force);
 			}
 
-			return $this->syncInternalPad($node, $fileId, $padId, (string)$currentContent, $force, $lockRetries);
+			return $this->syncInternalPad($node, $fileId, $padId, (string)$currentContent, $force);
+		} catch (PadFileLockRetryExhaustedException $e) {
+			$lockRetries = $e->getRetryAttempts();
+			return $this->lockedSyncResponse($e->getLockedException(), $fileId, $absolutePath, $padId, $accessMode, $isExternal, $force, $lockRetries);
 		} catch (LockedException $e) {
-			$this->logger->info('Pad sync deferred because .pad file is locked', [
-				'app' => 'etherpad_nextcloud',
-				'fileId' => $fileId,
-				'path' => $absolutePath,
-				'padId' => $padId,
-				'accessMode' => $accessMode,
-				'external' => $isExternal,
-				'force' => $force,
-				'lockRetryAttempts' => $lockRetries,
-				'exception' => $e,
-			]);
-			return [
-				'status' => self::STATUS_LOCKED,
-				'file_id' => $fileId,
-				'pad_id' => $padId,
-				'external' => $isExternal,
-				'forced' => $force,
-				'lock_retries' => $lockRetries,
-				'retryable' => true,
-			];
+			return $this->lockedSyncResponse($e, $fileId, $absolutePath, $padId, $accessMode, $isExternal, $force, $lockRetries);
 		} catch (BindingException|PadFileFormatException|EtherpadClientException $e) {
 			throw $e;
 		} catch (\Throwable $e) {
@@ -157,7 +142,6 @@ class PadSyncService {
 		string $padUrl,
 		string $currentContent,
 		bool $force,
-		int &$lockRetries,
 	): array {
 		if ($padUrl === '') {
 			throw new EtherpadClientException('External pad URL metadata is missing or invalid.');
@@ -182,7 +166,7 @@ class PadSyncService {
 		$previousRev = $this->padFileService->getSnapshotRevision($currentContent);
 		$nextRev = max(0, $previousRev + 1);
 		$updatedContent = $this->padFileService->withExportSnapshot($currentContent, $text, '', $nextRev, false);
-		$this->lockRetryService->putContentWithSyncLockRetry($node, $updatedContent, $lockRetries);
+		$lockRetries = $this->lockRetryService->putContentWithSyncLockRetry($node, $updatedContent);
 
 		return [
 			'status' => self::STATUS_UPDATED,
@@ -202,7 +186,6 @@ class PadSyncService {
 		string $padId,
 		string $currentContent,
 		bool $force,
-		int &$lockRetries,
 	): array {
 		$currentRev = $this->etherpadClient->getRevisionsCount($padId);
 		$snapshotRev = $this->padFileService->getSnapshotRevision($currentContent);
@@ -238,7 +221,7 @@ class PadSyncService {
 		}
 
 		$updatedContent = $this->padFileService->withExportSnapshot($currentContent, $text, $html, $currentRev);
-		$this->lockRetryService->putContentWithSyncLockRetry($node, $updatedContent, $lockRetries);
+		$lockRetries = $this->lockRetryService->putContentWithSyncLockRetry($node, $updatedContent);
 
 		return [
 			'status' => self::STATUS_UPDATED,
@@ -248,6 +231,40 @@ class PadSyncService {
 			'forced' => $force,
 			'snapshot_rev' => $currentRev,
 			'lock_retries' => $lockRetries,
+		];
+	}
+
+	/** @return array<string,mixed> */
+	private function lockedSyncResponse(
+		LockedException $e,
+		int $fileId,
+		string $absolutePath,
+		string $padId,
+		string $accessMode,
+		bool $isExternal,
+		bool $force,
+		int $lockRetries,
+	): array {
+		$this->logger->info('Pad sync deferred because .pad file is locked', [
+			'app' => 'etherpad_nextcloud',
+			'fileId' => $fileId,
+			'path' => $absolutePath,
+			'padId' => $padId,
+			'accessMode' => $accessMode,
+			'external' => $isExternal,
+			'force' => $force,
+			'lockRetryAttempts' => $lockRetries,
+			'exception' => $e,
+		]);
+
+		return [
+			'status' => self::STATUS_LOCKED,
+			'file_id' => $fileId,
+			'pad_id' => $padId,
+			'external' => $isExternal,
+			'forced' => $force,
+			'lock_retries' => $lockRetries,
+			'retryable' => true,
 		];
 	}
 }

--- a/lib/Service/PadSyncService.php
+++ b/lib/Service/PadSyncService.php
@@ -18,6 +18,13 @@ use OCP\Lock\LockedException;
 use Psr\Log\LoggerInterface;
 
 class PadSyncService {
+	public const STATUS_UNCHANGED = 'unchanged';
+	public const STATUS_UPDATED = 'updated';
+	public const STATUS_LOCKED = 'locked';
+	public const STATUS_SYNCED = 'synced';
+	public const STATUS_OUT_OF_SYNC = 'out_of_sync';
+	public const STATUS_UNAVAILABLE = 'unavailable';
+
 	public function __construct(
 		private PadFileService $padFileService,
 		private UserNodeResolver $userNodeResolver,
@@ -61,7 +68,7 @@ class PadSyncService {
 
 			return $this->syncInternalPad($node, $fileId, $padId, (string)$currentContent, $force, $lockRetries);
 		} catch (LockedException $e) {
-			$this->logger->warning('Pad sync deferred because .pad file is locked', [
+			$this->logger->info('Pad sync deferred because .pad file is locked', [
 				'app' => 'etherpad_nextcloud',
 				'fileId' => $fileId,
 				'path' => $absolutePath,
@@ -73,7 +80,7 @@ class PadSyncService {
 				'exception' => $e,
 			]);
 			return [
-				'status' => 'locked',
+				'status' => self::STATUS_LOCKED,
 				'file_id' => $fileId,
 				'pad_id' => $padId,
 				'external' => $isExternal,
@@ -114,7 +121,7 @@ class PadSyncService {
 			$isExternal = $this->padFileService->isExternalFrontmatter($frontmatter, $padId);
 			if ($isExternal) {
 				return [
-					'status' => 'unavailable',
+					'status' => self::STATUS_UNAVAILABLE,
 					'in_sync' => null,
 					'reason' => 'external_no_revision',
 				];
@@ -125,7 +132,7 @@ class PadSyncService {
 			$inSync = $snapshotRev >= $currentRev;
 
 			return [
-				'status' => $inSync ? 'synced' : 'out_of_sync',
+				'status' => $inSync ? self::STATUS_SYNCED : self::STATUS_OUT_OF_SYNC,
 				'in_sync' => $inSync,
 				'snapshot_rev' => $snapshotRev,
 				'current_rev' => $currentRev,
@@ -164,7 +171,7 @@ class PadSyncService {
 		$existingText = $this->padFileService->getTextSnapshotForRestore($currentContent);
 		if ($existingText === $text) {
 			return [
-				'status' => 'unchanged',
+				'status' => self::STATUS_UNCHANGED,
 				'file_id' => $fileId,
 				'pad_id' => $padId,
 				'external' => true,
@@ -178,7 +185,7 @@ class PadSyncService {
 		$this->lockRetryService->putContentWithSyncLockRetry($node, $updatedContent, $lockRetries);
 
 		return [
-			'status' => 'updated',
+			'status' => self::STATUS_UPDATED,
 			'file_id' => $fileId,
 			'pad_id' => $padId,
 			'external' => true,
@@ -201,7 +208,7 @@ class PadSyncService {
 		$snapshotRev = $this->padFileService->getSnapshotRevision($currentContent);
 		if (!$force && $snapshotRev >= $currentRev) {
 			return [
-				'status' => 'unchanged',
+				'status' => self::STATUS_UNCHANGED,
 				'file_id' => $fileId,
 				'pad_id' => $padId,
 				'external' => false,
@@ -219,7 +226,7 @@ class PadSyncService {
 			$existingHtml = $this->padFileService->getHtmlSnapshotForRestore($currentContent);
 			if ($existingText === $text && $existingHtml === $html) {
 				return [
-					'status' => 'unchanged',
+					'status' => self::STATUS_UNCHANGED,
 					'file_id' => $fileId,
 					'pad_id' => $padId,
 					'external' => false,
@@ -234,7 +241,7 @@ class PadSyncService {
 		$this->lockRetryService->putContentWithSyncLockRetry($node, $updatedContent, $lockRetries);
 
 		return [
-			'status' => 'updated',
+			'status' => self::STATUS_UPDATED,
 			'file_id' => $fileId,
 			'pad_id' => $padId,
 			'external' => false,

--- a/lib/Service/PadSyncService.php
+++ b/lib/Service/PadSyncService.php
@@ -88,7 +88,7 @@ class PadSyncService {
 	}
 
 	/**
-	 * @return array<string,mixed>
+	 * @return array{status:string,in_sync:null,reason:string}|array{status:string,in_sync:bool,snapshot_rev:int,current_rev:int}
 	 * @throws NotFoundException
 	 */
 	public function syncStatusById(string $uid, int $fileId): array {
@@ -134,7 +134,7 @@ class PadSyncService {
 		}
 	}
 
-	/** @return array<string,mixed> */
+	/** @return array{status:string,file_id:int,pad_id:string,external:true,forced:bool}|array{status:string,file_id:int,pad_id:string,external:true,forced:bool,snapshot_rev:int,lock_retries:int} */
 	private function syncExternalPad(
 		File $node,
 		int $fileId,
@@ -179,7 +179,7 @@ class PadSyncService {
 		];
 	}
 
-	/** @return array<string,mixed> */
+	/** @return array{status:string,file_id:int,pad_id:string,external:false,forced:bool,snapshot_rev:int,current_rev:int}|array{status:string,file_id:int,pad_id:string,external:false,forced:bool,snapshot_rev:int,lock_retries:int} */
 	private function syncInternalPad(
 		File $node,
 		int $fileId,
@@ -234,7 +234,7 @@ class PadSyncService {
 		];
 	}
 
-	/** @return array<string,mixed> */
+	/** @return array{status:string,file_id:int,pad_id:string,external:bool,forced:bool,lock_retries:int,retryable:true} */
 	private function lockedSyncResponse(
 		LockedException $e,
 		int $fileId,

--- a/tests/phpunit/unit/BindingServiceTest.php
+++ b/tests/phpunit/unit/BindingServiceTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OCA\EtherpadNextcloud\Tests\Unit;
 
 use OCA\EtherpadNextcloud\Exception\BindingException;
+use OCA\EtherpadNextcloud\Exception\MissingBindingException;
 use OCA\EtherpadNextcloud\Service\BindingService;
 use OCP\IDBConnection;
 use PHPUnit\Framework\TestCase;
@@ -34,6 +35,15 @@ class BindingServiceTest extends TestCase {
 		$this->expectException(BindingException::class);
 		$this->expectExceptionMessage('Binding pad ID mismatch.');
 		$service->assertConsistentMapping(11, 'pad-b', BindingService::ACCESS_PROTECTED);
+	}
+
+	public function testAssertConsistentMappingRejectsMissingBindingWithSpecificException(): void {
+		$service = $this->buildServiceWithBinding(null);
+
+		$this->expectException(MissingBindingException::class);
+		$this->expectExceptionMessage('No binding exists for this file.');
+
+		$service->assertConsistentMapping(10, 'pad-123', BindingService::ACCESS_PUBLIC);
 	}
 
 	public function testAssertConsistentMappingRejectsUnsupportedAccessMode(): void {

--- a/tests/phpunit/unit/PadControllerErrorMapperTest.php
+++ b/tests/phpunit/unit/PadControllerErrorMapperTest.php
@@ -6,10 +6,12 @@ namespace OCA\EtherpadNextcloud\Tests\Unit;
 
 use OCA\EtherpadNextcloud\Controller\PadControllerErrorMapper;
 use OCA\EtherpadNextcloud\Exception\BindingException;
+use OCA\EtherpadNextcloud\Exception\ControllerBadRequestException;
 use OCA\EtherpadNextcloud\Exception\EtherpadClientException;
 use OCA\EtherpadNextcloud\Exception\PadFileAlreadyExistsException;
 use OCA\EtherpadNextcloud\Exception\PadFileFormatException;
 use OCA\EtherpadNextcloud\Exception\PadParentFolderNotWritableException;
+use OCA\EtherpadNextcloud\Exception\UnauthorizedRequestException;
 use OCA\EtherpadNextcloud\Service\AppConfigService;
 use OCA\EtherpadNextcloud\Service\PadResponseService;
 use OCP\AppFramework\Http;
@@ -30,6 +32,27 @@ class PadControllerErrorMapperTest extends TestCase {
 
 		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
 		$this->assertSame('Invalid file path.', $response->getData()['message']);
+	}
+
+	public function testRunMapsUnauthorizedRequest(): void {
+		$response = $this->buildMapper()->run(
+			static fn(): array => throw new UnauthorizedRequestException('Authentication required.'),
+			static fn(array $result): DataResponse => new DataResponse($result),
+		);
+
+		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+		$this->assertSame('Authentication required.', $response->getData()['message']);
+	}
+
+	public function testRunMapsControllerBadRequestWithoutOverridingMessage(): void {
+		$response = $this->buildMapper()->run(
+			static fn(): array => throw new ControllerBadRequestException('Invalid file ID.'),
+			static fn(array $result): DataResponse => new DataResponse($result),
+			['invalid_argument' => 'Invalid file path.'],
+		);
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame('Invalid file ID.', $response->getData()['message']);
 	}
 
 	public function testRunMapsInvalidArgumentWithDefaultMessageWhenMessagesAreEmpty(): void {

--- a/tests/phpunit/unit/PadControllerTest.php
+++ b/tests/phpunit/unit/PadControllerTest.php
@@ -440,7 +440,7 @@ class PadControllerTest extends TestCase {
 		);
 		$response = $controller->syncById(138);
 
-		$this->assertSame('updated', $response->getData()['status']);
+		$this->assertSame(PadSyncService::STATUS_UPDATED, $response->getData()['status']);
 		$this->assertFalse($response->getData()['external']);
 		$this->assertSame(2, $response->getData()['lock_retries']);
 		$this->assertSame(5, $response->getData()['snapshot_rev']);
@@ -493,7 +493,7 @@ class PadControllerTest extends TestCase {
 		);
 		$response = $controller->syncById(138);
 
-		$this->assertSame('locked', $response->getData()['status']);
+		$this->assertSame(PadSyncService::STATUS_LOCKED, $response->getData()['status']);
 		$this->assertTrue($response->getData()['retryable']);
 		$this->assertSame(3, $response->getData()['lock_retries']);
 	}
@@ -546,7 +546,7 @@ class PadControllerTest extends TestCase {
 		);
 		$response = $controller->syncById(138);
 
-		$this->assertSame('unchanged', $response->getData()['status']);
+		$this->assertSame(PadSyncService::STATUS_UNCHANGED, $response->getData()['status']);
 		$this->assertFalse($response->getData()['external']);
 		$this->assertTrue($response->getData()['forced']);
 		$this->assertSame(5, $response->getData()['snapshot_rev']);
@@ -604,7 +604,7 @@ class PadControllerTest extends TestCase {
 		);
 		$response = $controller->syncById(138);
 
-		$this->assertSame('unchanged', $response->getData()['status']);
+		$this->assertSame(PadSyncService::STATUS_UNCHANGED, $response->getData()['status']);
 		$this->assertTrue($response->getData()['external']);
 		$this->assertTrue($response->getData()['forced']);
 	}

--- a/tests/phpunit/unit/PadCreationServiceTest.php
+++ b/tests/phpunit/unit/PadCreationServiceTest.php
@@ -127,9 +127,8 @@ class PadCreationServiceTest extends TestCase {
 				'pad_id' => 'RemotePad',
 			]);
 		$etherpadClient->expects($this->once())
-			->method('getPublicTextFromPadUrl')
-			->with('https://pad.remote.test/p/RemotePad')
-			->willReturn('Remote text');
+			->method('assertPublicPadAvailable')
+			->with('https://pad.remote.test/p/RemotePad');
 
 		$padFileService = $this->createMock(PadFileService::class);
 		$padFileService->expects($this->once())

--- a/tests/phpunit/unit/PadCreationServiceTest.php
+++ b/tests/phpunit/unit/PadCreationServiceTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OCA\EtherpadNextcloud\Tests\Unit;
 
 use OCA\EtherpadNextcloud\Exception\BindingException;
+use OCA\EtherpadNextcloud\Exception\EtherpadClientException;
 use OCA\EtherpadNextcloud\Exception\PadParentFolderNotWritableException;
 use OCA\EtherpadNextcloud\Service\BindingService;
 use OCA\EtherpadNextcloud\Service\EtherpadClient;
@@ -161,6 +162,43 @@ class PadCreationServiceTest extends TestCase {
 			'access_mode' => BindingService::ACCESS_PUBLIC,
 			'pad_url' => 'https://pad.remote.test/p/RemotePad',
 		], $result);
+	}
+
+	public function testCreateFromUrlRollsBackWhenPublicPadValidationFails(): void {
+		$fileNode = $this->createMock(File::class);
+		$fileNode->method('getId')->willReturn(321);
+		$fileNode->expects($this->never())->method('putContent');
+
+		$padPaths = $this->createMock(PadPathService::class);
+		$padPaths->method('normalizeCreatePath')->with('/External')->willReturn('/External.pad');
+		$fileCreator = $this->createMock(PadFileCreator::class);
+		$fileCreator->method('createUserFile')->with('alice', '/External.pad')->willReturn($fileNode);
+		$rollbackService = $this->createMock(PadCreateRollbackService::class);
+		$rollbackService->method('buildExternalBindingPadId')->with('https://pad.remote.test', 'RemotePad', 321)->willReturn('ext.hash');
+		$rollbackService->expects($this->once())
+			->method('rollbackExternalCreate')
+			->with('alice', '/External.pad', true);
+
+		$etherpadClient = $this->createMock(EtherpadClient::class);
+		$etherpadClient->method('normalizeAndValidateExternalPublicPadUrl')
+			->with('https://pad.remote.test/p/RemotePad')
+			->willReturn([
+				'pad_url' => 'https://pad.remote.test/p/RemotePad',
+				'origin' => 'https://pad.remote.test',
+				'pad_id' => 'RemotePad',
+			]);
+		$etherpadClient->expects($this->once())
+			->method('assertPublicPadAvailable')
+			->with('https://pad.remote.test/p/RemotePad')
+			->willThrowException(new EtherpadClientException('Remote pad unavailable.'));
+
+		$padFileService = $this->createMock(PadFileService::class);
+		$padFileService->expects($this->never())->method('buildInitialDocument');
+
+		$this->expectException(EtherpadClientException::class);
+
+		$this->buildService($padFileService, $padPaths, $fileCreator, null, $rollbackService, etherpadClient: $etherpadClient)
+			->createFromUrl('alice', '/External', 'https://pad.remote.test/p/RemotePad');
 	}
 
 	private function buildService(

--- a/tests/phpunit/unit/PadFileLockRetryServiceTest.php
+++ b/tests/phpunit/unit/PadFileLockRetryServiceTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\EtherpadNextcloud\Tests\Unit;
+
+use OCA\EtherpadNextcloud\Service\PadFileLockRetryService;
+use OCP\Files\File;
+use OCP\Lock\LockedException;
+use PHPUnit\Framework\TestCase;
+
+class PadFileLockRetryServiceTest extends TestCase {
+	public function testReadContentPerformsFinalAttemptAfterConfiguredRetries(): void {
+		$sleeps = [];
+		$service = new PadFileLockRetryService(static function (int $delay) use (&$sleeps): void {
+			$sleeps[] = $delay;
+		});
+
+		$calls = 0;
+		$file = $this->createMock(File::class);
+		$file->expects($this->exactly(4))
+			->method('getContent')
+			->willReturnCallback(static function () use (&$calls): string {
+				$calls++;
+				if ($calls <= 3) {
+					throw new LockedException('locked');
+				}
+				return 'content';
+			});
+
+		$this->assertSame('content', $service->readContentWithOpenLockRetry($file));
+		$this->assertSame([100000, 200000, 400000], $sleeps);
+	}
+
+	public function testPutContentPerformsFinalAttemptAfterConfiguredRetries(): void {
+		$sleeps = [];
+		$service = new PadFileLockRetryService(static function (int $delay) use (&$sleeps): void {
+			$sleeps[] = $delay;
+		});
+
+		$calls = 0;
+		$file = $this->createMock(File::class);
+		$file->expects($this->exactly(4))
+			->method('putContent')
+			->with('content')
+			->willReturnCallback(static function () use (&$calls): void {
+				$calls++;
+				if ($calls <= 3) {
+					throw new LockedException('locked');
+				}
+			});
+
+		$lockRetries = 0;
+		$service->putContentWithSyncLockRetry($file, 'content', $lockRetries);
+
+		$this->assertSame(3, $lockRetries);
+		$this->assertSame([150000, 300000, 600000], $sleeps);
+	}
+}

--- a/tests/phpunit/unit/PadFileLockRetryServiceTest.php
+++ b/tests/phpunit/unit/PadFileLockRetryServiceTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace OCA\EtherpadNextcloud\Tests\Unit;
 
+use OCA\EtherpadNextcloud\Exception\PadFileLockRetryExhaustedException;
 use OCA\EtherpadNextcloud\Service\PadFileLockRetryService;
 use OCP\Files\File;
 use OCP\Lock\LockedException;
@@ -50,10 +51,31 @@ class PadFileLockRetryServiceTest extends TestCase {
 				}
 			});
 
-		$lockRetries = 0;
-		$service->putContentWithSyncLockRetry($file, 'content', $lockRetries);
+		$lockRetries = $service->putContentWithSyncLockRetry($file, 'content');
 
 		$this->assertSame(3, $lockRetries);
 		$this->assertSame([150000, 300000, 600000], $sleeps);
+	}
+
+	public function testPutContentThrowsRetryExhaustedWithRetryCount(): void {
+		$sleeps = [];
+		$service = new PadFileLockRetryService(static function (int $delay) use (&$sleeps): void {
+			$sleeps[] = $delay;
+		});
+
+		$file = $this->createMock(File::class);
+		$file->expects($this->exactly(4))
+			->method('putContent')
+			->with('content')
+			->willThrowException(new LockedException('locked'));
+
+		try {
+			$service->putContentWithSyncLockRetry($file, 'content');
+			$this->fail('Expected lock retry exhaustion.');
+		} catch (PadFileLockRetryExhaustedException $e) {
+			$this->assertSame(3, $e->getRetryAttempts());
+			$this->assertSame('locked', $e->getLockedException()->getMessage());
+			$this->assertSame([150000, 300000, 600000], $sleeps);
+		}
 	}
 }

--- a/tests/phpunit/unit/PadInitializationServiceTest.php
+++ b/tests/phpunit/unit/PadInitializationServiceTest.php
@@ -50,7 +50,7 @@ class PadInitializationServiceTest extends TestCase {
 		$result = (new PadInitializationService($padFileService, $padPaths, $userNodeResolver, $bootstrap))
 			->initializeByPath('alice', '/Existing.pad');
 
-		$this->assertSame('already_initialized', $result['status']);
+		$this->assertSame(PadInitializationService::STATUS_ALREADY_INITIALIZED, $result['status']);
 		$this->assertSame('/Existing.pad', $result['file']);
 		$this->assertSame(42, $result['file_id']);
 	}
@@ -85,7 +85,7 @@ class PadInitializationServiceTest extends TestCase {
 		$result = (new PadInitializationService($padFileService, $this->createMock(PadPathService::class), $userNodeResolver, $bootstrap))
 			->initializeById('alice', 42);
 
-		$this->assertSame('already_initialized', $result['status']);
+		$this->assertSame(PadInitializationService::STATUS_ALREADY_INITIALIZED, $result['status']);
 		$this->assertSame('/Existing.pad', $result['file']);
 		$this->assertSame(42, $result['file_id']);
 	}
@@ -131,7 +131,7 @@ class PadInitializationServiceTest extends TestCase {
 			->initialize('alice', $file, 'content');
 
 		$this->assertSame([
-			'status' => 'already_initialized',
+			'status' => PadInitializationService::STATUS_ALREADY_INITIALIZED,
 			'file' => '/Existing.pad',
 			'file_id' => 42,
 			'pad_id' => 'g.ABC$pad',
@@ -174,7 +174,7 @@ class PadInitializationServiceTest extends TestCase {
 			->initialize('alice', $file, 'legacy-content');
 
 		$this->assertSame([
-			'status' => 'initialized',
+			'status' => PadInitializationService::STATUS_INITIALIZED,
 			'file' => '/Legacy.pad',
 			'file_id' => 42,
 			'pad_id' => 'g.XYZ$pad',

--- a/tests/phpunit/unit/PadResponseServiceTest.php
+++ b/tests/phpunit/unit/PadResponseServiceTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace OCA\EtherpadNextcloud\Tests\Unit;
 
-use OCA\EtherpadNextcloud\Exception\BindingException;
+use OCA\EtherpadNextcloud\Exception\MissingBindingException;
 use OCA\EtherpadNextcloud\Service\AppConfigService;
-use OCA\EtherpadNextcloud\Service\PadLifecycleOperationService;
+use OCA\EtherpadNextcloud\Service\LifecycleService;
 use OCA\EtherpadNextcloud\Service\PadResponseService;
 use OCP\AppFramework\Http;
 use OCP\IURLGenerator;
@@ -61,7 +61,7 @@ class PadResponseServiceTest extends TestCase {
 			$this->createMock(IURLGenerator::class),
 			$this->createMock(AppConfigService::class),
 		))->lifecycleResponse([
-			'status' => PadLifecycleOperationService::RESULT_SKIPPED,
+			'status' => LifecycleService::RESULT_SKIPPED,
 			'reason' => 'binding_not_active',
 		]);
 
@@ -72,7 +72,7 @@ class PadResponseServiceTest extends TestCase {
 		$message = (new PadResponseService(
 			$this->createMock(IURLGenerator::class),
 			$this->createMock(AppConfigService::class),
-		))->bindingErrorMessage(new BindingException('No binding exists for this file.'));
+		))->bindingErrorMessage(new MissingBindingException('No binding exists for this file.'));
 
 		$this->assertSame('This .pad file is not linked to a managed pad. It looks like a copied .pad file. Open the original .pad file or create a new pad.', $message);
 	}

--- a/tests/phpunit/unit/PadSessionServiceTest.php
+++ b/tests/phpunit/unit/PadSessionServiceTest.php
@@ -152,7 +152,7 @@ class PadSessionServiceTest extends TestCase {
 		$this->assertStringNotContainsString("\r", $header);
 	}
 
-	public function testCreateProtectedOpenContextUsesCachedAuthorWithoutRecreatingAuthor(): void {
+	public function testCreateProtectedOpenContextRefreshesCachedAuthorMapping(): void {
 		$uid = 'alice';
 		$displayName = 'Alice Example';
 		$padId = 'g.ABCDEFGHIJKLMNOP$pad-1';
@@ -162,8 +162,10 @@ class PadSessionServiceTest extends TestCase {
 		$padUrl = 'https://pad.example.test/p/' . rawurlencode($padId);
 
 		$etherpadClient = $this->createMock(EtherpadClient::class);
-		$etherpadClient->expects($this->never())->method('createAuthorIfNotExistsFor');
-		$etherpadClient->expects($this->never())->method('setAuthorName');
+		$etherpadClient->expects($this->once())
+			->method('createAuthorIfNotExistsFor')
+			->with('nc:' . $uid, $displayName)
+			->willReturn($authorId);
 		$etherpadClient->expects($this->once())
 			->method('createSession')
 			->with($groupId, $authorId, $this->isType('int'))
@@ -205,8 +207,9 @@ class PadSessionServiceTest extends TestCase {
 
 		$etherpadClient = $this->createMock(EtherpadClient::class);
 		$etherpadClient->expects($this->once())
-			->method('setAuthorName')
-			->with($authorId, $displayName);
+			->method('createAuthorIfNotExistsFor')
+			->with('nc:' . $uid, $displayName)
+			->willReturn($authorId);
 		$etherpadClient->expects($this->once())
 			->method('createSession')
 			->with($groupId, $authorId, $this->isType('int'))
@@ -243,10 +246,15 @@ class PadSessionServiceTest extends TestCase {
 		$sessionId = 's.fresh';
 
 		$etherpadClient = $this->createMock(EtherpadClient::class);
-		$etherpadClient->expects($this->once())
+		$etherpadClient->expects($this->exactly(2))
 			->method('createAuthorIfNotExistsFor')
-			->with('nc:' . $uid, $displayName)
-			->willReturn($freshAuthorId);
+			->willReturnCallback(static function (string $authorMapper, string $name) use ($uid, $displayName, $cachedAuthorId, $freshAuthorId): string {
+				static $call = 0;
+				$call++;
+				TestCase::assertSame('nc:' . $uid, $authorMapper);
+				TestCase::assertSame($displayName, $name);
+				return $call === 1 ? $cachedAuthorId : $freshAuthorId;
+			});
 		$etherpadClient->expects($this->exactly(2))
 			->method('createSession')
 			->willReturnCallback(static function (string $actualGroupId, string $actualAuthorId, int $validUntil) use ($groupId, $cachedAuthorId, $freshAuthorId, $sessionId): string {
@@ -292,9 +300,22 @@ class PadSessionServiceTest extends TestCase {
 
 				TestCase::assertSame('etherpad_author_display_name', $key);
 			});
-		$config->expects($this->once())
+		$config->expects($this->exactly(2))
 			->method('setUserValue')
-			->with($uid, 'etherpad_nextcloud', 'etherpad_author_id', $freshAuthorId);
+			->willReturnCallback(static function (string $actualUid, string $appName, string $key, string $value) use ($uid, $freshAuthorId, $displayName): void {
+				static $call = 0;
+				$call++;
+				TestCase::assertSame($uid, $actualUid);
+				TestCase::assertSame('etherpad_nextcloud', $appName);
+				if ($call === 1) {
+					TestCase::assertSame('etherpad_author_id', $key);
+					TestCase::assertSame($freshAuthorId, $value);
+					return;
+				}
+
+				TestCase::assertSame('etherpad_author_display_name', $key);
+				TestCase::assertSame($displayName, $value);
+			});
 
 		$service = new PadSessionService($etherpadClient, $config);
 		$result = $service->createProtectedOpenContext($uid, $displayName, $padId);
@@ -315,9 +336,6 @@ class PadSessionServiceTest extends TestCase {
 			->with('nc:' . $uid, $displayName)
 			->willReturn($authorId);
 		$etherpadClient->expects($this->once())
-			->method('setAuthorName')
-			->with($authorId, $displayName);
-		$etherpadClient->expects($this->once())
 			->method('createSession')
 			->willReturn($sessionId);
 		$etherpadClient->method('buildPadUrl')->willReturn('https://pad.example.test/p/' . rawurlencode($padId));
@@ -329,10 +347,6 @@ class PadSessionServiceTest extends TestCase {
 				['etherpad_nextcloud', 'etherpad_cookie_domain_configured', 'no', 'no'],
 				['etherpad_nextcloud', 'etherpad_host', '', 'https://pad.example.test'],
 			]);
-		$config->expects($this->once())
-			->method('getUserValue')
-			->with($uid, 'etherpad_nextcloud', 'etherpad_author_display_name', '')
-			->willReturn('');
 		$config->expects($this->never())->method('setUserValue');
 		$config->expects($this->never())->method('deleteUserValue');
 

--- a/tests/phpunit/unit/PadSyncServiceTest.php
+++ b/tests/phpunit/unit/PadSyncServiceTest.php
@@ -45,7 +45,7 @@ class PadSyncServiceTest extends TestCase {
 			->syncStatusById('alice', 138);
 
 		$this->assertSame([
-			'status' => 'unavailable',
+			'status' => PadSyncService::STATUS_UNAVAILABLE,
 			'in_sync' => null,
 			'reason' => 'external_no_revision',
 		], $result);
@@ -88,7 +88,7 @@ class PadSyncServiceTest extends TestCase {
 			->syncStatusById('alice', 138);
 
 		$this->assertSame([
-			'status' => 'out_of_sync',
+			'status' => PadSyncService::STATUS_OUT_OF_SYNC,
 			'in_sync' => false,
 			'snapshot_rev' => 3,
 			'current_rev' => 5,


### PR DESCRIPTION
This PR collects follow-up fixes after the controller/service refactor.

## Changes

- Replace brittle binding error string handling with a dedicated missing-binding exception.
- Use domain-specific exceptions for create conflicts and non-writable parent folders.
- Improve controller error handling with default logging and guard exceptions.
- Reduce duplicate create rollback handling in PadCreationService.
- Make external pad availability validation explicit.
- Improve lock retry handling by removing reference parameters and preserving retry counts.
- Add status constants and more focused tests around retries, error mapping, and rollback behavior.
- Refresh Etherpad author names via createAuthorIfNotExistsFor, which works with the configured Etherpad API.
- Document that public pads intentionally open without an Etherpad session to avoid sharing Nextcloud user identity.