### PR TITLE
Store initial snapshot for external public pads

### DIFF
--- a/lib/Service/EtherpadClient.php
+++ b/lib/Service/EtherpadClient.php
@@ -128,19 +128,17 @@ class EtherpadClient {
 
 	public function getPublicTextFromPadUrl(string $padUrl): string {
 		$resolved = $this->resolveAndValidateExternalPublicPadUrl($padUrl);
-		$url = $this->buildPublicExportUrl($resolved['pad_url'], 'txt');
-		return $this->sendPinnedPublicGetRequest($url, $resolved['host'], $resolved['port'], $resolved['resolved_ips']);
+		return $this->getPublicTextFromResolvedExternalPad($resolved);
 	}
 
 	/** @return array{origin:string,pad_id:string,pad_url:string,text:string} */
 	public function normalizeAndFetchExternalPublicPadText(string $padUrl): array {
 		$resolved = $this->resolveAndValidateExternalPublicPadUrl($padUrl);
-		$url = $this->buildPublicExportUrl($resolved['pad_url'], 'txt');
 		return [
 			'origin' => $resolved['origin'],
 			'pad_id' => $resolved['pad_id'],
 			'pad_url' => $resolved['pad_url'],
-			'text' => $this->sendPinnedPublicGetRequest($url, $resolved['host'], $resolved['port'], $resolved['resolved_ips']),
+			'text' => $this->getPublicTextFromResolvedExternalPad($resolved),
 		];
 	}
 
@@ -302,6 +300,14 @@ class EtherpadClient {
 	private function buildPublicExportUrl(string $padUrl, string $format): string {
 		$parsed = $this->parsePublicPadUrl($padUrl);
 		return $parsed['pad_url'] . '/export/' . $format;
+	}
+
+	/**
+	 * @param array{pad_url:string,host:string,port:int,resolved_ips:list<string>} $resolved
+	 */
+	private function getPublicTextFromResolvedExternalPad(array $resolved): string {
+		$url = $this->buildPublicExportUrl($resolved['pad_url'], 'txt');
+		return $this->sendPinnedPublicGetRequest($url, $resolved['host'], $resolved['port'], $resolved['resolved_ips']);
 	}
 
 	/** @return array{origin:string,pad_id:string,pad_url:string,host:string,port:int,resolved_ips:list<string>} */

--- a/lib/Service/EtherpadClient.php
+++ b/lib/Service/EtherpadClient.php
@@ -132,6 +132,18 @@ class EtherpadClient {
 		return $this->sendPinnedPublicGetRequest($url, $resolved['host'], $resolved['port'], $resolved['resolved_ips']);
 	}
 
+	/** @return array{origin:string,pad_id:string,pad_url:string,text:string} */
+	public function normalizeAndFetchExternalPublicPadText(string $padUrl): array {
+		$resolved = $this->resolveAndValidateExternalPublicPadUrl($padUrl);
+		$url = $this->buildPublicExportUrl($resolved['pad_url'], 'txt');
+		return [
+			'origin' => $resolved['origin'],
+			'pad_id' => $resolved['pad_id'],
+			'pad_url' => $resolved['pad_url'],
+			'text' => $this->sendPinnedPublicGetRequest($url, $resolved['host'], $resolved['port'], $resolved['resolved_ips']),
+		];
+	}
+
 	public function assertPublicPadAvailable(string $padUrl): void {
 		$this->getPublicTextFromPadUrl($padUrl);
 	}

--- a/lib/Service/PadCreationService.php
+++ b/lib/Service/PadCreationService.php
@@ -181,11 +181,11 @@ class PadCreationService {
 	 */
 	public function createFromUrl(string $uid, string $file, string $padUrl): array {
 		$path = $this->padPaths->normalizeCreatePath($file);
-		$external = $this->etherpadClient->normalizeAndFetchExternalPublicPadText($padUrl);
 		$fileCreated = false;
+		$external = null;
 
 		return $this->withCreateRollback(
-			function () use ($uid, $path, $external, &$fileCreated): array {
+			function () use ($uid, $path, $padUrl, &$external, &$fileCreated): array {
 				$fileNode = $this->padFileCreator->createUserFile($uid, $path);
 				$fileCreated = true;
 				$fileId = (int)$fileNode->getId();
@@ -193,6 +193,7 @@ class PadCreationService {
 					throw new \RuntimeException('Could not resolve new file ID.');
 				}
 
+				$external = $this->etherpadClient->normalizeAndFetchExternalPublicPadText($padUrl);
 				$bindingPadId = $this->rollbackService->buildExternalBindingPadId($external['origin'], $external['pad_id'], $fileId);
 				$content = $this->padFileService->buildInitialDocument(
 					$fileId,
@@ -221,14 +222,14 @@ class PadCreationService {
 			function () use ($uid, $path, &$fileCreated): void {
 				$this->rollbackService->rollbackExternalCreate($uid, $path, $fileCreated);
 			},
-			function (\Throwable $e) use ($path, $padUrl, $external): ?array {
+			function (\Throwable $e) use ($path, $padUrl, &$external): ?array {
 				if ($e instanceof BindingException) {
 					return [
 						'message' => 'External pad URL already linked',
 						'context' => [
 							'file' => $path,
-							'origin' => $external['origin'],
-							'remotePadId' => $external['pad_id'],
+							'origin' => is_array($external) ? $external['origin'] : '',
+							'remotePadId' => is_array($external) ? $external['pad_id'] : '',
 						],
 					];
 				}

--- a/lib/Service/PadCreationService.php
+++ b/lib/Service/PadCreationService.php
@@ -194,7 +194,7 @@ class PadCreationService {
 				}
 
 				$bindingPadId = $this->rollbackService->buildExternalBindingPadId($external['origin'], $external['pad_id'], $fileId);
-				$this->etherpadClient->assertPublicPadAvailable($external['pad_url']);
+				$initialSnapshot = $this->etherpadClient->getPublicTextFromPadUrl($external['pad_url']);
 				$content = $this->padFileService->buildInitialDocument(
 					$fileId,
 					$bindingPadId,
@@ -206,6 +206,7 @@ class PadCreationService {
 						'remote_pad_id' => $external['pad_id'],
 					]
 				);
+				$content = $this->padFileService->withExportSnapshot($content, $initialSnapshot, '', 0, false);
 				$fileNode->putContent($content);
 
 				$this->bindingService->createBinding($fileId, $bindingPadId, BindingService::ACCESS_PUBLIC);

--- a/lib/Service/PadCreationService.php
+++ b/lib/Service/PadCreationService.php
@@ -181,7 +181,7 @@ class PadCreationService {
 	 */
 	public function createFromUrl(string $uid, string $file, string $padUrl): array {
 		$path = $this->padPaths->normalizeCreatePath($file);
-		$external = $this->etherpadClient->normalizeAndValidateExternalPublicPadUrl($padUrl);
+		$external = $this->etherpadClient->normalizeAndFetchExternalPublicPadText($padUrl);
 		$fileCreated = false;
 
 		return $this->withCreateRollback(
@@ -194,7 +194,6 @@ class PadCreationService {
 				}
 
 				$bindingPadId = $this->rollbackService->buildExternalBindingPadId($external['origin'], $external['pad_id'], $fileId);
-				$initialSnapshot = $this->etherpadClient->getPublicTextFromPadUrl($external['pad_url']);
 				$content = $this->padFileService->buildInitialDocument(
 					$fileId,
 					$bindingPadId,
@@ -206,7 +205,7 @@ class PadCreationService {
 						'remote_pad_id' => $external['pad_id'],
 					]
 				);
-				$content = $this->padFileService->withExportSnapshot($content, $initialSnapshot, '', 0, false);
+				$content = $this->padFileService->withExportSnapshot($content, $external['text'], '', 0, false);
 				$fileNode->putContent($content);
 
 				$this->bindingService->createBinding($fileId, $bindingPadId, BindingService::ACCESS_PUBLIC);

--- a/tests/phpunit/unit/PadCreationServiceTest.php
+++ b/tests/phpunit/unit/PadCreationServiceTest.php
@@ -120,17 +120,14 @@ class PadCreationServiceTest extends TestCase {
 		$rollbackService->method('buildExternalBindingPadId')->with('https://pad.remote.test', 'RemotePad', 321)->willReturn('ext.hash');
 
 		$etherpadClient = $this->createMock(EtherpadClient::class);
-		$etherpadClient->method('normalizeAndValidateExternalPublicPadUrl')
+		$etherpadClient->method('normalizeAndFetchExternalPublicPadText')
 			->with('https://pad.remote.test/p/RemotePad')
 			->willReturn([
 				'pad_url' => 'https://pad.remote.test/p/RemotePad',
 				'origin' => 'https://pad.remote.test',
 				'pad_id' => 'RemotePad',
+				'text' => "Initial snapshot\nfrom remote pad",
 			]);
-		$etherpadClient->expects($this->once())
-			->method('getPublicTextFromPadUrl')
-			->with('https://pad.remote.test/p/RemotePad')
-			->willReturn("Initial snapshot\nfrom remote pad");
 
 		$padFileService = $this->createMock(PadFileService::class);
 		$padFileService->expects($this->once())
@@ -169,7 +166,7 @@ class PadCreationServiceTest extends TestCase {
 		], $result);
 	}
 
-	public function testCreateFromUrlRollsBackWhenPublicPadValidationFails(): void {
+	public function testCreateFromUrlDoesNotCreateFileWhenInitialSnapshotFetchFails(): void {
 		$fileNode = $this->createMock(File::class);
 		$fileNode->method('getId')->willReturn(321);
 		$fileNode->expects($this->never())->method('putContent');
@@ -177,23 +174,12 @@ class PadCreationServiceTest extends TestCase {
 		$padPaths = $this->createMock(PadPathService::class);
 		$padPaths->method('normalizeCreatePath')->with('/External')->willReturn('/External.pad');
 		$fileCreator = $this->createMock(PadFileCreator::class);
-		$fileCreator->method('createUserFile')->with('alice', '/External.pad')->willReturn($fileNode);
+		$fileCreator->expects($this->never())->method('createUserFile');
 		$rollbackService = $this->createMock(PadCreateRollbackService::class);
-		$rollbackService->method('buildExternalBindingPadId')->with('https://pad.remote.test', 'RemotePad', 321)->willReturn('ext.hash');
-		$rollbackService->expects($this->once())
-			->method('rollbackExternalCreate')
-			->with('alice', '/External.pad', true);
+		$rollbackService->expects($this->never())->method('rollbackExternalCreate');
 
 		$etherpadClient = $this->createMock(EtherpadClient::class);
-		$etherpadClient->method('normalizeAndValidateExternalPublicPadUrl')
-			->with('https://pad.remote.test/p/RemotePad')
-			->willReturn([
-				'pad_url' => 'https://pad.remote.test/p/RemotePad',
-				'origin' => 'https://pad.remote.test',
-				'pad_id' => 'RemotePad',
-			]);
-		$etherpadClient->expects($this->once())
-			->method('getPublicTextFromPadUrl')
+		$etherpadClient->method('normalizeAndFetchExternalPublicPadText')
 			->with('https://pad.remote.test/p/RemotePad')
 			->willThrowException(new EtherpadClientException('Remote pad unavailable.'));
 

--- a/tests/phpunit/unit/PadCreationServiceTest.php
+++ b/tests/phpunit/unit/PadCreationServiceTest.php
@@ -128,8 +128,9 @@ class PadCreationServiceTest extends TestCase {
 				'pad_id' => 'RemotePad',
 			]);
 		$etherpadClient->expects($this->once())
-			->method('assertPublicPadAvailable')
-			->with('https://pad.remote.test/p/RemotePad');
+			->method('getPublicTextFromPadUrl')
+			->with('https://pad.remote.test/p/RemotePad')
+			->willReturn("Initial snapshot\nfrom remote pad");
 
 		$padFileService = $this->createMock(PadFileService::class);
 		$padFileService->expects($this->once())
@@ -145,6 +146,10 @@ class PadCreationServiceTest extends TestCase {
 					'remote_pad_id' => 'RemotePad',
 				]
 			)
+			->willReturn('external-empty-frontmatter');
+		$padFileService->expects($this->once())
+			->method('withExportSnapshot')
+			->with('external-empty-frontmatter', "Initial snapshot\nfrom remote pad", '', 0, false)
 			->willReturn('external-frontmatter');
 
 		$bindingService = $this->createMock(BindingService::class);
@@ -188,7 +193,7 @@ class PadCreationServiceTest extends TestCase {
 				'pad_id' => 'RemotePad',
 			]);
 		$etherpadClient->expects($this->once())
-			->method('assertPublicPadAvailable')
+			->method('getPublicTextFromPadUrl')
 			->with('https://pad.remote.test/p/RemotePad')
 			->willThrowException(new EtherpadClientException('Remote pad unavailable.'));
 

--- a/tests/phpunit/unit/PadCreationServiceTest.php
+++ b/tests/phpunit/unit/PadCreationServiceTest.php
@@ -166,7 +166,7 @@ class PadCreationServiceTest extends TestCase {
 		], $result);
 	}
 
-	public function testCreateFromUrlDoesNotCreateFileWhenInitialSnapshotFetchFails(): void {
+	public function testCreateFromUrlRollsBackWhenInitialSnapshotFetchFails(): void {
 		$fileNode = $this->createMock(File::class);
 		$fileNode->method('getId')->willReturn(321);
 		$fileNode->expects($this->never())->method('putContent');
@@ -174,9 +174,11 @@ class PadCreationServiceTest extends TestCase {
 		$padPaths = $this->createMock(PadPathService::class);
 		$padPaths->method('normalizeCreatePath')->with('/External')->willReturn('/External.pad');
 		$fileCreator = $this->createMock(PadFileCreator::class);
-		$fileCreator->expects($this->never())->method('createUserFile');
+		$fileCreator->expects($this->once())->method('createUserFile')->with('alice', '/External.pad')->willReturn($fileNode);
 		$rollbackService = $this->createMock(PadCreateRollbackService::class);
-		$rollbackService->expects($this->never())->method('rollbackExternalCreate');
+		$rollbackService->expects($this->once())
+			->method('rollbackExternalCreate')
+			->with('alice', '/External.pad', true);
 
 		$etherpadClient = $this->createMock(EtherpadClient::class);
 		$etherpadClient->method('normalizeAndFetchExternalPublicPadText')


### PR DESCRIPTION
## Summary

- fetch the external public pad text export during `from-url` creation
- store that text as snapshot revision `0` in the new `.pad` file before opening it
- keep the existing rollback path when the initial export cannot be loaded

## Checks

- `./vendor/bin/phpunit tests/phpunit/unit/PadCreationServiceTest.php`
- `composer test:phpunit`

Closes #7