### PR TITLE
Harden external public pad snapshots

### DIFF
--- a/docs/pad-format.md
+++ b/docs/pad-format.md
@@ -71,8 +71,9 @@ Notes:
 
 - Text is the primary restore snapshot.
 - HTML is an additional structure/format snapshot.
-- External pads (`pad_origin` + `remote_pad_id`) are synced as text only for security reasons; HTML section is omitted entirely.
+- External pads (`pad_origin` + `remote_pad_id`) are imported and synced as text only for security reasons; HTML sections are omitted when the app writes external snapshots.
 - The parser expects exact `[HTML-BEGIN] ... [HTML-END]` markers for the HTML part.
+- Viewer/API responses never expose stored HTML directly. `SnapshotExtractor` runs `SnapshotHtmlSanitizer`, which allowlists simple formatting tags only and drops every attribute before HTML reaches the frontend.
 
 ## Mode Variants
 
@@ -118,6 +119,7 @@ Snapshot write flow:
 - `PadFileService::withExportSnapshot(...)` builds the new `.pad` content after an Etherpad export.
 - `PadFileLockRetryService::putContentWithSyncLockRetry(...)` writes that content back to the Nextcloud file with bounded lock retry.
 - `SnapshotExtractor` is read-only: it extracts text + sanitized HTML for viewer responses and does not mutate `.pad` files.
+- External public pad create/sync paths use `EtherpadClient::normalizeAndFetchExternalPublicPadText(...)` / `getPublicTextFromPadUrl(...)`, which reuse the same validated, host-pinned public export fetch and store no HTML snapshot.
 
 ## Sync Semantics
 

--- a/docs/pad-format.md
+++ b/docs/pad-format.md
@@ -119,7 +119,9 @@ Snapshot write flow:
 - `PadFileService::withExportSnapshot(...)` builds the new `.pad` content after an Etherpad export.
 - `PadFileLockRetryService::putContentWithSyncLockRetry(...)` writes that content back to the Nextcloud file with bounded lock retry.
 - `SnapshotExtractor` is read-only: it extracts text + sanitized HTML for viewer responses and does not mutate `.pad` files.
-- External public pad create/sync paths use `EtherpadClient::normalizeAndFetchExternalPublicPadText(...)` / `getPublicTextFromPadUrl(...)`, which reuse the same validated, host-pinned public export fetch and store no HTML snapshot.
+- External public pad create/sync paths both use the validated, host-pinned `/export/txt` fetch internally and store no HTML snapshot:
+  - create uses `EtherpadClient::normalizeAndFetchExternalPublicPadTextOrEmpty(...)`, allowing the `.pad` file to be created with an empty initial snapshot if the export is not available yet.
+  - sync uses `EtherpadClient::normalizeAndFetchExternalPublicPadText(...)`, keeping later export failures visible.
 
 ## Sync Semantics
 

--- a/lib/Exception/ExternalPadExportNotFoundException.php
+++ b/lib/Exception/ExternalPadExportNotFoundException.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * Copyright (c) 2026 Jacob Bühler
+ */
+
+namespace OCA\EtherpadNextcloud\Exception;
+
+class ExternalPadExportNotFoundException extends EtherpadClientException {
+}

--- a/lib/Service/EtherpadClient.php
+++ b/lib/Service/EtherpadClient.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace OCA\EtherpadNextcloud\Service;
 
 use OCA\EtherpadNextcloud\Exception\EtherpadClientException;
+use OCA\EtherpadNextcloud\Exception\ExternalPadExportNotFoundException;
 use OCP\IConfig;
 
 class EtherpadClient {
@@ -139,6 +140,23 @@ class EtherpadClient {
 			'pad_id' => $resolved['pad_id'],
 			'pad_url' => $resolved['pad_url'],
 			'text' => $this->getPublicTextFromResolvedExternalPad($resolved),
+		];
+	}
+
+	/** @return array{origin:string,pad_id:string,pad_url:string,text:string} */
+	public function normalizeAndFetchExternalPublicPadTextOrEmpty(string $padUrl): array {
+		$resolved = $this->resolveAndValidateExternalPublicPadUrl($padUrl);
+		try {
+			$text = $this->getPublicTextFromResolvedExternalPad($resolved);
+		} catch (ExternalPadExportNotFoundException) {
+			$text = '';
+		}
+
+		return [
+			'origin' => $resolved['origin'],
+			'pad_id' => $resolved['pad_id'],
+			'pad_url' => $resolved['pad_url'],
+			'text' => $text,
 		];
 	}
 
@@ -438,6 +456,11 @@ class EtherpadClient {
 				continue;
 			}
 			if ($httpCode >= 400) {
+				if ($httpCode === 404) {
+					throw new ExternalPadExportNotFoundException(
+						'External public pad export was not found. Make sure the pad exists and can be exported.'
+					);
+				}
 				throw new EtherpadClientException('Public export HTTP error (' . $httpCode . ')');
 			}
 

--- a/lib/Service/PadCreationService.php
+++ b/lib/Service/PadCreationService.php
@@ -193,7 +193,7 @@ class PadCreationService {
 					throw new \RuntimeException('Could not resolve new file ID.');
 				}
 
-				$external = $this->etherpadClient->normalizeAndFetchExternalPublicPadText($padUrl);
+				$external = $this->etherpadClient->normalizeAndFetchExternalPublicPadTextOrEmpty($padUrl);
 				$bindingPadId = $this->rollbackService->buildExternalBindingPadId($external['origin'], $external['pad_id'], $fileId);
 				$content = $this->padFileService->buildInitialDocument(
 					$fileId,

--- a/lib/Service/PadSyncService.php
+++ b/lib/Service/PadSyncService.php
@@ -146,11 +146,10 @@ class PadSyncService {
 		if ($padUrl === '') {
 			throw new EtherpadClientException('External pad URL metadata is missing or invalid.');
 		}
-		$normalized = $this->etherpadClient->normalizeAndValidateExternalPublicPadUrl($padUrl);
-
 		// External sync already performs a live upstream text fetch on every call.
 		// force=1 therefore only marks caller intent while preserving the no-blind-rewrite invariant.
-		$text = $this->etherpadClient->getPublicTextFromPadUrl($normalized['pad_url']);
+		$external = $this->etherpadClient->normalizeAndFetchExternalPublicPadText($padUrl);
+		$text = $external['text'];
 
 		$existingText = $this->padFileService->getTextSnapshotForRestore($currentContent);
 		if ($existingText === $text) {

--- a/tests/phpunit/unit/PadControllerTest.php
+++ b/tests/phpunit/unit/PadControllerTest.php
@@ -595,13 +595,14 @@ class PadControllerTest extends TestCase {
 
 		$etherpadClient = $this->createMock(EtherpadClient::class);
 		$etherpadClient->expects($this->once())
-			->method('normalizeAndValidateExternalPublicPadUrl')
+			->method('normalizeAndFetchExternalPublicPadText')
 			->with('https://pad.example.test/p/public-pad')
-			->willReturn(['pad_url' => 'https://pad.example.test/p/public-pad']);
-		$etherpadClient->expects($this->once())
-			->method('getPublicTextFromPadUrl')
-			->with('https://pad.example.test/p/public-pad')
-			->willReturn('same text');
+			->willReturn([
+				'origin' => 'https://pad.example.test',
+				'pad_id' => 'public-pad',
+				'pad_url' => 'https://pad.example.test/p/public-pad',
+				'text' => 'same text',
+			]);
 
 		$controller = $this->buildController(
 			$request,

--- a/tests/phpunit/unit/PadCreationServiceTest.php
+++ b/tests/phpunit/unit/PadCreationServiceTest.php
@@ -120,7 +120,7 @@ class PadCreationServiceTest extends TestCase {
 		$rollbackService->method('buildExternalBindingPadId')->with('https://pad.remote.test', 'RemotePad', 321)->willReturn('ext.hash');
 
 		$etherpadClient = $this->createMock(EtherpadClient::class);
-		$etherpadClient->method('normalizeAndFetchExternalPublicPadText')
+		$etherpadClient->method('normalizeAndFetchExternalPublicPadTextOrEmpty')
 			->with('https://pad.remote.test/p/RemotePad')
 			->willReturn([
 				'pad_url' => 'https://pad.remote.test/p/RemotePad',
@@ -166,6 +166,52 @@ class PadCreationServiceTest extends TestCase {
 		], $result);
 	}
 
+	public function testCreateFromUrlBuildsExternalBindingWithoutInitialSnapshot(): void {
+		$fileNode = $this->createMock(File::class);
+		$fileNode->method('getId')->willReturn(321);
+		$fileNode->expects($this->once())->method('putContent')->with('external-frontmatter');
+
+		$padPaths = $this->createMock(PadPathService::class);
+		$padPaths->method('normalizeCreatePath')->with('/External')->willReturn('/External.pad');
+		$fileCreator = $this->createMock(PadFileCreator::class);
+		$fileCreator->method('createUserFile')->with('alice', '/External.pad')->willReturn($fileNode);
+		$rollbackService = $this->createMock(PadCreateRollbackService::class);
+		$rollbackService->method('buildExternalBindingPadId')->with('https://pad.remote.test', 'RemotePad', 321)->willReturn('ext.hash');
+
+		$etherpadClient = $this->createMock(EtherpadClient::class);
+		$etherpadClient->method('normalizeAndFetchExternalPublicPadTextOrEmpty')
+			->with('https://pad.remote.test/p/RemotePad')
+			->willReturn([
+				'pad_url' => 'https://pad.remote.test/p/RemotePad',
+				'origin' => 'https://pad.remote.test',
+				'pad_id' => 'RemotePad',
+				'text' => '',
+			]);
+
+		$padFileService = $this->createMock(PadFileService::class);
+		$padFileService->method('buildInitialDocument')->willReturn('external-empty-frontmatter');
+		$padFileService->expects($this->once())
+			->method('withExportSnapshot')
+			->with('external-empty-frontmatter', '', '', 0, false)
+			->willReturn('external-frontmatter');
+
+		$bindingService = $this->createMock(BindingService::class);
+		$bindingService->expects($this->once())
+			->method('createBinding')
+			->with(321, 'ext.hash', BindingService::ACCESS_PUBLIC);
+
+		$result = $this->buildService($padFileService, $padPaths, $fileCreator, null, $rollbackService, $bindingService, $etherpadClient)
+			->createFromUrl('alice', '/External', 'https://pad.remote.test/p/RemotePad');
+
+		$this->assertSame([
+			'file' => '/External.pad',
+			'file_id' => 321,
+			'pad_id' => 'ext.hash',
+			'access_mode' => BindingService::ACCESS_PUBLIC,
+			'pad_url' => 'https://pad.remote.test/p/RemotePad',
+		], $result);
+	}
+
 	public function testCreateFromUrlRollsBackWhenInitialSnapshotFetchFails(): void {
 		$fileNode = $this->createMock(File::class);
 		$fileNode->method('getId')->willReturn(321);
@@ -181,7 +227,7 @@ class PadCreationServiceTest extends TestCase {
 			->with('alice', '/External.pad', true);
 
 		$etherpadClient = $this->createMock(EtherpadClient::class);
-		$etherpadClient->method('normalizeAndFetchExternalPublicPadText')
+		$etherpadClient->method('normalizeAndFetchExternalPublicPadTextOrEmpty')
 			->with('https://pad.remote.test/p/RemotePad')
 			->willThrowException(new EtherpadClientException('Remote pad unavailable.'));
 

--- a/tests/phpunit/unit/PadSyncServiceTest.php
+++ b/tests/phpunit/unit/PadSyncServiceTest.php
@@ -95,16 +95,88 @@ class PadSyncServiceTest extends TestCase {
 		], $result);
 	}
 
+	public function testSyncExternalPadStoresOnlyTextSnapshot(): void {
+		$file = $this->createMock(File::class);
+		$file->method('getName')->willReturn('Remote.pad');
+		$file->method('getContent')->willReturn('frontmatter');
+
+		$userNodeResolver = $this->createMock(UserNodeResolver::class);
+		$userNodeResolver->method('resolveUserFileNodeById')->with('alice', 138)->willReturn($file);
+		$userNodeResolver->method('toUserAbsolutePath')->with('alice', $file)->willReturn('/Remote.pad');
+
+		$padFileService = $this->createMock(PadFileService::class);
+		$padFileService->method('parsePadFile')->with('frontmatter')->willReturn([
+			'frontmatter' => [
+				'pad_id' => 'ext.remote',
+				'access_mode' => BindingService::ACCESS_PUBLIC,
+			],
+		]);
+		$padFileService->method('extractPadMetadata')->willReturn([
+			'pad_id' => 'ext.remote',
+			'access_mode' => BindingService::ACCESS_PUBLIC,
+			'pad_url' => 'https://pad.example.test/p/remote',
+		]);
+		$padFileService->method('isExternalFrontmatter')->willReturn(true);
+		$padFileService->expects($this->once())
+			->method('getTextSnapshotForRestore')
+			->with('frontmatter')
+			->willReturn('previous text');
+		$padFileService->expects($this->once())
+			->method('getSnapshotRevision')
+			->with('frontmatter')
+			->willReturn(4);
+		$padFileService->expects($this->once())
+			->method('withExportSnapshot')
+			->with('frontmatter', "remote text\nfrom export", '', 5, false)
+			->willReturn('updated-frontmatter');
+
+		$bindingService = $this->createMock(BindingService::class);
+		$bindingService->expects($this->once())
+			->method('assertConsistentMapping')
+			->with(138, 'ext.remote', BindingService::ACCESS_PUBLIC);
+
+		$etherpadClient = $this->createMock(EtherpadClient::class);
+		$etherpadClient->expects($this->once())
+			->method('normalizeAndFetchExternalPublicPadText')
+			->with('https://pad.example.test/p/remote')
+			->willReturn([
+				'origin' => 'https://pad.example.test',
+				'pad_id' => 'remote',
+				'pad_url' => 'https://pad.example.test/p/remote',
+				'text' => "remote text\nfrom export",
+			]);
+
+		$lockRetryService = $this->createMock(PadFileLockRetryService::class);
+		$lockRetryService->expects($this->once())
+			->method('putContentWithSyncLockRetry')
+			->with($file, 'updated-frontmatter')
+			->willReturn(1);
+
+		$result = $this->buildService($padFileService, $userNodeResolver, $bindingService, $etherpadClient, $lockRetryService)
+			->syncById('alice', 138, true);
+
+		$this->assertSame([
+			'status' => PadSyncService::STATUS_UPDATED,
+			'file_id' => 138,
+			'pad_id' => 'ext.remote',
+			'external' => true,
+			'forced' => true,
+			'snapshot_rev' => 5,
+			'lock_retries' => 1,
+		], $result);
+	}
+
 	private function buildService(
 		?PadFileService $padFileService = null,
 		?UserNodeResolver $userNodeResolver = null,
 		?BindingService $bindingService = null,
 		?EtherpadClient $etherpadClient = null,
+		?PadFileLockRetryService $lockRetryService = null,
 	): PadSyncService {
 		return new PadSyncService(
 			$padFileService ?? $this->createMock(PadFileService::class),
 			$userNodeResolver ?? $this->createMock(UserNodeResolver::class),
-			$this->createMock(PadFileLockRetryService::class),
+			$lockRetryService ?? $this->createMock(PadFileLockRetryService::class),
 			$bindingService ?? $this->createMock(BindingService::class),
 			$etherpadClient ?? $this->createMock(EtherpadClient::class),
 			$this->createMock(LoggerInterface::class),

--- a/tests/phpunit/unit/SnapshotHtmlSanitizerTest.php
+++ b/tests/phpunit/unit/SnapshotHtmlSanitizerTest.php
@@ -44,10 +44,24 @@ class SnapshotHtmlSanitizerTest extends TestCase {
 		);
 	}
 
+	public function testDropsUrlBearingAttributesFromFormattingTags(): void {
+		$this->assertSame(
+			'<p><strong>Bold</strong> <em>Italic</em></p>',
+			$this->sanitize('<p><strong formaction="https://evil.test">Bold</strong> <em background="javascript:alert(1)">Italic</em></p>')
+		);
+	}
+
 	public function testUnwrapsUnknownTagsButKeepsTextContent(): void {
 		$this->assertSame(
 			'<p>Before custom text after</p>',
 			$this->sanitize('<p>Before <custom-element data-x="1">custom <span>text</span></custom-element> after</p>')
+		);
+	}
+
+	public function testUnwrapsLinksButKeepsPlainText(): void {
+		$this->assertSame(
+			'<p>Read this link</p>',
+			$this->sanitize('<p>Read <a href="javascript:alert(1)" onclick="alert(2)">this link</a></p>')
 		);
 	}
 


### PR DESCRIPTION
## Summary

- import and sync external public pads as text-only snapshots
- keep stored external HTML out of the write path and sanitize any stored HTML before viewer responses
- allow external pad files to be created even when the initial `/export/txt` snapshot is not available yet
- document the external snapshot safety model in the `.pad` format docs

## Validation

- `composer test:phpunit`
- deployed and smoke-tested on the Uberspace test server

Closes #8