### PR TITLE
Refactor/public viewer controller

### DIFF
--- a/lib/Controller/PublicViewerController.php
+++ b/lib/Controller/PublicViewerController.php
@@ -11,9 +11,8 @@ declare(strict_types=1);
 namespace OCA\EtherpadNextcloud\Controller;
 
 use OCA\EtherpadNextcloud\Exception\InvalidShareTokenException;
-use OCA\EtherpadNextcloud\Service\BindingService;
-use OCA\EtherpadNextcloud\Service\PadFileService;
-use OCA\EtherpadNextcloud\Service\PublicPadOpenService;
+use OCA\EtherpadNextcloud\Service\PublicPadContext;
+use OCA\EtherpadNextcloud\Service\PublicPadContextService;
 use OCA\EtherpadNextcloud\Service\PublicShareResolver;
 use OCA\EtherpadNextcloud\Service\PublicShareUrlBuilder;
 use OCP\AppFramework\Http\DataResponse;
@@ -31,9 +30,7 @@ class PublicViewerController extends PublicShareController {
 		string $appName,
 		IRequest $request,
 		private PublicShareResolver $shareResolver,
-		private PadFileService $padFileService,
-		private BindingService $bindingService,
-		private PublicPadOpenService $publicPadOpenService,
+		private PublicPadContextService $padContextService,
 		private PublicShareUrlBuilder $shareUrlBuilder,
 		private PublicViewerControllerErrorMapper $errors,
 		ISession $session,
@@ -74,58 +71,23 @@ class PublicViewerController extends PublicShareController {
 	#[\OCP\AppFramework\Http\Attribute\NoCSRFRequired]
 	public function openPadData(string $token, mixed $file = ''): DataResponse {
 		return $this->errors->runForData(
-			fn(): array => $this->resolvePublicPadContext($token, $file),
-			function (array $context): DataResponse {
+			fn(): PublicPadContext => $this->padContextService->resolve($token, $file, $this->share),
+			function (PublicPadContext $context): DataResponse {
 				$response = new DataResponse([
-					'title' => $context['title'],
-					'url' => $context['url'],
-					'is_external' => $context['is_external'],
-					'is_readonly_snapshot' => $context['is_readonly_snapshot'],
-					'snapshot_text' => $context['snapshot_text'],
-					'snapshot_html' => $context['snapshot_html'],
-					'original_pad_url' => $context['original_pad_url'],
+					'title' => $context->title,
+					'url' => $context->url,
+					'is_external' => $context->isExternal,
+					'is_readonly_snapshot' => $context->isReadOnlySnapshot,
+					'snapshot_text' => $context->snapshotText,
+					'snapshot_html' => $context->snapshotHtml,
+					'original_pad_url' => $context->originalPadUrl,
 				]);
-				if (($context['cookie_header'] ?? '') !== '') {
-					$response->addHeader('Set-Cookie', (string)$context['cookie_header']);
+				if ($context->cookieHeader !== '') {
+					$response->addHeader('Set-Cookie', $context->cookieHeader);
 				}
 				return $response;
 			},
 		);
-	}
-
-	private function resolvePublicPadContext(string $token, mixed $fileParam): array {
-		$share = $this->shareResolver->resolveShare($token, $this->share);
-		$resolved = $this->shareResolver->resolvePadFile($share, $fileParam, $token);
-		$node = $resolved->node;
-
-		$content = (string)$node->getContent();
-		$fileId = (int)$node->getId();
-
-		$parsed = $this->padFileService->parsePadFile($content);
-		$frontmatter = $parsed['frontmatter'];
-		$meta = $this->padFileService->extractPadMetadata($frontmatter);
-		$padId = $meta['pad_id'];
-		$accessMode = $meta['access_mode'];
-		$padUrl = $meta['pad_url'];
-		$isExternal = $this->padFileService->isExternalFrontmatter($frontmatter, $padId);
-
-		$this->bindingService->assertConsistentMapping($fileId, $padId, $accessMode);
-		$openTarget = $this->publicPadOpenService->open($padId, $accessMode, $resolved->readOnly, $token, $isExternal, $content, $padUrl);
-
-		return [
-			'title' => $resolved->name,
-			'url' => $openTarget->url,
-			'is_external' => $isExternal,
-			'is_readonly_snapshot' => $openTarget->isReadOnlySnapshot,
-			'snapshot_text' => $openTarget->snapshotText,
-			'snapshot_html' => $openTarget->snapshotHtml,
-			'is_public_pad' => $accessMode === BindingService::ACCESS_PUBLIC,
-			'open_new_tab_url' => $accessMode === BindingService::ACCESS_PUBLIC ? $openTarget->url : '',
-			'original_pad_url' => $openTarget->originalPadUrl,
-			'cookie_header' => $openTarget->cookieHeader,
-			'files_url' => $this->shareUrlBuilder->buildShareBaseUrl($token),
-			'download_url' => $this->shareUrlBuilder->buildDownloadUrl($token, $resolved->selectedRelativePath, $resolved->isFolderShare, $resolved->name),
-		];
 	}
 
 }

--- a/lib/Controller/PublicViewerController.php
+++ b/lib/Controller/PublicViewerController.php
@@ -10,24 +10,13 @@ declare(strict_types=1);
 
 namespace OCA\EtherpadNextcloud\Controller;
 
-use OCA\EtherpadNextcloud\Exception\BindingException;
-use OCA\EtherpadNextcloud\Exception\EtherpadClientException;
-use OCA\EtherpadNextcloud\Exception\InvalidShareFilePathException;
 use OCA\EtherpadNextcloud\Exception\InvalidShareTokenException;
-use OCA\EtherpadNextcloud\Exception\MissingBindingException;
-use OCA\EtherpadNextcloud\Exception\NoShareFileSelectedException;
-use OCA\EtherpadNextcloud\Exception\NotAPadFileException;
-use OCA\EtherpadNextcloud\Exception\PadFileFormatException;
-use OCA\EtherpadNextcloud\Exception\ShareFileNotInShareException;
-use OCA\EtherpadNextcloud\Exception\ShareItemUnavailableException;
-use OCA\EtherpadNextcloud\Exception\ShareReadForbiddenException;
 use OCA\EtherpadNextcloud\Service\BindingService;
 use OCA\EtherpadNextcloud\Service\PadFileService;
 use OCA\EtherpadNextcloud\Service\PublicPadOpenService;
 use OCA\EtherpadNextcloud\Service\PublicShareResolver;
 use OCA\EtherpadNextcloud\Service\PublicShareUrlBuilder;
 use OCP\AppFramework\Http\DataResponse;
-use OCP\AppFramework\Http;
 use OCP\AppFramework\PublicShareController;
 use OCP\AppFramework\Http\RedirectResponse;
 use OCP\AppFramework\Http\TemplateResponse;
@@ -46,6 +35,7 @@ class PublicViewerController extends PublicShareController {
 		private BindingService $bindingService,
 		private PublicPadOpenService $publicPadOpenService,
 		private PublicShareUrlBuilder $shareUrlBuilder,
+		private PublicViewerControllerErrorMapper $errors,
 		ISession $session,
 	) {
 		parent::__construct($appName, $request, $session);
@@ -72,37 +62,35 @@ class PublicViewerController extends PublicShareController {
 	#[\OCP\AppFramework\Http\Attribute\PublicPage]
 	#[\OCP\AppFramework\Http\Attribute\NoCSRFRequired]
 	public function showPad(string $token): RedirectResponse|TemplateResponse {
-		try {
-			$target = $this->shareUrlBuilder->buildShareRedirectUrl($token, $this->request->getParam('file', ''));
-		} catch (\RuntimeException $e) {
-			$status = $e->getCode() > 0 ? $e->getCode() : Http::STATUS_BAD_REQUEST;
-			return $this->publicErrorResponse($token, $e->getMessage(), $status);
-		}
-		return new RedirectResponse($target);
+		return $this->errors->runForTemplate(
+			fn(): string => $this->shareUrlBuilder->buildShareRedirectUrl($token, $this->request->getParam('file', '')),
+			static fn(string $target): RedirectResponse => new RedirectResponse($target),
+			$this->appName,
+			$token,
+		);
 	}
 
 	#[\OCP\AppFramework\Http\Attribute\PublicPage]
 	#[\OCP\AppFramework\Http\Attribute\NoCSRFRequired]
 	public function openPadData(string $token, mixed $file = ''): DataResponse {
-		try {
-			$context = $this->resolvePublicPadContext($token, $file);
-		} catch (\RuntimeException $e) {
-			return new DataResponse(['message' => $e->getMessage()], $this->mapPublicShareStatus($e));
-		}
-
-		$response = new DataResponse([
-			'title' => $context['title'],
-			'url' => $context['url'],
-			'is_external' => $context['is_external'],
-			'is_readonly_snapshot' => $context['is_readonly_snapshot'],
-			'snapshot_text' => $context['snapshot_text'],
-			'snapshot_html' => $context['snapshot_html'],
-			'original_pad_url' => $context['original_pad_url'],
-		]);
-		if (($context['cookie_header'] ?? '') !== '') {
-			$response->addHeader('Set-Cookie', (string)$context['cookie_header']);
-		}
-		return $response;
+		return $this->errors->runForData(
+			fn(): array => $this->resolvePublicPadContext($token, $file),
+			function (array $context): DataResponse {
+				$response = new DataResponse([
+					'title' => $context['title'],
+					'url' => $context['url'],
+					'is_external' => $context['is_external'],
+					'is_readonly_snapshot' => $context['is_readonly_snapshot'],
+					'snapshot_text' => $context['snapshot_text'],
+					'snapshot_html' => $context['snapshot_html'],
+					'original_pad_url' => $context['original_pad_url'],
+				]);
+				if (($context['cookie_header'] ?? '') !== '') {
+					$response->addHeader('Set-Cookie', (string)$context['cookie_header']);
+				}
+				return $response;
+			},
+		);
 	}
 
 	private function resolvePublicPadContext(string $token, mixed $fileParam): array {
@@ -113,20 +101,16 @@ class PublicViewerController extends PublicShareController {
 		$content = (string)$node->getContent();
 		$fileId = (int)$node->getId();
 
-		try {
-			$parsed = $this->padFileService->parsePadFile($content);
-			$frontmatter = $parsed['frontmatter'];
-			$meta = $this->padFileService->extractPadMetadata($frontmatter);
-			$padId = $meta['pad_id'];
-			$accessMode = $meta['access_mode'];
-			$padUrl = $meta['pad_url'];
-			$isExternal = $this->padFileService->isExternalFrontmatter($frontmatter, $padId);
+		$parsed = $this->padFileService->parsePadFile($content);
+		$frontmatter = $parsed['frontmatter'];
+		$meta = $this->padFileService->extractPadMetadata($frontmatter);
+		$padId = $meta['pad_id'];
+		$accessMode = $meta['access_mode'];
+		$padUrl = $meta['pad_url'];
+		$isExternal = $this->padFileService->isExternalFrontmatter($frontmatter, $padId);
 
-			$this->bindingService->assertConsistentMapping($fileId, $padId, $accessMode);
-			$openTarget = $this->publicPadOpenService->open($padId, $accessMode, $resolved->readOnly, $token, $isExternal, $content, $padUrl);
-		} catch (PadFileFormatException|BindingException|EtherpadClientException $e) {
-			$this->publicFail($this->mapPublicOpenError($e), Http::STATUS_BAD_REQUEST);
-		}
+		$this->bindingService->assertConsistentMapping($fileId, $padId, $accessMode);
+		$openTarget = $this->publicPadOpenService->open($padId, $accessMode, $resolved->readOnly, $token, $isExternal, $content, $padUrl);
 
 		return [
 			'title' => $resolved->name,
@@ -142,53 +126,6 @@ class PublicViewerController extends PublicShareController {
 			'files_url' => $this->shareUrlBuilder->buildShareBaseUrl($token),
 			'download_url' => $this->shareUrlBuilder->buildDownloadUrl($token, $resolved->selectedRelativePath, $resolved->isFolderShare, $resolved->name),
 		];
-	}
-
-	private function publicFail(string $message, int $status): never {
-		throw new \RuntimeException($message, $status);
-	}
-
-	private function publicErrorResponse(string $token, string $error, int $status = Http::STATUS_BAD_REQUEST): TemplateResponse {
-		$response = new TemplateResponse($this->appName, 'noviewer', [
-			'error' => $error,
-			'back_url' => $this->shareUrlBuilder->buildShareBaseUrl($token),
-			'back_label' => 'Back to shared files',
-		], 'blank');
-		$response->setStatus($status);
-		return $response;
-	}
-
-	private function mapPublicShareStatus(\RuntimeException $e): int {
-		return match (true) {
-			$e instanceof InvalidShareTokenException,
-			$e instanceof ShareItemUnavailableException,
-			$e instanceof ShareFileNotInShareException => Http::STATUS_NOT_FOUND,
-			$e instanceof ShareReadForbiddenException => Http::STATUS_FORBIDDEN,
-			$e instanceof InvalidShareFilePathException,
-			$e instanceof NoShareFileSelectedException,
-			$e instanceof NotAPadFileException => Http::STATUS_BAD_REQUEST,
-			default => $e->getCode() > 0 ? $e->getCode() : Http::STATUS_BAD_REQUEST,
-		};
-	}
-
-	private function mapPublicOpenError(\Throwable $error): string {
-		$message = $error->getMessage();
-		if ($error instanceof PadFileFormatException) {
-			if (str_contains($message, 'Missing YAML frontmatter')) {
-				return 'The selected .pad file is missing required metadata.';
-			}
-			return 'The selected .pad file has an invalid format.';
-		}
-		if ($error instanceof BindingException) {
-			if ($error instanceof MissingBindingException) {
-				return 'The selected .pad file is a copied file without an active pad binding. Please open the original shared .pad file.';
-			}
-			return 'Pad binding is inconsistent. Please contact the share owner.';
-		}
-		if ($error instanceof EtherpadClientException) {
-			return 'Etherpad is currently unavailable for this shared pad.';
-		}
-		return 'Unable to open pad.';
 	}
 
 }

--- a/lib/Controller/PublicViewerController.php
+++ b/lib/Controller/PublicViewerController.php
@@ -62,7 +62,6 @@ class PublicViewerController extends PublicShareController {
 		return $this->errors->runForTemplate(
 			fn(): string => $this->shareUrlBuilder->buildShareRedirectUrl($token, $this->request->getParam('file', '')),
 			static fn(string $target): RedirectResponse => new RedirectResponse($target),
-			$this->appName,
 			$token,
 		);
 	}

--- a/lib/Controller/PublicViewerController.php
+++ b/lib/Controller/PublicViewerController.php
@@ -15,9 +15,9 @@ use OCA\EtherpadNextcloud\Exception\EtherpadClientException;
 use OCA\EtherpadNextcloud\Exception\MissingBindingException;
 use OCA\EtherpadNextcloud\Exception\PadFileFormatException;
 use OCA\EtherpadNextcloud\Service\BindingService;
-use OCA\EtherpadNextcloud\Service\EtherpadClient;
 use OCA\EtherpadNextcloud\Service\PadFileService;
-use OCA\EtherpadNextcloud\Service\PadSessionService;
+use OCA\EtherpadNextcloud\Service\PublicPadOpenService;
+use OCA\EtherpadNextcloud\Service\PublicShareUrlBuilder;
 use OCA\EtherpadNextcloud\Util\PathNormalizer;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\Http;
@@ -30,7 +30,6 @@ use OCP\Files\Folder;
 use OCP\Files\NotFoundException;
 use OCP\IRequest;
 use OCP\ISession;
-use OCP\IURLGenerator;
 use OCP\Share\Exceptions\ShareNotFound;
 use OCP\Share\IManager;
 use OCP\Share\IShare;
@@ -45,9 +44,8 @@ class PublicViewerController extends PublicShareController {
 		private PathNormalizer $pathNormalizer,
 		private PadFileService $padFileService,
 		private BindingService $bindingService,
-		private EtherpadClient $etherpadClient,
-		private PadSessionService $padSessionService,
-		private IURLGenerator $urlGenerator,
+		private PublicPadOpenService $publicPadOpenService,
+		private PublicShareUrlBuilder $shareUrlBuilder,
 		ISession $session,
 	) {
 		parent::__construct($appName, $request, $session);
@@ -75,7 +73,7 @@ class PublicViewerController extends PublicShareController {
 	#[\OCP\AppFramework\Http\Attribute\NoCSRFRequired]
 	public function showPad(string $token): RedirectResponse|TemplateResponse {
 		try {
-			$target = $this->buildPublicShareRedirectUrl($token, $this->request->getParam('file', ''));
+			$target = $this->shareUrlBuilder->buildShareRedirectUrl($token, $this->request->getParam('file', ''));
 		} catch (\RuntimeException $e) {
 			$status = $e->getCode() > 0 ? $e->getCode() : Http::STATUS_BAD_REQUEST;
 			return $this->publicErrorResponse($token, $e->getMessage(), $status);
@@ -173,24 +171,24 @@ class PublicViewerController extends PublicShareController {
 			$isExternal = $this->padFileService->isExternalFrontmatter($frontmatter, $padId);
 
 			$this->bindingService->assertConsistentMapping($fileId, $padId, $accessMode);
-			$openTarget = $this->resolvePublicOpenTarget($padId, $accessMode, $readOnly, $token, $isExternal, $content, $padUrl);
+			$openTarget = $this->publicPadOpenService->open($padId, $accessMode, $readOnly, $token, $isExternal, $content, $padUrl);
 		} catch (PadFileFormatException|BindingException|EtherpadClientException $e) {
 			$this->publicFail($this->mapPublicOpenError($e), Http::STATUS_BAD_REQUEST);
 		}
 
 		return [
 			'title' => $node->getName(),
-			'url' => $openTarget['url'],
+			'url' => $openTarget->url,
 			'is_external' => $isExternal,
-			'is_readonly_snapshot' => $openTarget['is_readonly_snapshot'],
-			'snapshot_text' => $openTarget['snapshot_text'],
-			'snapshot_html' => $openTarget['snapshot_html'],
+			'is_readonly_snapshot' => $openTarget->isReadOnlySnapshot,
+			'snapshot_text' => $openTarget->snapshotText,
+			'snapshot_html' => $openTarget->snapshotHtml,
 			'is_public_pad' => $accessMode === BindingService::ACCESS_PUBLIC,
-			'open_new_tab_url' => $accessMode === BindingService::ACCESS_PUBLIC ? $openTarget['url'] : '',
-			'original_pad_url' => $openTarget['original_pad_url'],
-			'cookie_header' => $openTarget['cookie_header'],
-			'files_url' => $this->buildShareBaseUrl($token),
-			'download_url' => $this->buildPublicDownloadUrl($token, $selectedRelativePath, $isFolderShare, $node->getName()),
+			'open_new_tab_url' => $accessMode === BindingService::ACCESS_PUBLIC ? $openTarget->url : '',
+			'original_pad_url' => $openTarget->originalPadUrl,
+			'cookie_header' => $openTarget->cookieHeader,
+			'files_url' => $this->shareUrlBuilder->buildShareBaseUrl($token),
+			'download_url' => $this->shareUrlBuilder->buildDownloadUrl($token, $selectedRelativePath, $isFolderShare, $node->getName()),
 		];
 	}
 
@@ -201,16 +199,11 @@ class PublicViewerController extends PublicShareController {
 	private function publicErrorResponse(string $token, string $error, int $status = Http::STATUS_BAD_REQUEST): TemplateResponse {
 		$response = new TemplateResponse($this->appName, 'noviewer', [
 			'error' => $error,
-			'back_url' => $this->buildShareBaseUrl($token),
+			'back_url' => $this->shareUrlBuilder->buildShareBaseUrl($token),
 			'back_label' => 'Back to shared files',
 		], 'blank');
 		$response->setStatus($status);
 		return $response;
-	}
-
-	private function buildShareBaseUrl(string $token): string {
-		$webroot = rtrim($this->urlGenerator->getWebroot(), '/');
-		return $webroot . '/s/' . rawurlencode($token);
 	}
 
 	private function mapPublicOpenError(\Throwable $error): string {
@@ -231,200 +224,6 @@ class PublicViewerController extends PublicShareController {
 			return 'Etherpad is currently unavailable for this shared pad.';
 		}
 		return 'Unable to open pad.';
-	}
-
-	private function buildPublicShareRedirectUrl(string $token, mixed $fileParam): string {
-		$base = $this->buildShareBaseUrl($token);
-		$rawFile = is_scalar($fileParam) ? trim((string)$fileParam) : '';
-		if ($rawFile === '') {
-			return $base . '?dir=' . rawurlencode('/');
-		}
-
-		try {
-			$normalized = $this->pathNormalizer->normalizePublicShareFilePath($fileParam, $token);
-		} catch (\Throwable) {
-			$this->publicFail('Invalid file path.', Http::STATUS_BAD_REQUEST);
-		}
-		if ($normalized === '') {
-			return $base . '?dir=' . rawurlencode('/');
-		}
-
-		$path = trim($normalized, '/');
-		if ($path === '') {
-			return $base . '?dir=' . rawurlencode('/');
-		}
-
-		$dir = dirname($path);
-		if ($dir === '.' || $dir === '') {
-			$dir = '/';
-		} else {
-			$dir = '/' . $dir;
-		}
-		$fileName = basename($path);
-		if ($fileName === '' || !str_ends_with(strtolower($fileName), '.pad')) {
-			$this->publicFail('The selected file is not a .pad document.', Http::STATUS_BAD_REQUEST);
-		}
-
-		return $base . '?path=' . rawurlencode($dir) . '&files=' . rawurlencode($fileName);
-	}
-
-	private function buildPublicDownloadUrl(string $token, string $selectedRelativePath, bool $isFolderShare, string $fileName): string {
-		$base = $this->buildShareBaseUrl($token) . '/download';
-		if (!$isFolderShare) {
-			return $base;
-		}
-
-		$path = trim($selectedRelativePath, '/');
-		if ($path === '') {
-			return '';
-		}
-
-		$dir = dirname($path);
-		if ($dir === '.' || $dir === '') {
-			$dir = '/';
-		} else {
-			$dir = '/' . $dir;
-		}
-		$name = basename($path);
-		if ($name === '') {
-			$name = $fileName;
-		}
-		if ($name === '') {
-			return '';
-		}
-
-		return $base . '?path=' . rawurlencode($dir) . '&files=' . rawurlencode($name);
-	}
-
-	/** @return array{url:string,original_pad_url:string,cookie_header:string,is_readonly_snapshot:bool,snapshot_text:string,snapshot_html:string} */
-	private function resolvePublicOpenTarget(
-		string $padId,
-		string $accessMode,
-		bool $readOnly,
-		string $token,
-		bool $isExternal,
-		string $padFileContent,
-		string $padUrl = ''
-	): array {
-		if ($isExternal && $accessMode !== BindingService::ACCESS_PUBLIC) {
-			throw new EtherpadClientException('External pad metadata requires public access_mode.');
-		}
-
-		if ($accessMode === BindingService::ACCESS_PROTECTED) {
-			if ($readOnly) {
-				return [
-					'url' => '',
-					'original_pad_url' => '',
-					'cookie_header' => '',
-					'is_readonly_snapshot' => true,
-					'snapshot_text' => $this->padFileService->getTextSnapshotForRestore($padFileContent),
-					'snapshot_html' => $this->sanitizeSnapshotHtml($this->padFileService->getHtmlSnapshotForRestore($padFileContent)),
-				];
-			}
-
-			$authorUid = 'public-share:' . $token;
-			$authorName = 'Public share';
-			$openContext = $this->padSessionService->createProtectedOpenContext($authorUid, $authorName, $padId, 3600);
-			$cookieHeader = $this->padSessionService->buildSetCookieHeader($openContext['cookie']);
-			return [
-				'url' => $openContext['url'],
-				'original_pad_url' => '',
-				'cookie_header' => $cookieHeader,
-				'is_readonly_snapshot' => false,
-				'snapshot_text' => '',
-				'snapshot_html' => '',
-			];
-		}
-
-		if ($isExternal) {
-			if ($padUrl === '') {
-				throw new EtherpadClientException('External pad URL metadata is missing or invalid.');
-			}
-			$normalized = $this->etherpadClient->normalizeAndValidateExternalPublicPadUrl($padUrl);
-			return [
-				'url' => $normalized['pad_url'],
-				'original_pad_url' => $normalized['pad_url'],
-				'cookie_header' => '',
-				'is_readonly_snapshot' => false,
-				'snapshot_text' => $this->padFileService->getTextSnapshotForRestore($padFileContent),
-				'snapshot_html' => '',
-			];
-		}
-
-		if ($readOnly) {
-			return [
-				'url' => $this->etherpadClient->getReadOnlyPadUrl($padId),
-				'original_pad_url' => '',
-				'cookie_header' => '',
-				'is_readonly_snapshot' => false,
-				'snapshot_text' => '',
-				'snapshot_html' => '',
-			];
-		}
-
-		return [
-			'url' => $this->etherpadClient->buildPadUrl($padId),
-			'original_pad_url' => '',
-			'cookie_header' => '',
-			'is_readonly_snapshot' => false,
-			'snapshot_text' => '',
-			'snapshot_html' => '',
-		];
-	}
-
-	private function sanitizeSnapshotHtml(string $html): string {
-		$trimmed = trim($html);
-		if ($trimmed === '') {
-			return '';
-		}
-
-		$previous = libxml_use_internal_errors(true);
-		$document = new \DOMDocument();
-		$loaded = $document->loadHTML(
-			'<?xml encoding="UTF-8">' . $trimmed,
-			LIBXML_HTML_NODEFDTD | LIBXML_NOERROR | LIBXML_NOWARNING
-		);
-		libxml_clear_errors();
-		libxml_use_internal_errors($previous);
-		if (!$loaded) {
-			return '';
-		}
-
-		$body = $document->getElementsByTagName('body')->item(0);
-		$root = $body instanceof \DOMNode ? $body : $document;
-		$output = '';
-		foreach ($root->childNodes as $child) {
-			$output .= $this->sanitizeSnapshotHtmlNode($child);
-		}
-		return trim($output);
-	}
-
-	private function sanitizeSnapshotHtmlNode(\DOMNode $node): string {
-		if ($node instanceof \DOMText || $node instanceof \DOMCdataSection) {
-			return htmlspecialchars($node->nodeValue ?? '', ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
-		}
-		if (!$node instanceof \DOMElement) {
-			return '';
-		}
-
-		$tag = strtolower($node->tagName);
-		if (in_array($tag, ['script', 'style', 'iframe', 'object', 'embed', 'svg', 'math', 'img', 'video', 'audio', 'source', 'link', 'meta'], true)) {
-			return '';
-		}
-
-		$content = '';
-		foreach ($node->childNodes as $child) {
-			$content .= $this->sanitizeSnapshotHtmlNode($child);
-		}
-
-		$allowed = ['p', 'br', 'ul', 'ol', 'li', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'strong', 'b', 'em', 'i', 'u', 's', 'del', 'blockquote', 'pre', 'code'];
-		if (!in_array($tag, $allowed, true)) {
-			return $content;
-		}
-		if ($tag === 'br') {
-			return '<br>';
-		}
-		return '<' . $tag . '>' . $content . '</' . $tag . '>';
 	}
 
 }

--- a/lib/Controller/PublicViewerController.php
+++ b/lib/Controller/PublicViewerController.php
@@ -12,26 +12,27 @@ namespace OCA\EtherpadNextcloud\Controller;
 
 use OCA\EtherpadNextcloud\Exception\BindingException;
 use OCA\EtherpadNextcloud\Exception\EtherpadClientException;
+use OCA\EtherpadNextcloud\Exception\InvalidShareFilePathException;
+use OCA\EtherpadNextcloud\Exception\InvalidShareTokenException;
 use OCA\EtherpadNextcloud\Exception\MissingBindingException;
+use OCA\EtherpadNextcloud\Exception\NoShareFileSelectedException;
+use OCA\EtherpadNextcloud\Exception\NotAPadFileException;
 use OCA\EtherpadNextcloud\Exception\PadFileFormatException;
+use OCA\EtherpadNextcloud\Exception\ShareFileNotInShareException;
+use OCA\EtherpadNextcloud\Exception\ShareItemUnavailableException;
+use OCA\EtherpadNextcloud\Exception\ShareReadForbiddenException;
 use OCA\EtherpadNextcloud\Service\BindingService;
 use OCA\EtherpadNextcloud\Service\PadFileService;
 use OCA\EtherpadNextcloud\Service\PublicPadOpenService;
+use OCA\EtherpadNextcloud\Service\PublicShareResolver;
 use OCA\EtherpadNextcloud\Service\PublicShareUrlBuilder;
-use OCA\EtherpadNextcloud\Util\PathNormalizer;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\PublicShareController;
 use OCP\AppFramework\Http\RedirectResponse;
 use OCP\AppFramework\Http\TemplateResponse;
-use OCP\Constants;
-use OCP\Files\File;
-use OCP\Files\Folder;
-use OCP\Files\NotFoundException;
 use OCP\IRequest;
 use OCP\ISession;
-use OCP\Share\Exceptions\ShareNotFound;
-use OCP\Share\IManager;
 use OCP\Share\IShare;
 
 class PublicViewerController extends PublicShareController {
@@ -40,8 +41,7 @@ class PublicViewerController extends PublicShareController {
 	public function __construct(
 		string $appName,
 		IRequest $request,
-		private IManager $shareManager,
-		private PathNormalizer $pathNormalizer,
+		private PublicShareResolver $shareResolver,
 		private PadFileService $padFileService,
 		private BindingService $bindingService,
 		private PublicPadOpenService $publicPadOpenService,
@@ -53,8 +53,8 @@ class PublicViewerController extends PublicShareController {
 
 	public function isValidToken(): bool {
 		try {
-			$this->share = $this->shareManager->getShareByToken($this->getToken());
-		} catch (ShareNotFound) {
+			$this->share = $this->shareResolver->resolveShare($this->getToken());
+		} catch (InvalidShareTokenException) {
 			return false;
 		}
 
@@ -87,8 +87,7 @@ class PublicViewerController extends PublicShareController {
 		try {
 			$context = $this->resolvePublicPadContext($token, $file);
 		} catch (\RuntimeException $e) {
-			$status = $e->getCode() > 0 ? $e->getCode() : Http::STATUS_BAD_REQUEST;
-			return new DataResponse(['message' => $e->getMessage()], $status);
+			return new DataResponse(['message' => $e->getMessage()], $this->mapPublicShareStatus($e));
 		}
 
 		$response = new DataResponse([
@@ -107,59 +106,12 @@ class PublicViewerController extends PublicShareController {
 	}
 
 	private function resolvePublicPadContext(string $token, mixed $fileParam): array {
-		$share = $this->share;
-		if ($share === null) {
-			try {
-				$share = $this->shareManager->getShareByToken($token);
-			} catch (ShareNotFound) {
-				$this->publicFail('This share link is invalid or has expired.', Http::STATUS_NOT_FOUND);
-			}
-		}
-
-		if (!$share instanceof IShare) {
-			$this->publicFail('This share link is invalid or has expired.', Http::STATUS_NOT_FOUND);
-		}
-
-		if ((((int)$share->getPermissions()) & Constants::PERMISSION_READ) === 0) {
-			$this->publicFail('This share link does not allow reading files.', Http::STATUS_FORBIDDEN);
-		}
-
-		try {
-			$node = $share->getNode();
-		} catch (NotFoundException) {
-			$this->publicFail('This shared item is no longer available.', Http::STATUS_NOT_FOUND);
-		}
-
-		$isFolderShare = $node instanceof Folder;
-		$selectedRelativePath = '';
-
-		if ($node instanceof Folder) {
-			try {
-				$normalized = $this->pathNormalizer->normalizePublicShareFilePath($fileParam, $token);
-			} catch (\Throwable) {
-				$this->publicFail('Invalid file path.', Http::STATUS_BAD_REQUEST);
-			}
-			if ($normalized === '') {
-				$this->publicFail('No .pad file selected. Open a .pad file from this shared folder.', Http::STATUS_BAD_REQUEST);
-			}
-			$selectedRelativePath = $normalized;
-			try {
-				$node = $node->get($normalized);
-			} catch (NotFoundException) {
-				$this->publicFail('The selected file does not exist in this share.', Http::STATUS_NOT_FOUND);
-			}
-		}
-
-		if (!$node instanceof File) {
-			$this->publicFail('The selected item is not a file.', Http::STATUS_NOT_FOUND);
-		}
-		if (!str_ends_with(strtolower($node->getName()), '.pad')) {
-			$this->publicFail('The selected file is not a .pad document.', Http::STATUS_BAD_REQUEST);
-		}
+		$share = $this->shareResolver->resolveShare($token, $this->share);
+		$resolved = $this->shareResolver->resolvePadFile($share, $fileParam, $token);
+		$node = $resolved->node;
 
 		$content = (string)$node->getContent();
 		$fileId = (int)$node->getId();
-		$readOnly = (((int)$share->getPermissions()) & Constants::PERMISSION_UPDATE) === 0;
 
 		try {
 			$parsed = $this->padFileService->parsePadFile($content);
@@ -171,13 +123,13 @@ class PublicViewerController extends PublicShareController {
 			$isExternal = $this->padFileService->isExternalFrontmatter($frontmatter, $padId);
 
 			$this->bindingService->assertConsistentMapping($fileId, $padId, $accessMode);
-			$openTarget = $this->publicPadOpenService->open($padId, $accessMode, $readOnly, $token, $isExternal, $content, $padUrl);
+			$openTarget = $this->publicPadOpenService->open($padId, $accessMode, $resolved->readOnly, $token, $isExternal, $content, $padUrl);
 		} catch (PadFileFormatException|BindingException|EtherpadClientException $e) {
 			$this->publicFail($this->mapPublicOpenError($e), Http::STATUS_BAD_REQUEST);
 		}
 
 		return [
-			'title' => $node->getName(),
+			'title' => $resolved->name,
 			'url' => $openTarget->url,
 			'is_external' => $isExternal,
 			'is_readonly_snapshot' => $openTarget->isReadOnlySnapshot,
@@ -188,7 +140,7 @@ class PublicViewerController extends PublicShareController {
 			'original_pad_url' => $openTarget->originalPadUrl,
 			'cookie_header' => $openTarget->cookieHeader,
 			'files_url' => $this->shareUrlBuilder->buildShareBaseUrl($token),
-			'download_url' => $this->shareUrlBuilder->buildDownloadUrl($token, $selectedRelativePath, $isFolderShare, $node->getName()),
+			'download_url' => $this->shareUrlBuilder->buildDownloadUrl($token, $resolved->selectedRelativePath, $resolved->isFolderShare, $resolved->name),
 		];
 	}
 
@@ -204,6 +156,19 @@ class PublicViewerController extends PublicShareController {
 		], 'blank');
 		$response->setStatus($status);
 		return $response;
+	}
+
+	private function mapPublicShareStatus(\RuntimeException $e): int {
+		return match (true) {
+			$e instanceof InvalidShareTokenException,
+			$e instanceof ShareItemUnavailableException,
+			$e instanceof ShareFileNotInShareException => Http::STATUS_NOT_FOUND,
+			$e instanceof ShareReadForbiddenException => Http::STATUS_FORBIDDEN,
+			$e instanceof InvalidShareFilePathException,
+			$e instanceof NoShareFileSelectedException,
+			$e instanceof NotAPadFileException => Http::STATUS_BAD_REQUEST,
+			default => $e->getCode() > 0 ? $e->getCode() : Http::STATUS_BAD_REQUEST,
+		};
 	}
 
 	private function mapPublicOpenError(\Throwable $error): string {

--- a/lib/Controller/PublicViewerControllerErrorMapper.php
+++ b/lib/Controller/PublicViewerControllerErrorMapper.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace OCA\EtherpadNextcloud\Controller;
 
+use OCA\EtherpadNextcloud\AppInfo\Application;
 use OCA\EtherpadNextcloud\Exception\BindingException;
 use OCA\EtherpadNextcloud\Exception\EtherpadClientException;
 use OCA\EtherpadNextcloud\Exception\InvalidShareFilePathException;
@@ -25,10 +26,12 @@ use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\Http\RedirectResponse;
 use OCP\AppFramework\Http\TemplateResponse;
+use Psr\Log\LoggerInterface;
 
 class PublicViewerControllerErrorMapper {
 	public function __construct(
 		private PublicShareUrlBuilder $shareUrlBuilder,
+		private LoggerInterface $logger,
 	) {
 	}
 
@@ -40,6 +43,7 @@ class PublicViewerControllerErrorMapper {
 		try {
 			return $success($action());
 		} catch (\Throwable $e) {
+			$this->logUnexpected($e);
 			return new DataResponse(['message' => $this->messageFor($e)], $this->statusFor($e));
 		}
 	}
@@ -48,11 +52,12 @@ class PublicViewerControllerErrorMapper {
 	 * @param callable(): mixed $action
 	 * @param callable(mixed): RedirectResponse|TemplateResponse $success
 	 */
-	public function runForTemplate(callable $action, callable $success, string $appName, string $token): RedirectResponse|TemplateResponse {
+	public function runForTemplate(callable $action, callable $success, string $token): RedirectResponse|TemplateResponse {
 		try {
 			return $success($action());
 		} catch (\Throwable $e) {
-			$response = new TemplateResponse($appName, 'noviewer', [
+			$this->logUnexpected($e);
+			$response = new TemplateResponse(Application::APP_ID, 'noviewer', [
 				'error' => $this->messageFor($e),
 				'back_url' => $this->shareUrlBuilder->buildShareBaseUrl($token),
 				'back_label' => 'Back to shared files',
@@ -74,7 +79,7 @@ class PublicViewerControllerErrorMapper {
 			$e instanceof PadFileFormatException,
 			$e instanceof BindingException,
 			$e instanceof EtherpadClientException => Http::STATUS_BAD_REQUEST,
-			default => $e->getCode() > 0 ? $e->getCode() : Http::STATUS_BAD_REQUEST,
+			default => Http::STATUS_INTERNAL_SERVER_ERROR,
 		};
 	}
 
@@ -94,6 +99,33 @@ class PublicViewerControllerErrorMapper {
 		if ($e instanceof EtherpadClientException) {
 			return 'Etherpad is currently unavailable for this shared pad.';
 		}
-		return $e->getMessage();
+		if ($this->isExpectedPublicError($e)) {
+			return $e->getMessage();
+		}
+		return 'Unable to open pad.';
+	}
+
+	private function logUnexpected(\Throwable $e): void {
+		if ($this->isExpectedPublicError($e)) {
+			return;
+		}
+
+		$this->logger->error('Unhandled public viewer error', [
+			'app' => Application::APP_ID,
+			'exception' => $e,
+		]);
+	}
+
+	private function isExpectedPublicError(\Throwable $e): bool {
+		return $e instanceof InvalidShareTokenException
+			|| $e instanceof ShareItemUnavailableException
+			|| $e instanceof ShareFileNotInShareException
+			|| $e instanceof ShareReadForbiddenException
+			|| $e instanceof InvalidShareFilePathException
+			|| $e instanceof NoShareFileSelectedException
+			|| $e instanceof NotAPadFileException
+			|| $e instanceof PadFileFormatException
+			|| $e instanceof BindingException
+			|| $e instanceof EtherpadClientException;
 	}
 }

--- a/lib/Controller/PublicViewerControllerErrorMapper.php
+++ b/lib/Controller/PublicViewerControllerErrorMapper.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Copyright (c) 2026 Jacob Bühler
+ */
+
+namespace OCA\EtherpadNextcloud\Controller;
+
+use OCA\EtherpadNextcloud\Exception\BindingException;
+use OCA\EtherpadNextcloud\Exception\EtherpadClientException;
+use OCA\EtherpadNextcloud\Exception\InvalidShareFilePathException;
+use OCA\EtherpadNextcloud\Exception\InvalidShareTokenException;
+use OCA\EtherpadNextcloud\Exception\MissingBindingException;
+use OCA\EtherpadNextcloud\Exception\NoShareFileSelectedException;
+use OCA\EtherpadNextcloud\Exception\NotAPadFileException;
+use OCA\EtherpadNextcloud\Exception\PadFileFormatException;
+use OCA\EtherpadNextcloud\Exception\ShareFileNotInShareException;
+use OCA\EtherpadNextcloud\Exception\ShareItemUnavailableException;
+use OCA\EtherpadNextcloud\Exception\ShareReadForbiddenException;
+use OCA\EtherpadNextcloud\Service\PublicShareUrlBuilder;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\DataResponse;
+use OCP\AppFramework\Http\RedirectResponse;
+use OCP\AppFramework\Http\TemplateResponse;
+
+class PublicViewerControllerErrorMapper {
+	public function __construct(
+		private PublicShareUrlBuilder $shareUrlBuilder,
+	) {
+	}
+
+	/**
+	 * @param callable(): mixed $action
+	 * @param callable(mixed): DataResponse $success
+	 */
+	public function runForData(callable $action, callable $success): DataResponse {
+		try {
+			return $success($action());
+		} catch (\Throwable $e) {
+			return new DataResponse(['message' => $this->messageFor($e)], $this->statusFor($e));
+		}
+	}
+
+	/**
+	 * @param callable(): mixed $action
+	 * @param callable(mixed): RedirectResponse|TemplateResponse $success
+	 */
+	public function runForTemplate(callable $action, callable $success, string $appName, string $token): RedirectResponse|TemplateResponse {
+		try {
+			return $success($action());
+		} catch (\Throwable $e) {
+			$response = new TemplateResponse($appName, 'noviewer', [
+				'error' => $this->messageFor($e),
+				'back_url' => $this->shareUrlBuilder->buildShareBaseUrl($token),
+				'back_label' => 'Back to shared files',
+			], 'blank');
+			$response->setStatus($this->statusFor($e));
+			return $response;
+		}
+	}
+
+	private function statusFor(\Throwable $e): int {
+		return match (true) {
+			$e instanceof InvalidShareTokenException,
+			$e instanceof ShareItemUnavailableException,
+			$e instanceof ShareFileNotInShareException => Http::STATUS_NOT_FOUND,
+			$e instanceof ShareReadForbiddenException => Http::STATUS_FORBIDDEN,
+			$e instanceof InvalidShareFilePathException,
+			$e instanceof NoShareFileSelectedException,
+			$e instanceof NotAPadFileException,
+			$e instanceof PadFileFormatException,
+			$e instanceof BindingException,
+			$e instanceof EtherpadClientException => Http::STATUS_BAD_REQUEST,
+			default => $e->getCode() > 0 ? $e->getCode() : Http::STATUS_BAD_REQUEST,
+		};
+	}
+
+	private function messageFor(\Throwable $e): string {
+		if ($e instanceof PadFileFormatException) {
+			if (str_contains($e->getMessage(), 'Missing YAML frontmatter')) {
+				return 'The selected .pad file is missing required metadata.';
+			}
+			return 'The selected .pad file has an invalid format.';
+		}
+		if ($e instanceof BindingException) {
+			if ($e instanceof MissingBindingException) {
+				return 'The selected .pad file is a copied file without an active pad binding. Please open the original shared .pad file.';
+			}
+			return 'Pad binding is inconsistent. Please contact the share owner.';
+		}
+		if ($e instanceof EtherpadClientException) {
+			return 'Etherpad is currently unavailable for this shared pad.';
+		}
+		return $e->getMessage();
+	}
+}

--- a/lib/Exception/InvalidShareFilePathException.php
+++ b/lib/Exception/InvalidShareFilePathException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Copyright (c) 2026 Jacob Bühler
+ */
+
+namespace OCA\EtherpadNextcloud\Exception;
+
+class InvalidShareFilePathException extends \InvalidArgumentException {
+}

--- a/lib/Exception/InvalidShareTokenException.php
+++ b/lib/Exception/InvalidShareTokenException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Copyright (c) 2026 Jacob Bühler
+ */
+
+namespace OCA\EtherpadNextcloud\Exception;
+
+class InvalidShareTokenException extends \RuntimeException {
+}

--- a/lib/Exception/NoShareFileSelectedException.php
+++ b/lib/Exception/NoShareFileSelectedException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Copyright (c) 2026 Jacob Bühler
+ */
+
+namespace OCA\EtherpadNextcloud\Exception;
+
+class NoShareFileSelectedException extends \InvalidArgumentException {
+}

--- a/lib/Exception/NotAPadFileException.php
+++ b/lib/Exception/NotAPadFileException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Copyright (c) 2026 Jacob Bühler
+ */
+
+namespace OCA\EtherpadNextcloud\Exception;
+
+class NotAPadFileException extends \InvalidArgumentException {
+}

--- a/lib/Exception/ShareFileNotInShareException.php
+++ b/lib/Exception/ShareFileNotInShareException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Copyright (c) 2026 Jacob Bühler
+ */
+
+namespace OCA\EtherpadNextcloud\Exception;
+
+class ShareFileNotInShareException extends \RuntimeException {
+}

--- a/lib/Exception/ShareItemUnavailableException.php
+++ b/lib/Exception/ShareItemUnavailableException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Copyright (c) 2026 Jacob Bühler
+ */
+
+namespace OCA\EtherpadNextcloud\Exception;
+
+class ShareItemUnavailableException extends \RuntimeException {
+}

--- a/lib/Exception/ShareReadForbiddenException.php
+++ b/lib/Exception/ShareReadForbiddenException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Copyright (c) 2026 Jacob Bühler
+ */
+
+namespace OCA\EtherpadNextcloud\Exception;
+
+class ShareReadForbiddenException extends \RuntimeException {
+}

--- a/lib/Service/PublicPadContext.php
+++ b/lib/Service/PublicPadContext.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Copyright (c) 2026 Jacob Bühler
+ */
+
+namespace OCA\EtherpadNextcloud\Service;
+
+class PublicPadContext {
+	public function __construct(
+		public string $title,
+		public string $url,
+		public bool $isExternal,
+		public bool $isReadOnlySnapshot,
+		public string $snapshotText,
+		public string $snapshotHtml,
+		public string $originalPadUrl,
+		public string $cookieHeader,
+	) {
+	}
+}

--- a/lib/Service/PublicPadContextService.php
+++ b/lib/Service/PublicPadContextService.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Copyright (c) 2026 Jacob Bühler
+ */
+
+namespace OCA\EtherpadNextcloud\Service;
+
+use OCP\Share\IShare;
+
+class PublicPadContextService {
+	public function __construct(
+		private PublicShareResolver $shareResolver,
+		private PadFileService $padFileService,
+		private BindingService $bindingService,
+		private PublicPadOpenService $publicPadOpenService,
+	) {
+	}
+
+	public function resolve(string $token, mixed $fileParam, ?IShare $cachedShare = null): PublicPadContext {
+		$share = $this->shareResolver->resolveShare($token, $cachedShare);
+		$resolved = $this->shareResolver->resolvePadFile($share, $fileParam, $token);
+		$node = $resolved->node;
+
+		$content = (string)$node->getContent();
+		$fileId = (int)$node->getId();
+
+		$parsed = $this->padFileService->parsePadFile($content);
+		$frontmatter = $parsed['frontmatter'];
+		$meta = $this->padFileService->extractPadMetadata($frontmatter);
+		$padId = $meta['pad_id'];
+		$accessMode = $meta['access_mode'];
+		$padUrl = $meta['pad_url'];
+		$isExternal = $this->padFileService->isExternalFrontmatter($frontmatter, $padId);
+
+		$this->bindingService->assertConsistentMapping($fileId, $padId, $accessMode);
+		$openTarget = $this->publicPadOpenService->open(
+			$padId,
+			$accessMode,
+			$resolved->readOnly,
+			$token,
+			$isExternal,
+			$content,
+			$padUrl,
+		);
+
+		return new PublicPadContext(
+			$resolved->name,
+			$openTarget->url,
+			$isExternal,
+			$openTarget->isReadOnlySnapshot,
+			$openTarget->snapshotText,
+			$openTarget->snapshotHtml,
+			$openTarget->originalPadUrl,
+			$openTarget->cookieHeader,
+		);
+	}
+}

--- a/lib/Service/PublicPadContextService.php
+++ b/lib/Service/PublicPadContextService.php
@@ -11,6 +11,12 @@ namespace OCA\EtherpadNextcloud\Service;
 
 use OCP\Share\IShare;
 
+/**
+ * Assembles all data needed by the public viewer API response for one .pad file.
+ *
+ * The service keeps the controller out of share/file metadata parsing and leaves
+ * final HTTP response shaping to the controller.
+ */
 class PublicPadContextService {
 	public function __construct(
 		private PublicShareResolver $shareResolver,

--- a/lib/Service/PublicPadOpenService.php
+++ b/lib/Service/PublicPadOpenService.php
@@ -11,6 +11,12 @@ namespace OCA\EtherpadNextcloud\Service;
 
 use OCA\EtherpadNextcloud\Exception\EtherpadClientException;
 
+/**
+ * Applies public-share-specific open rules for internal, protected and external pads.
+ *
+ * Public protected write access uses an anonymous public-share Etherpad author;
+ * read-only protected access intentionally serves the stored snapshot instead.
+ */
 class PublicPadOpenService {
 	private const PUBLIC_SHARE_AUTHOR_NAME = 'Public share';
 	private const PUBLIC_SHARE_SESSION_TTL_SECONDS = 3600;

--- a/lib/Service/PublicPadOpenService.php
+++ b/lib/Service/PublicPadOpenService.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Copyright (c) 2026 Jacob Bühler
+ */
+
+namespace OCA\EtherpadNextcloud\Service;
+
+use OCA\EtherpadNextcloud\Exception\EtherpadClientException;
+
+class PublicPadOpenService {
+	private const PUBLIC_SHARE_AUTHOR_NAME = 'Public share';
+	private const PUBLIC_SHARE_SESSION_TTL_SECONDS = 3600;
+
+	public function __construct(
+		private PadFileService $padFileService,
+		private EtherpadClient $etherpadClient,
+		private PadSessionService $padSessionService,
+		private SnapshotHtmlSanitizer $snapshotHtmlSanitizer,
+	) {
+	}
+
+	public function open(
+		string $padId,
+		string $accessMode,
+		bool $readOnly,
+		string $token,
+		bool $isExternal,
+		string $padFileContent,
+		string $padUrl = '',
+	): PublicPadOpenTarget {
+		if ($isExternal && $accessMode !== BindingService::ACCESS_PUBLIC) {
+			throw new EtherpadClientException('External pad metadata requires public access_mode.');
+		}
+
+		if ($accessMode === BindingService::ACCESS_PROTECTED) {
+			if ($readOnly) {
+				return new PublicPadOpenTarget(
+					'',
+					'',
+					'',
+					true,
+					$this->padFileService->getTextSnapshotForRestore($padFileContent),
+					$this->snapshotHtmlSanitizer->sanitize($this->padFileService->getHtmlSnapshotForRestore($padFileContent)),
+				);
+			}
+
+			$openContext = $this->padSessionService->createProtectedOpenContext(
+				'public-share:' . $token,
+				self::PUBLIC_SHARE_AUTHOR_NAME,
+				$padId,
+				self::PUBLIC_SHARE_SESSION_TTL_SECONDS
+			);
+
+			return new PublicPadOpenTarget(
+				$openContext['url'],
+				'',
+				$this->padSessionService->buildSetCookieHeader($openContext['cookie']),
+				false,
+				'',
+				'',
+			);
+		}
+
+		if ($isExternal) {
+			if ($padUrl === '') {
+				throw new EtherpadClientException('External pad URL metadata is missing or invalid.');
+			}
+			$normalized = $this->etherpadClient->normalizeAndValidateExternalPublicPadUrl($padUrl);
+			return new PublicPadOpenTarget(
+				$normalized['pad_url'],
+				$normalized['pad_url'],
+				'',
+				false,
+				$this->padFileService->getTextSnapshotForRestore($padFileContent),
+				'',
+			);
+		}
+
+		if ($readOnly) {
+			return new PublicPadOpenTarget(
+				$this->etherpadClient->getReadOnlyPadUrl($padId),
+				'',
+				'',
+				false,
+				'',
+				'',
+			);
+		}
+
+		return new PublicPadOpenTarget(
+			$this->etherpadClient->buildPadUrl($padId),
+			'',
+			'',
+			false,
+			'',
+			'',
+		);
+	}
+}

--- a/lib/Service/PublicPadOpenTarget.php
+++ b/lib/Service/PublicPadOpenTarget.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Copyright (c) 2026 Jacob Bühler
+ */
+
+namespace OCA\EtherpadNextcloud\Service;
+
+class PublicPadOpenTarget {
+	public function __construct(
+		public string $url,
+		public string $originalPadUrl,
+		public string $cookieHeader,
+		public bool $isReadOnlySnapshot,
+		public string $snapshotText,
+		public string $snapshotHtml,
+	) {
+	}
+}

--- a/lib/Service/PublicShareResolver.php
+++ b/lib/Service/PublicShareResolver.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Copyright (c) 2026 Jacob Bühler
+ */
+
+namespace OCA\EtherpadNextcloud\Service;
+
+use OCA\EtherpadNextcloud\Exception\InvalidShareFilePathException;
+use OCA\EtherpadNextcloud\Exception\InvalidShareTokenException;
+use OCA\EtherpadNextcloud\Exception\NoShareFileSelectedException;
+use OCA\EtherpadNextcloud\Exception\NotAPadFileException;
+use OCA\EtherpadNextcloud\Exception\ShareFileNotInShareException;
+use OCA\EtherpadNextcloud\Exception\ShareItemUnavailableException;
+use OCA\EtherpadNextcloud\Exception\ShareReadForbiddenException;
+use OCA\EtherpadNextcloud\Util\PathNormalizer;
+use OCP\Constants;
+use OCP\Files\File;
+use OCP\Files\Folder;
+use OCP\Files\NotFoundException;
+use OCP\Share\Exceptions\ShareNotFound;
+use OCP\Share\IManager;
+use OCP\Share\IShare;
+
+class PublicShareResolver {
+	public function __construct(
+		private IManager $shareManager,
+		private PathNormalizer $pathNormalizer,
+	) {
+	}
+
+	public function resolveShare(string $token, ?IShare $cached = null): IShare {
+		if ($cached instanceof IShare) {
+			return $cached;
+		}
+
+		try {
+			return $this->shareManager->getShareByToken($token);
+		} catch (ShareNotFound) {
+			throw new InvalidShareTokenException('This share link is invalid or has expired.');
+		}
+	}
+
+	public function resolvePadFile(IShare $share, mixed $fileParam, string $token): ResolvedPadShare {
+		if ((((int)$share->getPermissions()) & Constants::PERMISSION_READ) === 0) {
+			throw new ShareReadForbiddenException('This share link does not allow reading files.');
+		}
+
+		try {
+			$node = $share->getNode();
+		} catch (NotFoundException) {
+			throw new ShareItemUnavailableException('This shared item is no longer available.');
+		}
+
+		$isFolderShare = $node instanceof Folder;
+		$selectedRelativePath = '';
+
+		if ($node instanceof Folder) {
+			try {
+				$normalized = $this->pathNormalizer->normalizePublicShareFilePath($fileParam, $token);
+			} catch (\Throwable) {
+				throw new InvalidShareFilePathException('Invalid file path.');
+			}
+			if ($normalized === '') {
+				throw new NoShareFileSelectedException('No .pad file selected. Open a .pad file from this shared folder.');
+			}
+			$selectedRelativePath = $normalized;
+			try {
+				$node = $node->get($normalized);
+			} catch (NotFoundException) {
+				throw new ShareFileNotInShareException('The selected file does not exist in this share.');
+			}
+		}
+
+		if (!$node instanceof File) {
+			throw new ShareFileNotInShareException('The selected item is not a file.');
+		}
+		if (!str_ends_with(strtolower($node->getName()), '.pad')) {
+			throw new NotAPadFileException('The selected file is not a .pad document.');
+		}
+
+		return new ResolvedPadShare(
+			$node,
+			$isFolderShare,
+			$selectedRelativePath,
+			(((int)$share->getPermissions()) & Constants::PERMISSION_UPDATE) === 0,
+			$node->getName(),
+		);
+	}
+}

--- a/lib/Service/PublicShareResolver.php
+++ b/lib/Service/PublicShareResolver.php
@@ -67,7 +67,7 @@ class PublicShareResolver {
 		if ($node instanceof Folder) {
 			try {
 				$normalized = $this->pathNormalizer->normalizePublicShareFilePath($fileParam, $token);
-			} catch (\Throwable $e) {
+			} catch (\InvalidArgumentException $e) {
 				throw new InvalidShareFilePathException('Invalid file path.', 0, $e);
 			}
 			if ($normalized === '') {

--- a/lib/Service/PublicShareResolver.php
+++ b/lib/Service/PublicShareResolver.php
@@ -25,6 +25,12 @@ use OCP\Share\Exceptions\ShareNotFound;
 use OCP\Share\IManager;
 use OCP\Share\IShare;
 
+/**
+ * Resolves a public share token and optional folder-file parameter to a .pad file.
+ *
+ * Permission, existence and file-type failures are expressed as typed public
+ * share exceptions so controller-facing code can map them consistently.
+ */
 class PublicShareResolver {
 	public function __construct(
 		private IManager $shareManager,
@@ -61,8 +67,8 @@ class PublicShareResolver {
 		if ($node instanceof Folder) {
 			try {
 				$normalized = $this->pathNormalizer->normalizePublicShareFilePath($fileParam, $token);
-			} catch (\Throwable) {
-				throw new InvalidShareFilePathException('Invalid file path.');
+			} catch (\Throwable $e) {
+				throw new InvalidShareFilePathException('Invalid file path.', 0, $e);
 			}
 			if ($normalized === '') {
 				throw new NoShareFileSelectedException('No .pad file selected. Open a .pad file from this shared folder.');

--- a/lib/Service/PublicShareUrlBuilder.php
+++ b/lib/Service/PublicShareUrlBuilder.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace OCA\EtherpadNextcloud\Service;
 
+use OCA\EtherpadNextcloud\Exception\InvalidShareFilePathException;
+use OCA\EtherpadNextcloud\Exception\NotAPadFileException;
 use OCA\EtherpadNextcloud\Util\PathNormalizer;
 use OCP\IURLGenerator;
 
@@ -34,7 +36,7 @@ class PublicShareUrlBuilder {
 		try {
 			$normalized = $this->pathNormalizer->normalizePublicShareFilePath($fileParam, $token);
 		} catch (\Throwable) {
-			throw new \InvalidArgumentException('Invalid file path.');
+			throw new InvalidShareFilePathException('Invalid file path.');
 		}
 		if ($normalized === '') {
 			return $base . '?dir=' . rawurlencode('/');
@@ -53,7 +55,7 @@ class PublicShareUrlBuilder {
 		}
 		$fileName = basename($path);
 		if ($fileName === '' || !str_ends_with(strtolower($fileName), '.pad')) {
-			throw new \InvalidArgumentException('The selected file is not a .pad document.');
+			throw new NotAPadFileException('The selected file is not a .pad document.');
 		}
 
 		return $base . '?path=' . rawurlencode($dir) . '&files=' . rawurlencode($fileName);

--- a/lib/Service/PublicShareUrlBuilder.php
+++ b/lib/Service/PublicShareUrlBuilder.php
@@ -14,6 +14,12 @@ use OCA\EtherpadNextcloud\Exception\NotAPadFileException;
 use OCA\EtherpadNextcloud\Util\PathNormalizer;
 use OCP\IURLGenerator;
 
+/**
+ * Builds URLs that point back into Nextcloud public shares.
+ *
+ * This is intentionally separate from the internal files-viewer URL builders:
+ * public shares use /s/{token} routes and folder-selection query parameters.
+ */
 class PublicShareUrlBuilder {
 	public function __construct(
 		private IURLGenerator $urlGenerator,
@@ -35,8 +41,8 @@ class PublicShareUrlBuilder {
 
 		try {
 			$normalized = $this->pathNormalizer->normalizePublicShareFilePath($fileParam, $token);
-		} catch (\Throwable) {
-			throw new InvalidShareFilePathException('Invalid file path.');
+		} catch (\Throwable $e) {
+			throw new InvalidShareFilePathException('Invalid file path.', 0, $e);
 		}
 		if ($normalized === '') {
 			return $base . '?dir=' . rawurlencode('/');

--- a/lib/Service/PublicShareUrlBuilder.php
+++ b/lib/Service/PublicShareUrlBuilder.php
@@ -41,7 +41,7 @@ class PublicShareUrlBuilder {
 
 		try {
 			$normalized = $this->pathNormalizer->normalizePublicShareFilePath($fileParam, $token);
-		} catch (\Throwable $e) {
+		} catch (\InvalidArgumentException $e) {
 			throw new InvalidShareFilePathException('Invalid file path.', 0, $e);
 		}
 		if ($normalized === '') {

--- a/lib/Service/PublicShareUrlBuilder.php
+++ b/lib/Service/PublicShareUrlBuilder.php
@@ -34,13 +34,17 @@ class PublicShareUrlBuilder {
 
 	public function buildShareRedirectUrl(string $token, mixed $fileParam): string {
 		$base = $this->buildShareBaseUrl($token);
-		$rawFile = is_scalar($fileParam) ? trim((string)$fileParam) : '';
+		if (!is_string($fileParam)) {
+			throw new InvalidShareFilePathException('Invalid file path.');
+		}
+
+		$rawFile = trim($fileParam);
 		if ($rawFile === '') {
 			return $base . '?dir=' . rawurlencode('/');
 		}
 
 		try {
-			$normalized = $this->pathNormalizer->normalizePublicShareFilePath($fileParam, $token);
+			$normalized = $this->pathNormalizer->normalizePublicShareFilePath($rawFile, $token);
 		} catch (\InvalidArgumentException $e) {
 			throw new InvalidShareFilePathException('Invalid file path.', 0, $e);
 		}

--- a/lib/Service/PublicShareUrlBuilder.php
+++ b/lib/Service/PublicShareUrlBuilder.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Copyright (c) 2026 Jacob Bühler
+ */
+
+namespace OCA\EtherpadNextcloud\Service;
+
+use OCA\EtherpadNextcloud\Util\PathNormalizer;
+use OCP\IURLGenerator;
+
+class PublicShareUrlBuilder {
+	public function __construct(
+		private IURLGenerator $urlGenerator,
+		private PathNormalizer $pathNormalizer,
+	) {
+	}
+
+	public function buildShareBaseUrl(string $token): string {
+		$webroot = rtrim($this->urlGenerator->getWebroot(), '/');
+		return $webroot . '/s/' . rawurlencode($token);
+	}
+
+	public function buildShareRedirectUrl(string $token, mixed $fileParam): string {
+		$base = $this->buildShareBaseUrl($token);
+		$rawFile = is_scalar($fileParam) ? trim((string)$fileParam) : '';
+		if ($rawFile === '') {
+			return $base . '?dir=' . rawurlencode('/');
+		}
+
+		try {
+			$normalized = $this->pathNormalizer->normalizePublicShareFilePath($fileParam, $token);
+		} catch (\Throwable) {
+			throw new \InvalidArgumentException('Invalid file path.');
+		}
+		if ($normalized === '') {
+			return $base . '?dir=' . rawurlencode('/');
+		}
+
+		$path = trim($normalized, '/');
+		if ($path === '') {
+			return $base . '?dir=' . rawurlencode('/');
+		}
+
+		$dir = dirname($path);
+		if ($dir === '.' || $dir === '') {
+			$dir = '/';
+		} else {
+			$dir = '/' . $dir;
+		}
+		$fileName = basename($path);
+		if ($fileName === '' || !str_ends_with(strtolower($fileName), '.pad')) {
+			throw new \InvalidArgumentException('The selected file is not a .pad document.');
+		}
+
+		return $base . '?path=' . rawurlencode($dir) . '&files=' . rawurlencode($fileName);
+	}
+
+	public function buildDownloadUrl(string $token, string $selectedRelativePath, bool $isFolderShare, string $fileName): string {
+		$base = $this->buildShareBaseUrl($token) . '/download';
+		if (!$isFolderShare) {
+			return $base;
+		}
+
+		$path = trim($selectedRelativePath, '/');
+		if ($path === '') {
+			return '';
+		}
+
+		$dir = dirname($path);
+		if ($dir === '.' || $dir === '') {
+			$dir = '/';
+		} else {
+			$dir = '/' . $dir;
+		}
+		$name = basename($path);
+		if ($name === '') {
+			$name = $fileName;
+		}
+		if ($name === '') {
+			return '';
+		}
+
+		return $base . '?path=' . rawurlencode($dir) . '&files=' . rawurlencode($name);
+	}
+}

--- a/lib/Service/ResolvedPadShare.php
+++ b/lib/Service/ResolvedPadShare.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Copyright (c) 2026 Jacob Bühler
+ */
+
+namespace OCA\EtherpadNextcloud\Service;
+
+use OCP\Files\File;
+
+class ResolvedPadShare {
+	public function __construct(
+		public File $node,
+		public bool $isFolderShare,
+		public string $selectedRelativePath,
+		public bool $readOnly,
+		public string $name,
+	) {
+	}
+}

--- a/lib/Service/SnapshotHtmlSanitizer.php
+++ b/lib/Service/SnapshotHtmlSanitizer.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Copyright (c) 2026 Jacob Bühler
+ */
+
+namespace OCA\EtherpadNextcloud\Service;
+
+/**
+ * Sanitizes stored Etherpad snapshot HTML for read-only public previews.
+ *
+ * No attributes are preserved by design: links, styles, event handlers and
+ * classes are all dropped. Unknown tags are unwrapped, while explicitly
+ * dangerous/embedded content tags are removed with their content.
+ */
+class SnapshotHtmlSanitizer {
+	private const FORBIDDEN_TAGS = [
+		'script',
+		'style',
+		'iframe',
+		'object',
+		'embed',
+		'svg',
+		'math',
+		'img',
+		'video',
+		'audio',
+		'source',
+		'link',
+		'meta',
+	];
+
+	private const ALLOWED_TAGS = [
+		'p',
+		'br',
+		'ul',
+		'ol',
+		'li',
+		'h1',
+		'h2',
+		'h3',
+		'h4',
+		'h5',
+		'h6',
+		'strong',
+		'b',
+		'em',
+		'i',
+		'u',
+		's',
+		'del',
+		'blockquote',
+		'pre',
+		'code',
+	];
+
+	public function sanitize(string $html): string {
+		$trimmed = trim($html);
+		if ($trimmed === '') {
+			return '';
+		}
+
+		$previous = libxml_use_internal_errors(true);
+		$document = new \DOMDocument();
+		$loaded = $document->loadHTML(
+			'<?xml encoding="UTF-8">' . $trimmed,
+			LIBXML_HTML_NODEFDTD | LIBXML_NOERROR | LIBXML_NOWARNING
+		);
+		libxml_clear_errors();
+		libxml_use_internal_errors($previous);
+		if (!$loaded) {
+			return '';
+		}
+
+		$body = $document->getElementsByTagName('body')->item(0);
+		$root = $body instanceof \DOMNode ? $body : $document;
+		$output = '';
+		foreach ($root->childNodes as $child) {
+			$output .= $this->sanitizeNode($child);
+		}
+		return trim($output);
+	}
+
+	private function sanitizeNode(\DOMNode $node): string {
+		if ($node instanceof \DOMText || $node instanceof \DOMCdataSection) {
+			return htmlspecialchars($node->nodeValue ?? '', ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+		}
+		if (!$node instanceof \DOMElement) {
+			return '';
+		}
+
+		$tag = strtolower($node->tagName);
+		if (in_array($tag, self::FORBIDDEN_TAGS, true)) {
+			return '';
+		}
+
+		$content = '';
+		foreach ($node->childNodes as $child) {
+			$content .= $this->sanitizeNode($child);
+		}
+
+		if (!in_array($tag, self::ALLOWED_TAGS, true)) {
+			return $content;
+		}
+		if ($tag === 'br') {
+			return '<br>';
+		}
+		return '<' . $tag . '>' . $content . '</' . $tag . '>';
+	}
+}

--- a/tests/phpunit/stubs/OCP/AppFramework/Http/TemplateResponse.php
+++ b/tests/phpunit/stubs/OCP/AppFramework/Http/TemplateResponse.php
@@ -9,6 +9,7 @@ if (!class_exists(TemplateResponse::class)) {
 		/** @var array<string,mixed> */
 		private array $params;
 		private ?ContentSecurityPolicy $contentSecurityPolicy = null;
+		private int $status = 200;
 
 		/** @param array<string,mixed> $params */
 		public function __construct(
@@ -31,6 +32,14 @@ if (!class_exists(TemplateResponse::class)) {
 
 		public function getRenderAs(): string {
 			return $this->renderAs;
+		}
+
+		public function setStatus(int $status): void {
+			$this->status = $status;
+		}
+
+		public function getStatus(): int {
+			return $this->status;
 		}
 
 		public function setContentSecurityPolicy(ContentSecurityPolicy $contentSecurityPolicy): void {

--- a/tests/phpunit/unit/PublicPadContextServiceTest.php
+++ b/tests/phpunit/unit/PublicPadContextServiceTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\EtherpadNextcloud\Tests\Unit;
+
+use OCA\EtherpadNextcloud\Service\BindingService;
+use OCA\EtherpadNextcloud\Service\PadFileService;
+use OCA\EtherpadNextcloud\Service\PublicPadContextService;
+use OCA\EtherpadNextcloud\Service\PublicPadOpenService;
+use OCA\EtherpadNextcloud\Service\PublicPadOpenTarget;
+use OCA\EtherpadNextcloud\Service\PublicShareResolver;
+use OCA\EtherpadNextcloud\Util\PathNormalizer;
+use OCP\Constants;
+use OCP\Files\File;
+use OCP\Share\IManager;
+use OCP\Share\IShare;
+use PHPUnit\Framework\TestCase;
+
+class PublicPadContextServiceTest extends TestCase {
+	public function testResolveBuildsPublicPadContextFromCachedShare(): void {
+		$file = $this->createMock(File::class);
+		$file->method('getName')->willReturn('Shared.pad');
+		$file->method('getId')->willReturn(42);
+		$file->method('getContent')->willReturn('frontmatter');
+
+		$share = $this->createMock(IShare::class);
+		$share->method('getPermissions')->willReturn(Constants::PERMISSION_READ);
+		$share->method('getNode')->willReturn($file);
+
+		$shareManager = $this->createMock(IManager::class);
+		$shareManager->expects($this->never())->method('getShareByToken');
+		$shareResolver = new PublicShareResolver($shareManager, new PathNormalizer());
+
+		$frontmatter = [
+			'pad_id' => 'g.group$pad',
+			'access_mode' => BindingService::ACCESS_PROTECTED,
+			'pad_url' => '',
+		];
+		$padFiles = $this->createMock(PadFileService::class);
+		$padFiles->expects($this->once())->method('parsePadFile')->with('frontmatter')->willReturn(['frontmatter' => $frontmatter]);
+		$padFiles->expects($this->once())->method('extractPadMetadata')->with($frontmatter)->willReturn([
+			'pad_id' => 'g.group$pad',
+			'access_mode' => BindingService::ACCESS_PROTECTED,
+			'pad_url' => '',
+		]);
+		$padFiles->expects($this->once())->method('isExternalFrontmatter')->with($frontmatter, 'g.group$pad')->willReturn(false);
+
+		$bindings = $this->createMock(BindingService::class);
+		$bindings->expects($this->once())
+			->method('assertConsistentMapping')
+			->with(42, 'g.group$pad', BindingService::ACCESS_PROTECTED);
+
+		$openService = $this->createMock(PublicPadOpenService::class);
+		$openService->expects($this->once())
+			->method('open')
+			->with('g.group$pad', BindingService::ACCESS_PROTECTED, true, 'token', false, 'frontmatter', '')
+			->willReturn(new PublicPadOpenTarget('', '', '', true, 'Snapshot text', '<p>Snapshot</p>'));
+
+		$context = (new PublicPadContextService($shareResolver, $padFiles, $bindings, $openService))->resolve('token', '', $share);
+
+		$this->assertSame('Shared.pad', $context->title);
+		$this->assertSame('', $context->url);
+		$this->assertFalse($context->isExternal);
+		$this->assertTrue($context->isReadOnlySnapshot);
+		$this->assertSame('Snapshot text', $context->snapshotText);
+		$this->assertSame('<p>Snapshot</p>', $context->snapshotHtml);
+	}
+}

--- a/tests/phpunit/unit/PublicPadOpenServiceTest.php
+++ b/tests/phpunit/unit/PublicPadOpenServiceTest.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\EtherpadNextcloud\Tests\Unit;
+
+use OCA\EtherpadNextcloud\Exception\EtherpadClientException;
+use OCA\EtherpadNextcloud\Service\BindingService;
+use OCA\EtherpadNextcloud\Service\EtherpadClient;
+use OCA\EtherpadNextcloud\Service\PadFileService;
+use OCA\EtherpadNextcloud\Service\PadSessionService;
+use OCA\EtherpadNextcloud\Service\PublicPadOpenService;
+use OCA\EtherpadNextcloud\Service\SnapshotHtmlSanitizer;
+use PHPUnit\Framework\TestCase;
+
+class PublicPadOpenServiceTest extends TestCase {
+	public function testProtectedReadOnlyReturnsSanitizedSnapshot(): void {
+		$padFiles = $this->createMock(PadFileService::class);
+		$padFiles->expects($this->once())->method('getTextSnapshotForRestore')->with('content')->willReturn('Snapshot text');
+		$padFiles->expects($this->once())->method('getHtmlSnapshotForRestore')->with('content')->willReturn('<h1 onclick="x">Title</h1><script>x</script>');
+
+		$result = $this->buildService($padFiles)->open(
+			'g.group$pad',
+			BindingService::ACCESS_PROTECTED,
+			true,
+			'token',
+			false,
+			'content',
+		);
+
+		$this->assertSame('', $result->url);
+		$this->assertTrue($result->isReadOnlySnapshot);
+		$this->assertSame('Snapshot text', $result->snapshotText);
+		$this->assertSame('<h1>Title</h1>', $result->snapshotHtml);
+		$this->assertSame('', $result->cookieHeader);
+	}
+
+	public function testProtectedWritableCreatesPublicShareSession(): void {
+		$sessions = $this->createMock(PadSessionService::class);
+		$sessions->expects($this->once())
+			->method('createProtectedOpenContext')
+			->with('public-share:token', 'Public share', 'g.group$pad', 3600)
+			->willReturn(['url' => 'https://pad.example/p/g.group$pad', 'cookie' => ['name' => 'sessionID']]);
+		$sessions->expects($this->once())
+			->method('buildSetCookieHeader')
+			->with(['name' => 'sessionID'])
+			->willReturn('sessionID=abc; Path=/');
+
+		$result = $this->buildService(padSessionService: $sessions)->open(
+			'g.group$pad',
+			BindingService::ACCESS_PROTECTED,
+			false,
+			'token',
+			false,
+			'content',
+		);
+
+		$this->assertSame('https://pad.example/p/g.group$pad', $result->url);
+		$this->assertSame('sessionID=abc; Path=/', $result->cookieHeader);
+		$this->assertFalse($result->isReadOnlySnapshot);
+	}
+
+	public function testExternalPublicPadReturnsNormalizedUrlAndTextSnapshot(): void {
+		$padFiles = $this->createMock(PadFileService::class);
+		$padFiles->expects($this->once())->method('getTextSnapshotForRestore')->with('content')->willReturn('External snapshot');
+
+		$etherpad = $this->createMock(EtherpadClient::class);
+		$etherpad->expects($this->once())
+			->method('normalizeAndValidateExternalPublicPadUrl')
+			->with('https://remote.example/p/Test')
+			->willReturn(['pad_url' => 'https://remote.example/p/Test']);
+
+		$result = $this->buildService($padFiles, $etherpad)->open(
+			'ext.abc',
+			BindingService::ACCESS_PUBLIC,
+			true,
+			'token',
+			true,
+			'content',
+			'https://remote.example/p/Test',
+		);
+
+		$this->assertSame('https://remote.example/p/Test', $result->url);
+		$this->assertSame('https://remote.example/p/Test', $result->originalPadUrl);
+		$this->assertSame('External snapshot', $result->snapshotText);
+		$this->assertSame('', $result->snapshotHtml);
+	}
+
+	public function testExternalProtectedMetadataIsRejected(): void {
+		$this->expectException(EtherpadClientException::class);
+		$this->expectExceptionMessage('External pad metadata requires public access_mode.');
+
+		$this->buildService()->open(
+			'ext.abc',
+			BindingService::ACCESS_PROTECTED,
+			false,
+			'token',
+			true,
+			'content',
+			'https://remote.example/p/Test',
+		);
+	}
+
+	public function testExternalPadWithoutUrlIsRejected(): void {
+		$this->expectException(EtherpadClientException::class);
+		$this->expectExceptionMessage('External pad URL metadata is missing or invalid.');
+
+		$this->buildService()->open(
+			'ext.abc',
+			BindingService::ACCESS_PUBLIC,
+			false,
+			'token',
+			true,
+			'content',
+			'',
+		);
+	}
+
+	public function testInternalReadOnlyUsesEtherpadReadOnlyUrl(): void {
+		$etherpad = $this->createMock(EtherpadClient::class);
+		$etherpad->expects($this->once())
+			->method('getReadOnlyPadUrl')
+			->with('public-pad')
+			->willReturn('https://pad.example/p/r.public-pad');
+
+		$result = $this->buildService(etherpadClient: $etherpad)->open(
+			'public-pad',
+			BindingService::ACCESS_PUBLIC,
+			true,
+			'token',
+			false,
+			'content',
+		);
+
+		$this->assertSame('https://pad.example/p/r.public-pad', $result->url);
+		$this->assertSame('', $result->cookieHeader);
+	}
+
+	public function testInternalWritableUsesPublicPadUrlWithoutSession(): void {
+		$etherpad = $this->createMock(EtherpadClient::class);
+		$etherpad->expects($this->once())
+			->method('buildPadUrl')
+			->with('public-pad')
+			->willReturn('https://pad.example/p/public-pad');
+
+		$sessions = $this->createMock(PadSessionService::class);
+		$sessions->expects($this->never())->method('createProtectedOpenContext');
+
+		$result = $this->buildService(etherpadClient: $etherpad, padSessionService: $sessions)->open(
+			'public-pad',
+			BindingService::ACCESS_PUBLIC,
+			false,
+			'token',
+			false,
+			'content',
+		);
+
+		$this->assertSame('https://pad.example/p/public-pad', $result->url);
+		$this->assertSame('', $result->cookieHeader);
+	}
+
+	private function buildService(
+		?PadFileService $padFileService = null,
+		?EtherpadClient $etherpadClient = null,
+		?PadSessionService $padSessionService = null,
+	): PublicPadOpenService {
+		return new PublicPadOpenService(
+			$padFileService ?? $this->createMock(PadFileService::class),
+			$etherpadClient ?? $this->createMock(EtherpadClient::class),
+			$padSessionService ?? $this->createMock(PadSessionService::class),
+			new SnapshotHtmlSanitizer(),
+		);
+	}
+}

--- a/tests/phpunit/unit/PublicShareResolverTest.php
+++ b/tests/phpunit/unit/PublicShareResolverTest.php
@@ -106,6 +106,17 @@ class PublicShareResolverTest extends TestCase {
 		$this->buildResolver()->resolvePadFile($share, '../Shared.pad', 'token');
 	}
 
+	public function testResolvePadFilePreservesInvalidPathPreviousException(): void {
+		$share = $this->share($this->createMock(Folder::class), Constants::PERMISSION_READ);
+
+		try {
+			$this->buildResolver()->resolvePadFile($share, '../Shared.pad', 'token');
+			$this->fail('Expected invalid share file path exception.');
+		} catch (InvalidShareFilePathException $e) {
+			$this->assertInstanceOf(\InvalidArgumentException::class, $e->getPrevious());
+		}
+	}
+
 	public function testResolvePadFileMapsMissingFolderFile(): void {
 		$folder = $this->createMock(Folder::class);
 		$folder->method('get')->willThrowException(new NotFoundException('missing'));

--- a/tests/phpunit/unit/PublicShareResolverTest.php
+++ b/tests/phpunit/unit/PublicShareResolverTest.php
@@ -92,7 +92,7 @@ class PublicShareResolverTest extends TestCase {
 		$share = $this->share($this->createMock(Folder::class), Constants::PERMISSION_READ);
 
 		$this->expectException(NoShareFileSelectedException::class);
-		$this->expectExceptionMessage('No .pad file selected.');
+		$this->expectExceptionMessage('No .pad file selected. Open a .pad file from this shared folder.');
 
 		$this->buildResolver()->resolvePadFile($share, '', 'token');
 	}

--- a/tests/phpunit/unit/PublicShareResolverTest.php
+++ b/tests/phpunit/unit/PublicShareResolverTest.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\EtherpadNextcloud\Tests\Unit;
+
+use OCA\EtherpadNextcloud\Exception\InvalidShareFilePathException;
+use OCA\EtherpadNextcloud\Exception\InvalidShareTokenException;
+use OCA\EtherpadNextcloud\Exception\NoShareFileSelectedException;
+use OCA\EtherpadNextcloud\Exception\NotAPadFileException;
+use OCA\EtherpadNextcloud\Exception\ShareFileNotInShareException;
+use OCA\EtherpadNextcloud\Exception\ShareItemUnavailableException;
+use OCA\EtherpadNextcloud\Exception\ShareReadForbiddenException;
+use OCA\EtherpadNextcloud\Service\PublicShareResolver;
+use OCA\EtherpadNextcloud\Util\PathNormalizer;
+use OCP\Constants;
+use OCP\Files\File;
+use OCP\Files\Folder;
+use OCP\Files\NotFoundException;
+use OCP\Share\Exceptions\ShareNotFound;
+use OCP\Share\IManager;
+use OCP\Share\IShare;
+use PHPUnit\Framework\TestCase;
+
+class PublicShareResolverTest extends TestCase {
+	public function testResolveShareReturnsCachedShareWithoutManagerLookup(): void {
+		$cached = $this->createMock(IShare::class);
+		$manager = $this->createMock(IManager::class);
+		$manager->expects($this->never())->method('getShareByToken');
+
+		$this->assertSame($cached, (new PublicShareResolver($manager, new PathNormalizer()))->resolveShare('token', $cached));
+	}
+
+	public function testResolveShareMapsMissingToken(): void {
+		$manager = $this->createMock(IManager::class);
+		$manager->method('getShareByToken')->willThrowException(new ShareNotFound());
+
+		$this->expectException(InvalidShareTokenException::class);
+		$this->expectExceptionMessage('This share link is invalid or has expired.');
+
+		(new PublicShareResolver($manager, new PathNormalizer()))->resolveShare('token');
+	}
+
+	public function testResolvePadFileReturnsSingleFileShare(): void {
+		$file = $this->padFile('Shared.pad', 42);
+		$share = $this->share($file, Constants::PERMISSION_READ);
+
+		$resolved = $this->buildResolver()->resolvePadFile($share, '', 'token');
+
+		$this->assertSame($file, $resolved->node);
+		$this->assertFalse($resolved->isFolderShare);
+		$this->assertSame('', $resolved->selectedRelativePath);
+		$this->assertTrue($resolved->readOnly);
+		$this->assertSame('Shared.pad', $resolved->name);
+	}
+
+	public function testResolvePadFileReturnsWritableFolderSelection(): void {
+		$file = $this->padFile('Shared.pad', 42);
+		$folder = $this->createMock(Folder::class);
+		$folder->expects($this->once())->method('get')->with('Folder/Shared.pad')->willReturn($file);
+		$share = $this->share($folder, Constants::PERMISSION_READ | Constants::PERMISSION_UPDATE);
+
+		$resolved = $this->buildResolver()->resolvePadFile($share, '/Folder/Shared.pad', 'token');
+
+		$this->assertSame($file, $resolved->node);
+		$this->assertTrue($resolved->isFolderShare);
+		$this->assertSame('Folder/Shared.pad', $resolved->selectedRelativePath);
+		$this->assertFalse($resolved->readOnly);
+	}
+
+	public function testResolvePadFileRejectsShareWithoutReadPermission(): void {
+		$share = $this->share($this->padFile('Shared.pad', 42), Constants::PERMISSION_UPDATE);
+
+		$this->expectException(ShareReadForbiddenException::class);
+		$this->expectExceptionMessage('This share link does not allow reading files.');
+
+		$this->buildResolver()->resolvePadFile($share, '', 'token');
+	}
+
+	public function testResolvePadFileMapsMissingShareNode(): void {
+		$share = $this->createMock(IShare::class);
+		$share->method('getPermissions')->willReturn(Constants::PERMISSION_READ);
+		$share->method('getNode')->willThrowException(new NotFoundException('missing'));
+
+		$this->expectException(ShareItemUnavailableException::class);
+		$this->expectExceptionMessage('This shared item is no longer available.');
+
+		$this->buildResolver()->resolvePadFile($share, '', 'token');
+	}
+
+	public function testResolvePadFileRejectsFolderShareWithoutSelectedFile(): void {
+		$share = $this->share($this->createMock(Folder::class), Constants::PERMISSION_READ);
+
+		$this->expectException(NoShareFileSelectedException::class);
+		$this->expectExceptionMessage('No .pad file selected.');
+
+		$this->buildResolver()->resolvePadFile($share, '', 'token');
+	}
+
+	public function testResolvePadFileRejectsInvalidFolderPath(): void {
+		$share = $this->share($this->createMock(Folder::class), Constants::PERMISSION_READ);
+
+		$this->expectException(InvalidShareFilePathException::class);
+		$this->expectExceptionMessage('Invalid file path.');
+
+		$this->buildResolver()->resolvePadFile($share, '../Shared.pad', 'token');
+	}
+
+	public function testResolvePadFileMapsMissingFolderFile(): void {
+		$folder = $this->createMock(Folder::class);
+		$folder->method('get')->willThrowException(new NotFoundException('missing'));
+		$share = $this->share($folder, Constants::PERMISSION_READ);
+
+		$this->expectException(ShareFileNotInShareException::class);
+		$this->expectExceptionMessage('The selected file does not exist in this share.');
+
+		$this->buildResolver()->resolvePadFile($share, 'Missing.pad', 'token');
+	}
+
+	public function testResolvePadFileRejectsFolderSelectionThatIsNotAFile(): void {
+		$folder = $this->createMock(Folder::class);
+		$folder->method('get')->willReturn($this->createMock(Folder::class));
+		$share = $this->share($folder, Constants::PERMISSION_READ);
+
+		$this->expectException(ShareFileNotInShareException::class);
+		$this->expectExceptionMessage('The selected item is not a file.');
+
+		$this->buildResolver()->resolvePadFile($share, 'NestedFolder', 'token');
+	}
+
+	public function testResolvePadFileRejectsNonPadFile(): void {
+		$share = $this->share($this->padFile('Text.txt', 42), Constants::PERMISSION_READ);
+
+		$this->expectException(NotAPadFileException::class);
+		$this->expectExceptionMessage('The selected file is not a .pad document.');
+
+		$this->buildResolver()->resolvePadFile($share, '', 'token');
+	}
+
+	private function buildResolver(?IManager $manager = null): PublicShareResolver {
+		return new PublicShareResolver($manager ?? $this->createMock(IManager::class), new PathNormalizer());
+	}
+
+	private function padFile(string $name, int $id): File {
+		$file = $this->createMock(File::class);
+		$file->method('getName')->willReturn($name);
+		$file->method('getId')->willReturn($id);
+		return $file;
+	}
+
+	private function share(File|Folder $node, int $permissions): IShare {
+		$share = $this->createMock(IShare::class);
+		$share->method('getPermissions')->willReturn($permissions);
+		$share->method('getNode')->willReturn($node);
+		return $share;
+	}
+}

--- a/tests/phpunit/unit/PublicShareUrlBuilderTest.php
+++ b/tests/phpunit/unit/PublicShareUrlBuilderTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace OCA\EtherpadNextcloud\Tests\Unit;
 
+use OCA\EtherpadNextcloud\Exception\InvalidShareFilePathException;
+use OCA\EtherpadNextcloud\Exception\NotAPadFileException;
 use OCA\EtherpadNextcloud\Service\PublicShareUrlBuilder;
 use OCA\EtherpadNextcloud\Util\PathNormalizer;
 use OCP\IURLGenerator;
@@ -26,17 +28,26 @@ class PublicShareUrlBuilderTest extends TestCase {
 	}
 
 	public function testBuildShareRedirectUrlRejectsNonPadFile(): void {
-		$this->expectException(\InvalidArgumentException::class);
+		$this->expectException(NotAPadFileException::class);
 		$this->expectExceptionMessage('The selected file is not a .pad document.');
 
 		$this->buildBuilder()->buildShareRedirectUrl('share-token', '/Folder/Text.txt');
 	}
 
 	public function testBuildShareRedirectUrlRejectsInvalidPath(): void {
-		$this->expectException(\InvalidArgumentException::class);
+		$this->expectException(InvalidShareFilePathException::class);
 		$this->expectExceptionMessage('Invalid file path.');
 
 		$this->buildBuilder()->buildShareRedirectUrl('share-token', '../Shared.pad');
+	}
+
+	public function testBuildShareRedirectUrlPreservesInvalidPathPreviousException(): void {
+		try {
+			$this->buildBuilder()->buildShareRedirectUrl('share-token', '../Shared.pad');
+			$this->fail('Expected invalid share file path exception.');
+		} catch (InvalidShareFilePathException $e) {
+			$this->assertInstanceOf(\InvalidArgumentException::class, $e->getPrevious());
+		}
 	}
 
 	public function testBuildDownloadUrlForSingleFileShare(): void {

--- a/tests/phpunit/unit/PublicShareUrlBuilderTest.php
+++ b/tests/phpunit/unit/PublicShareUrlBuilderTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\EtherpadNextcloud\Tests\Unit;
+
+use OCA\EtherpadNextcloud\Service\PublicShareUrlBuilder;
+use OCA\EtherpadNextcloud\Util\PathNormalizer;
+use OCP\IURLGenerator;
+use PHPUnit\Framework\TestCase;
+
+class PublicShareUrlBuilderTest extends TestCase {
+	public function testBuildShareBaseUrlEncodesToken(): void {
+		$this->assertSame('/nc/s/token%20with%2Fslash', $this->buildBuilder('/nc/')->buildShareBaseUrl('token with/slash'));
+	}
+
+	public function testBuildShareRedirectUrlDefaultsToRootDirectory(): void {
+		$this->assertSame('/s/share-token?dir=%2F', $this->buildBuilder()->buildShareRedirectUrl('share-token', ''));
+	}
+
+	public function testBuildShareRedirectUrlBuildsNestedPadSelection(): void {
+		$this->assertSame(
+			'/s/share-token?path=%2FFolder%2FSub&files=Shared.pad',
+			$this->buildBuilder()->buildShareRedirectUrl('share-token', '/Folder/Sub/Shared.pad')
+		);
+	}
+
+	public function testBuildShareRedirectUrlRejectsNonPadFile(): void {
+		$this->expectException(\InvalidArgumentException::class);
+		$this->expectExceptionMessage('The selected file is not a .pad document.');
+
+		$this->buildBuilder()->buildShareRedirectUrl('share-token', '/Folder/Text.txt');
+	}
+
+	public function testBuildShareRedirectUrlRejectsInvalidPath(): void {
+		$this->expectException(\InvalidArgumentException::class);
+		$this->expectExceptionMessage('Invalid file path.');
+
+		$this->buildBuilder()->buildShareRedirectUrl('share-token', '../Shared.pad');
+	}
+
+	public function testBuildDownloadUrlForSingleFileShare(): void {
+		$this->assertSame('/s/share-token/download', $this->buildBuilder()->buildDownloadUrl('share-token', '', false, 'Shared.pad'));
+	}
+
+	public function testBuildDownloadUrlForFolderShare(): void {
+		$this->assertSame(
+			'/s/share-token/download?path=%2FFolder&files=Shared.pad',
+			$this->buildBuilder()->buildDownloadUrl('share-token', '/Folder/Shared.pad', true, 'Shared.pad')
+		);
+	}
+
+	public function testBuildDownloadUrlReturnsEmptyForFolderShareWithoutSelection(): void {
+		$this->assertSame('', $this->buildBuilder()->buildDownloadUrl('share-token', '', true, 'Shared.pad'));
+	}
+
+	private function buildBuilder(string $webroot = ''): PublicShareUrlBuilder {
+		$urlGenerator = $this->createMock(IURLGenerator::class);
+		$urlGenerator->method('getWebroot')->willReturn($webroot);
+		return new PublicShareUrlBuilder($urlGenerator, new PathNormalizer());
+	}
+}

--- a/tests/phpunit/unit/PublicShareUrlBuilderTest.php
+++ b/tests/phpunit/unit/PublicShareUrlBuilderTest.php
@@ -41,6 +41,13 @@ class PublicShareUrlBuilderTest extends TestCase {
 		$this->buildBuilder()->buildShareRedirectUrl('share-token', '../Shared.pad');
 	}
 
+	public function testBuildShareRedirectUrlRejectsNonStringFileParam(): void {
+		$this->expectException(InvalidShareFilePathException::class);
+		$this->expectExceptionMessage('Invalid file path.');
+
+		$this->buildBuilder()->buildShareRedirectUrl('share-token', 123);
+	}
+
 	public function testBuildShareRedirectUrlPreservesInvalidPathPreviousException(): void {
 		try {
 			$this->buildBuilder()->buildShareRedirectUrl('share-token', '../Shared.pad');

--- a/tests/phpunit/unit/PublicViewerControllerErrorMapperTest.php
+++ b/tests/phpunit/unit/PublicViewerControllerErrorMapperTest.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\EtherpadNextcloud\Tests\Unit;
+
+use OCA\EtherpadNextcloud\Controller\PublicViewerControllerErrorMapper;
+use OCA\EtherpadNextcloud\Exception\EtherpadClientException;
+use OCA\EtherpadNextcloud\Exception\InvalidShareFilePathException;
+use OCA\EtherpadNextcloud\Exception\InvalidShareTokenException;
+use OCA\EtherpadNextcloud\Exception\MissingBindingException;
+use OCA\EtherpadNextcloud\Exception\NotAPadFileException;
+use OCA\EtherpadNextcloud\Exception\PadFileFormatException;
+use OCA\EtherpadNextcloud\Exception\ShareFileNotInShareException;
+use OCA\EtherpadNextcloud\Exception\ShareReadForbiddenException;
+use OCA\EtherpadNextcloud\Service\PublicShareUrlBuilder;
+use OCA\EtherpadNextcloud\Util\PathNormalizer;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\DataResponse;
+use OCP\AppFramework\Http\RedirectResponse;
+use OCP\AppFramework\Http\TemplateResponse;
+use OCP\IURLGenerator;
+use PHPUnit\Framework\TestCase;
+
+class PublicViewerControllerErrorMapperTest extends TestCase {
+	public function testRunForDataReturnsSuccessResponse(): void {
+		$response = $this->buildMapper()->runForData(
+			static fn(): array => ['ok' => true],
+			static fn(array $result): DataResponse => new DataResponse($result),
+		);
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertTrue((bool)$response->getData()['ok']);
+	}
+
+	public function testRunForDataMapsInvalidShareToNotFound(): void {
+		$response = $this->buildMapper()->runForData(
+			static fn(): array => throw new InvalidShareTokenException('This share link is invalid or has expired.'),
+			static fn(array $result): DataResponse => new DataResponse($result),
+		);
+
+		$this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+		$this->assertSame('This share link is invalid or has expired.', $response->getData()['message']);
+	}
+
+	public function testRunForDataMapsReadForbidden(): void {
+		$response = $this->buildMapper()->runForData(
+			static fn(): array => throw new ShareReadForbiddenException('This share link does not allow reading files.'),
+			static fn(array $result): DataResponse => new DataResponse($result),
+		);
+
+		$this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+	}
+
+	public function testRunForDataMapsInvalidFilePath(): void {
+		$response = $this->buildMapper()->runForData(
+			static fn(): array => throw new InvalidShareFilePathException('Invalid file path.'),
+			static fn(array $result): DataResponse => new DataResponse($result),
+		);
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame('Invalid file path.', $response->getData()['message']);
+	}
+
+	public function testRunForDataMapsMissingFolderFile(): void {
+		$response = $this->buildMapper()->runForData(
+			static fn(): array => throw new ShareFileNotInShareException('The selected file does not exist in this share.'),
+			static fn(array $result): DataResponse => new DataResponse($result),
+		);
+
+		$this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+	}
+
+	public function testRunForDataMapsNotPadFile(): void {
+		$response = $this->buildMapper()->runForData(
+			static fn(): array => throw new NotAPadFileException('The selected file is not a .pad document.'),
+			static fn(array $result): DataResponse => new DataResponse($result),
+		);
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame('The selected file is not a .pad document.', $response->getData()['message']);
+	}
+
+	public function testRunForDataMapsMissingFrontmatterMessage(): void {
+		$response = $this->buildMapper()->runForData(
+			static fn(): array => throw new PadFileFormatException('Missing YAML frontmatter.'),
+			static fn(array $result): DataResponse => new DataResponse($result),
+		);
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame('The selected .pad file is missing required metadata.', $response->getData()['message']);
+	}
+
+	public function testRunForDataMapsMissingBindingMessageForPublicAudience(): void {
+		$response = $this->buildMapper()->runForData(
+			static fn(): array => throw new MissingBindingException('No binding exists for this file.'),
+			static fn(array $result): DataResponse => new DataResponse($result),
+		);
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame(
+			'The selected .pad file is a copied file without an active pad binding. Please open the original shared .pad file.',
+			$response->getData()['message']
+		);
+	}
+
+	public function testRunForDataMapsEtherpadFailure(): void {
+		$response = $this->buildMapper()->runForData(
+			static fn(): array => throw new EtherpadClientException('down'),
+			static fn(array $result): DataResponse => new DataResponse($result),
+		);
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame('Etherpad is currently unavailable for this shared pad.', $response->getData()['message']);
+	}
+
+	public function testRunForTemplateReturnsRedirectOnSuccess(): void {
+		$response = $this->buildMapper('/nc')->runForTemplate(
+			static fn(): string => '/nc/s/token?dir=%2F',
+			static fn(string $target): RedirectResponse => new RedirectResponse($target),
+			'etherpad_nextcloud',
+			'token',
+		);
+
+		$this->assertInstanceOf(RedirectResponse::class, $response);
+		$this->assertSame('/nc/s/token?dir=%2F', $response->getRedirectURL());
+	}
+
+	public function testRunForTemplateReturnsNoViewerTemplateOnError(): void {
+		$response = $this->buildMapper('/nc')->runForTemplate(
+			static fn(): string => throw new NotAPadFileException('The selected file is not a .pad document.'),
+			static fn(string $target): RedirectResponse => new RedirectResponse($target),
+			'etherpad_nextcloud',
+			'token',
+		);
+
+		$this->assertInstanceOf(TemplateResponse::class, $response);
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame('noviewer', $response->getTemplateName());
+		$this->assertSame('The selected file is not a .pad document.', $response->getParams()['error']);
+		$this->assertSame('/nc/s/token', $response->getParams()['back_url']);
+		$this->assertSame('Back to shared files', $response->getParams()['back_label']);
+	}
+
+	private function buildMapper(string $webroot = ''): PublicViewerControllerErrorMapper {
+		$urlGenerator = $this->createMock(IURLGenerator::class);
+		$urlGenerator->method('getWebroot')->willReturn($webroot);
+		return new PublicViewerControllerErrorMapper(new PublicShareUrlBuilder($urlGenerator, new PathNormalizer()));
+	}
+}

--- a/tests/phpunit/unit/PublicViewerControllerErrorMapperTest.php
+++ b/tests/phpunit/unit/PublicViewerControllerErrorMapperTest.php
@@ -21,6 +21,7 @@ use OCP\AppFramework\Http\RedirectResponse;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\IURLGenerator;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 
 class PublicViewerControllerErrorMapperTest extends TestCase {
 	public function testRunForDataReturnsSuccessResponse(): void {
@@ -118,7 +119,6 @@ class PublicViewerControllerErrorMapperTest extends TestCase {
 		$response = $this->buildMapper('/nc')->runForTemplate(
 			static fn(): string => '/nc/s/token?dir=%2F',
 			static fn(string $target): RedirectResponse => new RedirectResponse($target),
-			'etherpad_nextcloud',
 			'token',
 		);
 
@@ -130,7 +130,6 @@ class PublicViewerControllerErrorMapperTest extends TestCase {
 		$response = $this->buildMapper('/nc')->runForTemplate(
 			static fn(): string => throw new NotAPadFileException('The selected file is not a .pad document.'),
 			static fn(string $target): RedirectResponse => new RedirectResponse($target),
-			'etherpad_nextcloud',
 			'token',
 		);
 
@@ -142,9 +141,41 @@ class PublicViewerControllerErrorMapperTest extends TestCase {
 		$this->assertSame('Back to shared files', $response->getParams()['back_label']);
 	}
 
-	private function buildMapper(string $webroot = ''): PublicViewerControllerErrorMapper {
+	public function testRunForDataLogsAndMasksUnexpectedFailures(): void {
+		$logger = $this->createMock(LoggerInterface::class);
+		$logger->expects($this->once())->method('error')->with('Unhandled public viewer error');
+
+		$response = $this->buildMapper(logger: $logger)->runForData(
+			static fn(): array => throw new \RuntimeException('internal path /var/secret/file.pad'),
+			static fn(array $result): DataResponse => new DataResponse($result),
+		);
+
+		$this->assertSame(Http::STATUS_INTERNAL_SERVER_ERROR, $response->getStatus());
+		$this->assertSame('Unable to open pad.', $response->getData()['message']);
+	}
+
+	public function testRunForTemplateLogsAndMasksUnexpectedFailures(): void {
+		$logger = $this->createMock(LoggerInterface::class);
+		$logger->expects($this->once())->method('error')->with('Unhandled public viewer error');
+
+		$response = $this->buildMapper('/nc', $logger)->runForTemplate(
+			static fn(): string => throw new \RuntimeException('internal path /var/secret/file.pad'),
+			static fn(string $target): RedirectResponse => new RedirectResponse($target),
+			'token',
+		);
+
+		$this->assertInstanceOf(TemplateResponse::class, $response);
+		$this->assertSame(Http::STATUS_INTERNAL_SERVER_ERROR, $response->getStatus());
+		$this->assertSame('Unable to open pad.', $response->getParams()['error']);
+		$this->assertSame('/nc/s/token', $response->getParams()['back_url']);
+	}
+
+	private function buildMapper(string $webroot = '', ?LoggerInterface $logger = null): PublicViewerControllerErrorMapper {
 		$urlGenerator = $this->createMock(IURLGenerator::class);
 		$urlGenerator->method('getWebroot')->willReturn($webroot);
-		return new PublicViewerControllerErrorMapper(new PublicShareUrlBuilder($urlGenerator, new PathNormalizer()));
+		return new PublicViewerControllerErrorMapper(
+			new PublicShareUrlBuilder($urlGenerator, new PathNormalizer()),
+			$logger ?? $this->createMock(LoggerInterface::class),
+		);
 	}
 }

--- a/tests/phpunit/unit/PublicViewerControllerErrorMapperTest.php
+++ b/tests/phpunit/unit/PublicViewerControllerErrorMapperTest.php
@@ -143,7 +143,14 @@ class PublicViewerControllerErrorMapperTest extends TestCase {
 
 	public function testRunForDataLogsAndMasksUnexpectedFailures(): void {
 		$logger = $this->createMock(LoggerInterface::class);
-		$logger->expects($this->once())->method('error')->with('Unhandled public viewer error');
+		$logger->expects($this->once())->method('error')->with(
+			'Unhandled public viewer error',
+			$this->callback(static function ($context): bool {
+				return is_array($context)
+					&& ($context['app'] ?? '') === 'etherpad_nextcloud'
+					&& ($context['exception'] ?? null) instanceof \RuntimeException;
+			}),
+		);
 
 		$response = $this->buildMapper(logger: $logger)->runForData(
 			static fn(): array => throw new \RuntimeException('internal path /var/secret/file.pad'),
@@ -156,7 +163,14 @@ class PublicViewerControllerErrorMapperTest extends TestCase {
 
 	public function testRunForTemplateLogsAndMasksUnexpectedFailures(): void {
 		$logger = $this->createMock(LoggerInterface::class);
-		$logger->expects($this->once())->method('error')->with('Unhandled public viewer error');
+		$logger->expects($this->once())->method('error')->with(
+			'Unhandled public viewer error',
+			$this->callback(static function ($context): bool {
+				return is_array($context)
+					&& ($context['app'] ?? '') === 'etherpad_nextcloud'
+					&& ($context['exception'] ?? null) instanceof \RuntimeException;
+			}),
+		);
 
 		$response = $this->buildMapper('/nc', $logger)->runForTemplate(
 			static fn(): string => throw new \RuntimeException('internal path /var/secret/file.pad'),

--- a/tests/phpunit/unit/PublicViewerControllerTest.php
+++ b/tests/phpunit/unit/PublicViewerControllerTest.php
@@ -10,6 +10,7 @@ use OCA\EtherpadNextcloud\Service\EtherpadClient;
 use OCA\EtherpadNextcloud\Service\PadFileService;
 use OCA\EtherpadNextcloud\Service\PadSessionService;
 use OCA\EtherpadNextcloud\Service\PublicPadOpenService;
+use OCA\EtherpadNextcloud\Service\PublicShareResolver;
 use OCA\EtherpadNextcloud\Service\PublicShareUrlBuilder;
 use OCA\EtherpadNextcloud\Service\SnapshotHtmlSanitizer;
 use OCA\EtherpadNextcloud\Util\PathNormalizer;
@@ -245,8 +246,7 @@ class PublicViewerControllerTest extends TestCase {
 		$controller = new PublicViewerController(
 			'etherpad_nextcloud',
 			$this->createMock(IRequest::class),
-			$shareManager,
-			new PathNormalizer(),
+			new PublicShareResolver($shareManager, new PathNormalizer()),
 			$padFileService,
 			$bindingService,
 			new PublicPadOpenService($padFileService, $etherpadClient, $padSessionService, new SnapshotHtmlSanitizer()),
@@ -336,8 +336,7 @@ class PublicViewerControllerTest extends TestCase {
 		return new PublicViewerController(
 			'etherpad_nextcloud',
 			$this->createMock(IRequest::class),
-			$shareManager,
-			new PathNormalizer(),
+			new PublicShareResolver($shareManager, new PathNormalizer()),
 			$padFileService,
 			$bindingService ?? $this->createMock(BindingService::class),
 			new PublicPadOpenService($padFileService, $etherpadClient, $padSessionService, new SnapshotHtmlSanitizer()),

--- a/tests/phpunit/unit/PublicViewerControllerTest.php
+++ b/tests/phpunit/unit/PublicViewerControllerTest.php
@@ -25,6 +25,7 @@ use OCP\IURLGenerator;
 use OCP\Share\IManager;
 use OCP\Share\IShare;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 
 class PublicViewerControllerTest extends TestCase {
 	public function testProtectedReadOnlyPublicShareReturnsSnapshotWithoutEtherpadSessionCookie(): void {
@@ -254,7 +255,7 @@ class PublicViewerControllerTest extends TestCase {
 			$shareResolver,
 			new PublicPadContextService($shareResolver, $padFileService, $bindingService, $publicPadOpenService),
 			$shareUrlBuilder,
-			new PublicViewerControllerErrorMapper($shareUrlBuilder),
+			new PublicViewerControllerErrorMapper($shareUrlBuilder, $this->createMock(LoggerInterface::class)),
 			$this->createMock(ISession::class),
 		);
 
@@ -347,7 +348,7 @@ class PublicViewerControllerTest extends TestCase {
 			$shareResolver,
 			new PublicPadContextService($shareResolver, $padFileService, $bindingService, $publicPadOpenService),
 			$shareUrlBuilder,
-			new PublicViewerControllerErrorMapper($shareUrlBuilder),
+			new PublicViewerControllerErrorMapper($shareUrlBuilder, $this->createMock(LoggerInterface::class)),
 			$session ?? $this->createMock(ISession::class),
 		);
 	}

--- a/tests/phpunit/unit/PublicViewerControllerTest.php
+++ b/tests/phpunit/unit/PublicViewerControllerTest.php
@@ -10,6 +10,7 @@ use OCA\EtherpadNextcloud\Service\BindingService;
 use OCA\EtherpadNextcloud\Service\EtherpadClient;
 use OCA\EtherpadNextcloud\Service\PadFileService;
 use OCA\EtherpadNextcloud\Service\PadSessionService;
+use OCA\EtherpadNextcloud\Service\PublicPadContextService;
 use OCA\EtherpadNextcloud\Service\PublicPadOpenService;
 use OCA\EtherpadNextcloud\Service\PublicShareResolver;
 use OCA\EtherpadNextcloud\Service\PublicShareUrlBuilder;
@@ -244,14 +245,14 @@ class PublicViewerControllerTest extends TestCase {
 		$urlGenerator = $this->createMock(IURLGenerator::class);
 		$urlGenerator->method('getWebroot')->willReturn('');
 		$shareUrlBuilder = new PublicShareUrlBuilder($urlGenerator, new PathNormalizer());
+		$shareResolver = new PublicShareResolver($shareManager, new PathNormalizer());
+		$publicPadOpenService = new PublicPadOpenService($padFileService, $etherpadClient, $padSessionService, new SnapshotHtmlSanitizer());
 
 		$controller = new PublicViewerController(
 			'etherpad_nextcloud',
 			$this->createMock(IRequest::class),
-			new PublicShareResolver($shareManager, new PathNormalizer()),
-			$padFileService,
-			$bindingService,
-			new PublicPadOpenService($padFileService, $etherpadClient, $padSessionService, new SnapshotHtmlSanitizer()),
+			$shareResolver,
+			new PublicPadContextService($shareResolver, $padFileService, $bindingService, $publicPadOpenService),
 			$shareUrlBuilder,
 			new PublicViewerControllerErrorMapper($shareUrlBuilder),
 			$this->createMock(ISession::class),
@@ -336,14 +337,15 @@ class PublicViewerControllerTest extends TestCase {
 		$padFileService ??= $this->createMock(PadFileService::class);
 		$etherpadClient ??= $this->createMock(EtherpadClient::class);
 		$padSessionService ??= $this->createMock(PadSessionService::class);
+		$bindingService ??= $this->createMock(BindingService::class);
+		$shareResolver = new PublicShareResolver($shareManager, new PathNormalizer());
+		$publicPadOpenService = new PublicPadOpenService($padFileService, $etherpadClient, $padSessionService, new SnapshotHtmlSanitizer());
 
 		return new PublicViewerController(
 			'etherpad_nextcloud',
 			$this->createMock(IRequest::class),
-			new PublicShareResolver($shareManager, new PathNormalizer()),
-			$padFileService,
-			$bindingService ?? $this->createMock(BindingService::class),
-			new PublicPadOpenService($padFileService, $etherpadClient, $padSessionService, new SnapshotHtmlSanitizer()),
+			$shareResolver,
+			new PublicPadContextService($shareResolver, $padFileService, $bindingService, $publicPadOpenService),
 			$shareUrlBuilder,
 			new PublicViewerControllerErrorMapper($shareUrlBuilder),
 			$session ?? $this->createMock(ISession::class),

--- a/tests/phpunit/unit/PublicViewerControllerTest.php
+++ b/tests/phpunit/unit/PublicViewerControllerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OCA\EtherpadNextcloud\Tests\Unit;
 
 use OCA\EtherpadNextcloud\Controller\PublicViewerController;
+use OCA\EtherpadNextcloud\Controller\PublicViewerControllerErrorMapper;
 use OCA\EtherpadNextcloud\Service\BindingService;
 use OCA\EtherpadNextcloud\Service\EtherpadClient;
 use OCA\EtherpadNextcloud\Service\PadFileService;
@@ -242,6 +243,7 @@ class PublicViewerControllerTest extends TestCase {
 
 		$urlGenerator = $this->createMock(IURLGenerator::class);
 		$urlGenerator->method('getWebroot')->willReturn('');
+		$shareUrlBuilder = new PublicShareUrlBuilder($urlGenerator, new PathNormalizer());
 
 		$controller = new PublicViewerController(
 			'etherpad_nextcloud',
@@ -250,7 +252,8 @@ class PublicViewerControllerTest extends TestCase {
 			$padFileService,
 			$bindingService,
 			new PublicPadOpenService($padFileService, $etherpadClient, $padSessionService, new SnapshotHtmlSanitizer()),
-			new PublicShareUrlBuilder($urlGenerator, new PathNormalizer()),
+			$shareUrlBuilder,
+			new PublicViewerControllerErrorMapper($shareUrlBuilder),
 			$this->createMock(ISession::class),
 		);
 
@@ -329,6 +332,7 @@ class PublicViewerControllerTest extends TestCase {
 	): PublicViewerController {
 		$urlGenerator = $this->createMock(IURLGenerator::class);
 		$urlGenerator->method('getWebroot')->willReturn('');
+		$shareUrlBuilder = new PublicShareUrlBuilder($urlGenerator, new PathNormalizer());
 		$padFileService ??= $this->createMock(PadFileService::class);
 		$etherpadClient ??= $this->createMock(EtherpadClient::class);
 		$padSessionService ??= $this->createMock(PadSessionService::class);
@@ -340,7 +344,8 @@ class PublicViewerControllerTest extends TestCase {
 			$padFileService,
 			$bindingService ?? $this->createMock(BindingService::class),
 			new PublicPadOpenService($padFileService, $etherpadClient, $padSessionService, new SnapshotHtmlSanitizer()),
-			new PublicShareUrlBuilder($urlGenerator, new PathNormalizer()),
+			$shareUrlBuilder,
+			new PublicViewerControllerErrorMapper($shareUrlBuilder),
 			$session ?? $this->createMock(ISession::class),
 		);
 	}

--- a/tests/phpunit/unit/PublicViewerControllerTest.php
+++ b/tests/phpunit/unit/PublicViewerControllerTest.php
@@ -9,6 +9,9 @@ use OCA\EtherpadNextcloud\Service\BindingService;
 use OCA\EtherpadNextcloud\Service\EtherpadClient;
 use OCA\EtherpadNextcloud\Service\PadFileService;
 use OCA\EtherpadNextcloud\Service\PadSessionService;
+use OCA\EtherpadNextcloud\Service\PublicPadOpenService;
+use OCA\EtherpadNextcloud\Service\PublicShareUrlBuilder;
+use OCA\EtherpadNextcloud\Service\SnapshotHtmlSanitizer;
 use OCA\EtherpadNextcloud\Util\PathNormalizer;
 use OCP\AppFramework\Http;
 use OCP\Constants;
@@ -246,9 +249,8 @@ class PublicViewerControllerTest extends TestCase {
 			new PathNormalizer(),
 			$padFileService,
 			$bindingService,
-			$etherpadClient,
-			$padSessionService,
-			$urlGenerator,
+			new PublicPadOpenService($padFileService, $etherpadClient, $padSessionService, new SnapshotHtmlSanitizer()),
+			new PublicShareUrlBuilder($urlGenerator, new PathNormalizer()),
 			$this->createMock(ISession::class),
 		);
 
@@ -327,17 +329,19 @@ class PublicViewerControllerTest extends TestCase {
 	): PublicViewerController {
 		$urlGenerator = $this->createMock(IURLGenerator::class);
 		$urlGenerator->method('getWebroot')->willReturn('');
+		$padFileService ??= $this->createMock(PadFileService::class);
+		$etherpadClient ??= $this->createMock(EtherpadClient::class);
+		$padSessionService ??= $this->createMock(PadSessionService::class);
 
 		return new PublicViewerController(
 			'etherpad_nextcloud',
 			$this->createMock(IRequest::class),
 			$shareManager,
 			new PathNormalizer(),
-			$padFileService ?? $this->createMock(PadFileService::class),
+			$padFileService,
 			$bindingService ?? $this->createMock(BindingService::class),
-			$etherpadClient ?? $this->createMock(EtherpadClient::class),
-			$padSessionService ?? $this->createMock(PadSessionService::class),
-			$urlGenerator,
+			new PublicPadOpenService($padFileService, $etherpadClient, $padSessionService, new SnapshotHtmlSanitizer()),
+			new PublicShareUrlBuilder($urlGenerator, new PathNormalizer()),
 			$session ?? $this->createMock(ISession::class),
 		);
 	}

--- a/tests/phpunit/unit/SnapshotHtmlSanitizerTest.php
+++ b/tests/phpunit/unit/SnapshotHtmlSanitizerTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\EtherpadNextcloud\Tests\Unit;
+
+use OCA\EtherpadNextcloud\Service\SnapshotHtmlSanitizer;
+use PHPUnit\Framework\TestCase;
+
+class SnapshotHtmlSanitizerTest extends TestCase {
+	public function testEmptyInputReturnsEmptyString(): void {
+		$this->assertSame('', $this->sanitize(" \n "));
+	}
+
+	public function testPreservesBasicBlockAndInlineTags(): void {
+		$this->assertSame(
+			'<h1>Title</h1><p><strong>Bold</strong> <em>Italic</em> <u>Under</u></p>',
+			$this->sanitize('<h1>Title</h1><p><strong>Bold</strong> <em>Italic</em> <u>Under</u></p>')
+		);
+	}
+
+	public function testPreservesLists(): void {
+		$this->assertSame(
+			'<ol><li>One</li><li>Two<ul><li>Nested</li></ul></li></ol>',
+			$this->sanitize('<ol start="1" class="number"><li>One</li><li>Two<ul><li>Nested</li></ul></li></ol>')
+		);
+	}
+
+	public function testPreservesPreCodeAndBlockquote(): void {
+		$this->assertSame(
+			'<blockquote>Quote</blockquote><pre><code>$ echo test</code></pre>',
+			$this->sanitize('<blockquote cite="x">Quote</blockquote><pre><code>$ echo test</code></pre>')
+		);
+	}
+
+	public function testPreservesLineBreakAsVoidTag(): void {
+		$this->assertSame('<p>A<br>B</p>', $this->sanitize('<p>A<br>B</p>'));
+	}
+
+	public function testDropsAllAttributes(): void {
+		$this->assertSame(
+			'<h1>Title</h1><p>Text</p>',
+			$this->sanitize('<h1 style="color:red" onclick="alert(1)">Title</h1><p class="lead" data-x="1">Text</p>')
+		);
+	}
+
+	public function testUnwrapsUnknownTagsButKeepsTextContent(): void {
+		$this->assertSame(
+			'<p>Before custom text after</p>',
+			$this->sanitize('<p>Before <custom-element data-x="1">custom <span>text</span></custom-element> after</p>')
+		);
+	}
+
+	public function testDropsScriptWithContent(): void {
+		$this->assertSame('<p>Safe</p>', $this->sanitize('<p>Safe<script>alert(1)</script></p>'));
+	}
+
+	public function testDropsEmbeddedMediaWithContent(): void {
+		$this->assertSame(
+			'<p>Safe</p>',
+			$this->sanitize('<p>Safe<iframe src="x">fallback</iframe><svg><text>svg text</text></svg><img src="x"></p>')
+		);
+	}
+
+	public function testEscapesTextContent(): void {
+		$this->assertSame(
+			'<p>Tom &amp; Jerry &quot;quoted&quot;</p>',
+			$this->sanitize('<p>Tom & Jerry "quoted"</p>')
+		);
+	}
+
+	public function testEscapesEntityDecodedLessThanText(): void {
+		$this->assertSame(
+			'<p>1 &lt; 2</p>',
+			$this->sanitize('<p>1 &lt; 2</p>')
+		);
+	}
+
+	public function testMalformedHtmlIsParsedAndSanitized(): void {
+		$this->assertSame(
+			'<p><strong>Bold</strong></p>',
+			$this->sanitize('<p><strong>Bold')
+		);
+	}
+
+	public function testWholeDocumentInputUsesBodyChildren(): void {
+		$this->assertSame(
+			'<h2>Heading</h2><p>Body</p>',
+			$this->sanitize('<!DOCTYPE HTML><html><body><h2>Heading</h2><p>Body</p></body></html>')
+		);
+	}
+
+	public function testCommentsAndProcessingInstructionsAreDropped(): void {
+		$this->assertSame('<p>Text</p>', $this->sanitize('<p>Text<!-- hidden --></p><?pi test?>'));
+	}
+
+	private function sanitize(string $html): string {
+		return (new SnapshotHtmlSanitizer())->sanitize($html);
+	}
+}


### PR DESCRIPTION
Refactors the public viewer controller into focused services and centralizes public-share error handling.

### Changes:

- Extract public viewer helper services:
  - SnapshotHtmlSanitizer
  - PublicShareUrlBuilder
  - PublicPadOpenService
  - PublicShareResolver
  - PublicPadContextService
- Add typed public-share exceptions for invalid tokens, missing files, forbidden reads, invalid paths, and non-.pad selections.
- Add PublicViewerControllerErrorMapper with separate handling for API responses and template responses.
- Harden public error handling:
  - unexpected errors now return 500
  - unexpected errors are logged
  - internal exception messages are not exposed to anonymous public-share visitors
- Keep public protected read-only behavior snapshot-based and preserve existing public/external/protected pad behavior.
- Add focused tests for sanitizer behavior, URL building, share resolution, pad-open logic, context assembly, and error mapping.