### PR TITLE
Add tiered pending delete retry jobs

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -19,9 +19,9 @@ Etherpad is the editing source of truth; the `.pad` file acts as binding storage
   - On Etherpad delete failures: `pending_delete` instead of blocking Nextcloud trash.
 - `lib/BackgroundJob/*PendingDeleteRetryJob.php`
   - Bucketed retry for deferred Etherpad deletions:
-    - hot rows: every 5 minutes during the first hour
-    - warm rows: hourly during the first day
-    - cold rows: daily after that
+    - hot rows: every 5 minutes for the first hour after trash (`deleted_at <= 1h ago`)
+    - warm rows: hourly from 1h to 24h after trash
+    - cold rows: daily after 24h
   - The legacy `RetryPendingDeleteJob` class remains as a compatibility shim for existing queued jobs.
 - `lib/Service/EtherpadClient.php`
   - Adapter for Etherpad HTTP API (pad create/delete/session/read-only/export).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -17,9 +17,12 @@ Etherpad is the editing source of truth; the `.pad` file acts as binding storage
   - Trash/restore flow.
   - Snapshot on trash, re-provisioning on restore.
   - On Etherpad delete failures: `pending_delete` instead of blocking Nextcloud trash.
-- `lib/BackgroundJob/RetryPendingDeleteJob.php`
-  - Daily retry for deferred Etherpad deletions:
-    - unresolved `pending_delete`
+- `lib/BackgroundJob/*PendingDeleteRetryJob.php`
+  - Bucketed retry for deferred Etherpad deletions:
+    - hot rows: every 5 minutes during the first hour
+    - warm rows: hourly during the first day
+    - cold rows: daily after that
+  - The legacy `RetryPendingDeleteJob` class remains as a compatibility shim for existing queued jobs.
 - `lib/Service/EtherpadClient.php`
   - Adapter for Etherpad HTTP API (pad create/delete/session/read-only/export).
 - `lib/Service/PadFileService.php`
@@ -212,6 +215,7 @@ Primary flow (native viewer when available):
 - If Etherpad is unavailable during delete: switch state to `pending_delete`, keep Nextcloud trash successful.
 - Restore: provision a new pad from `.pad` frontmatter/snapshot when no binding row exists, or finish a `pending_delete` row if one remains.
 - External pads skip lifecycle side effects entirely. Trash/restore only affects the Nextcloud file; the remote Etherpad server is never mutated.
+- Pending-delete cleanup is retried in age buckets: first every 5 minutes, then hourly, then daily.
 
 ### 6) Admin Integrity Check (optional)
 

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -79,6 +79,7 @@ class Application extends App implements IBootstrap {
 
 	public function boot(IBootContext $context): void {
 		$context->injectFn(function (IJobList $jobList): void {
+			$jobList->remove(\OCA\EtherpadNextcloud\BackgroundJob\RetryPendingDeleteJob::class);
 			$jobList->add(\OCA\EtherpadNextcloud\BackgroundJob\HotPendingDeleteRetryJob::class);
 			$jobList->add(\OCA\EtherpadNextcloud\BackgroundJob\WarmPendingDeleteRetryJob::class);
 			$jobList->add(\OCA\EtherpadNextcloud\BackgroundJob\ColdPendingDeleteRetryJob::class);

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -79,7 +79,9 @@ class Application extends App implements IBootstrap {
 
 	public function boot(IBootContext $context): void {
 		$context->injectFn(function (IJobList $jobList): void {
-			$jobList->add(\OCA\EtherpadNextcloud\BackgroundJob\RetryPendingDeleteJob::class);
+			$jobList->add(\OCA\EtherpadNextcloud\BackgroundJob\HotPendingDeleteRetryJob::class);
+			$jobList->add(\OCA\EtherpadNextcloud\BackgroundJob\WarmPendingDeleteRetryJob::class);
+			$jobList->add(\OCA\EtherpadNextcloud\BackgroundJob\ColdPendingDeleteRetryJob::class);
 		});
 	}
 }

--- a/lib/BackgroundJob/AbstractPendingDeleteRetryJob.php
+++ b/lib/BackgroundJob/AbstractPendingDeleteRetryJob.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Copyright (c) 2026 Jacob Bühler
+ */
+
+namespace OCA\EtherpadNextcloud\BackgroundJob;
+
+use OCA\EtherpadNextcloud\Service\PendingDeleteRetryService;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\TimedJob;
+
+abstract class AbstractPendingDeleteRetryJob extends TimedJob {
+	protected const INTERVAL_SECONDS = 24 * 60 * 60;
+	protected const MIN_AGE_SECONDS = 0;
+	protected const MAX_AGE_SECONDS = null;
+	protected const LIMIT = 200;
+
+	public function __construct(
+		ITimeFactory $time,
+		private PendingDeleteRetryService $retryService,
+	) {
+		parent::__construct($time);
+		$this->setInterval(static::INTERVAL_SECONDS);
+	}
+
+	/**
+	 * @param mixed $argument
+	 */
+	protected function run($argument): void {
+		$this->retryService->retryByAge(static::MIN_AGE_SECONDS, static::MAX_AGE_SECONDS, static::LIMIT);
+	}
+}

--- a/lib/BackgroundJob/ColdPendingDeleteRetryJob.php
+++ b/lib/BackgroundJob/ColdPendingDeleteRetryJob.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Copyright (c) 2026 Jacob Bühler
+ */
+
+namespace OCA\EtherpadNextcloud\BackgroundJob;
+
+class ColdPendingDeleteRetryJob extends AbstractPendingDeleteRetryJob {
+	protected const INTERVAL_SECONDS = 24 * 60 * 60;
+	protected const MIN_AGE_SECONDS = 24 * 60 * 60;
+	protected const MAX_AGE_SECONDS = null;
+}

--- a/lib/BackgroundJob/HotPendingDeleteRetryJob.php
+++ b/lib/BackgroundJob/HotPendingDeleteRetryJob.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Copyright (c) 2026 Jacob Bühler
+ */
+
+namespace OCA\EtherpadNextcloud\BackgroundJob;
+
+class HotPendingDeleteRetryJob extends AbstractPendingDeleteRetryJob {
+	protected const INTERVAL_SECONDS = 5 * 60;
+	protected const MIN_AGE_SECONDS = 0;
+	protected const MAX_AGE_SECONDS = 60 * 60;
+}

--- a/lib/BackgroundJob/WarmPendingDeleteRetryJob.php
+++ b/lib/BackgroundJob/WarmPendingDeleteRetryJob.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Copyright (c) 2026 Jacob Bühler
+ */
+
+namespace OCA\EtherpadNextcloud\BackgroundJob;
+
+class WarmPendingDeleteRetryJob extends AbstractPendingDeleteRetryJob {
+	protected const INTERVAL_SECONDS = 60 * 60;
+	protected const MIN_AGE_SECONDS = 60 * 60;
+	protected const MAX_AGE_SECONDS = 24 * 60 * 60;
+}

--- a/lib/Service/BindingService.php
+++ b/lib/Service/BindingService.php
@@ -13,6 +13,7 @@ use OCA\EtherpadNextcloud\Exception\BindingException;
 use OCA\EtherpadNextcloud\Exception\BindingStateConflictException;
 use OCA\EtherpadNextcloud\Exception\MissingBindingException;
 use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\IDBConnection;
 use Psr\Log\LoggerInterface;
 
@@ -25,6 +26,7 @@ class BindingService {
 
 	public function __construct(
 		private IDBConnection $db,
+		private ITimeFactory $timeFactory,
 		private LoggerInterface $logger,
 	) {
 	}
@@ -91,7 +93,7 @@ class BindingService {
 
 	/** @return array<int,array<string,mixed>> */
 	public function findPendingDeleteByAge(int $minAgeSeconds, ?int $maxAgeSeconds, int $limit = 100): array {
-		$now = time();
+		$now = $this->timeFactory->getTime();
 		$qb = $this->db->getQueryBuilder();
 		$qb->select('*')
 			->from(self::TABLE)
@@ -136,7 +138,7 @@ class BindingService {
 
 	public function createBinding(int $fileId, string $padId, string $accessMode): void {
 		$this->assertAccessMode($accessMode);
-		$now = time();
+		$now = $this->timeFactory->getTime();
 
 		$qb = $this->db->getQueryBuilder();
 		$qb->insert(self::TABLE)
@@ -186,7 +188,7 @@ class BindingService {
 			->set('pad_id', $qb->createNamedParameter($newPadId))
 			->set('state', $qb->createNamedParameter(self::STATE_ACTIVE))
 			->set('deleted_at', $qb->createNamedParameter(null, IQueryBuilder::PARAM_NULL))
-			->set('updated_at', $qb->createNamedParameter(time(), IQueryBuilder::PARAM_INT))
+			->set('updated_at', $qb->createNamedParameter($this->timeFactory->getTime(), IQueryBuilder::PARAM_INT))
 			->where($qb->expr()->eq('file_id', $qb->createNamedParameter($fileId, IQueryBuilder::PARAM_INT)))
 			->andWhere($qb->expr()->eq('state', $qb->createNamedParameter(self::STATE_PENDING_DELETE)));
 		$updated = $qb->executeStatement();
@@ -200,7 +202,7 @@ class BindingService {
 		$qb->update(self::TABLE)
 			->set('state', $qb->createNamedParameter(self::STATE_PENDING_DELETE))
 			->set('deleted_at', $qb->createNamedParameter($deletedAtTs, IQueryBuilder::PARAM_INT))
-			->set('updated_at', $qb->createNamedParameter(time(), IQueryBuilder::PARAM_INT))
+			->set('updated_at', $qb->createNamedParameter($this->timeFactory->getTime(), IQueryBuilder::PARAM_INT))
 			->where($qb->expr()->eq('file_id', $qb->createNamedParameter($fileId, IQueryBuilder::PARAM_INT)))
 			->andWhere($qb->expr()->eq('state', $qb->createNamedParameter(self::STATE_ACTIVE)));
 		$updated = $qb->executeStatement();

--- a/lib/Service/BindingService.php
+++ b/lib/Service/BindingService.php
@@ -89,6 +89,34 @@ class BindingService {
 		return max(0, (int)$row['cnt']);
 	}
 
+	/** @return array<int,array<string,mixed>> */
+	public function findPendingDeleteByAge(int $minAgeSeconds, ?int $maxAgeSeconds, int $limit = 100): array {
+		$now = time();
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('*')
+			->from(self::TABLE)
+			->where($qb->expr()->eq('state', $qb->createNamedParameter(self::STATE_PENDING_DELETE)))
+			->andWhere($qb->expr()->isNotNull('deleted_at'))
+			->andWhere($qb->expr()->lte(
+				'deleted_at',
+				$qb->createNamedParameter($now - max(0, $minAgeSeconds), IQueryBuilder::PARAM_INT),
+			))
+			->orderBy('deleted_at', 'ASC')
+			->setMaxResults(max(1, $limit));
+
+		if ($maxAgeSeconds !== null) {
+			$qb->andWhere($qb->expr()->gt(
+				'deleted_at',
+				$qb->createNamedParameter($now - max(0, $maxAgeSeconds), IQueryBuilder::PARAM_INT),
+			));
+		}
+
+		$result = $qb->executeQuery();
+		$rows = $result->fetchAll();
+		$result->closeCursor();
+		return $rows;
+	}
+
 	public function hasFileCacheEntry(int $fileId): bool {
 		$qb = $this->db->getQueryBuilder();
 		$qb->selectAlias($qb->createFunction('COUNT(*)'), 'cnt')

--- a/lib/Service/PendingDeleteRetryService.php
+++ b/lib/Service/PendingDeleteRetryService.php
@@ -30,7 +30,31 @@ class PendingDeleteRetryService {
 	 */
 	public function retry(int $limit = 200): array {
 		$safeLimit = max(1, $limit);
-		$pendingResult = $this->retryPendingDeletes($safeLimit);
+		$pendingResult = $this->retryPendingDeleteRows(
+			$this->bindingService->findByState(BindingService::STATE_PENDING_DELETE, $safeLimit),
+		);
+
+		return [
+			'attempted' => $pendingResult['attempted'],
+			'resolved' => $pendingResult['resolved'],
+			'failed' => $pendingResult['failed'],
+			'remaining' => $this->countPendingDeletes(),
+		];
+	}
+
+	/**
+	 * @return array{
+	 *   attempted:int,
+	 *   resolved:int,
+	 *   failed:int,
+	 *   remaining:int
+	 * }
+	 */
+	public function retryByAge(int $minAgeSeconds, ?int $maxAgeSeconds, int $limit = 200): array {
+		$safeLimit = max(1, $limit);
+		$pendingResult = $this->retryPendingDeleteRows(
+			$this->bindingService->findPendingDeleteByAge($minAgeSeconds, $maxAgeSeconds, $safeLimit),
+		);
 
 		return [
 			'attempted' => $pendingResult['attempted'],
@@ -44,12 +68,14 @@ class PendingDeleteRetryService {
 		return $this->bindingService->countByState(BindingService::STATE_PENDING_DELETE);
 	}
 
-	/** @return array{attempted:int,resolved:int,failed:int} */
-	private function retryPendingDeletes(int $limit): array {
+	/**
+	 * @param array<int,array<string,mixed>> $pending
+	 * @return array{attempted:int,resolved:int,failed:int}
+	 */
+	private function retryPendingDeleteRows(array $pending): array {
 		$attempted = 0;
 		$resolved = 0;
 		$failed = 0;
-		$pending = $this->bindingService->findByState(BindingService::STATE_PENDING_DELETE, $limit);
 		foreach ($pending as $row) {
 			$fileId = (int)($row['file_id'] ?? 0);
 			$padId = (string)($row['pad_id'] ?? '');

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -15,6 +15,8 @@ $stubFiles = [
 	__DIR__ . '/stubs/OCP/AppFramework/Http/Attribute/NoAdminRequired.php',
 	__DIR__ . '/stubs/OCP/AppFramework/Http/Attribute/NoCSRFRequired.php',
 	__DIR__ . '/stubs/OCP/AppFramework/Http/Attribute/PublicPage.php',
+	__DIR__ . '/stubs/OCP/AppFramework/Utility/ITimeFactory.php',
+	__DIR__ . '/stubs/OCP/BackgroundJob/TimedJob.php',
 	__DIR__ . '/stubs/OC/Security/CSRF/CsrfToken.php',
 	__DIR__ . '/stubs/OC/Security/CSRF/CsrfTokenManager.php',
 	__DIR__ . '/stubs/OCP/DB/QueryBuilder/IQueryBuilder.php',

--- a/tests/phpunit/stubs/OCP/AppFramework/Utility/ITimeFactory.php
+++ b/tests/phpunit/stubs/OCP/AppFramework/Utility/ITimeFactory.php
@@ -6,5 +6,6 @@ namespace OCP\AppFramework\Utility;
 
 if (!interface_exists(ITimeFactory::class)) {
 	interface ITimeFactory {
+		public function getTime(): int;
 	}
 }

--- a/tests/phpunit/stubs/OCP/AppFramework/Utility/ITimeFactory.php
+++ b/tests/phpunit/stubs/OCP/AppFramework/Utility/ITimeFactory.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCP\AppFramework\Utility;
+
+if (!interface_exists(ITimeFactory::class)) {
+	interface ITimeFactory {
+	}
+}

--- a/tests/phpunit/stubs/OCP/BackgroundJob/TimedJob.php
+++ b/tests/phpunit/stubs/OCP/BackgroundJob/TimedJob.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCP\BackgroundJob;
+
+use OCP\AppFramework\Utility\ITimeFactory;
+
+if (!class_exists(TimedJob::class)) {
+	abstract class TimedJob {
+		private int $interval = 0;
+
+		public function __construct(protected ITimeFactory $time) {
+		}
+
+		public function setInterval(int $interval): void {
+			$this->interval = $interval;
+		}
+
+		public function getInterval(): int {
+			return $this->interval;
+		}
+
+		/**
+		 * @param mixed $argument
+		 */
+		abstract protected function run($argument): void;
+	}
+}

--- a/tests/phpunit/unit/BindingServiceTest.php
+++ b/tests/phpunit/unit/BindingServiceTest.php
@@ -7,6 +7,8 @@ namespace OCA\EtherpadNextcloud\Tests\Unit;
 use OCA\EtherpadNextcloud\Exception\BindingException;
 use OCA\EtherpadNextcloud\Exception\MissingBindingException;
 use OCA\EtherpadNextcloud\Service\BindingService;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
@@ -59,20 +61,167 @@ class BindingServiceTest extends TestCase {
 		$service->assertConsistentMapping(12, 'pad-a', 'legacy');
 	}
 
+	public function testFindPendingDeleteByAgeAddsUpperAndLowerAgeBounds(): void {
+		$qb = new BindingServiceTestQueryBuilder([['file_id' => 10, 'pad_id' => 'pad-a']]);
+		$service = $this->buildServiceWithQueryBuilder($qb, 100000);
+
+		$rows = $service->findPendingDeleteByAge(3600, 86400, 50);
+
+		$this->assertSame([['file_id' => 10, 'pad_id' => 'pad-a']], $rows);
+		$this->assertSame(50, $qb->maxResults);
+		$this->assertContains(['lte', 'deleted_at', 'param2'], $qb->conditions);
+		$this->assertContains(['gt', 'deleted_at', 'param3'], $qb->conditions);
+		$this->assertSame([
+			['param1', BindingService::STATE_PENDING_DELETE, null],
+			['param2', 96400, IQueryBuilder::PARAM_INT],
+			['param3', 13600, IQueryBuilder::PARAM_INT],
+		], $qb->parameters);
+	}
+
+	public function testFindPendingDeleteByAgeOmitsUpperBoundForColdBucketAndClampsNegativeAge(): void {
+		$qb = new BindingServiceTestQueryBuilder([]);
+		$service = $this->buildServiceWithQueryBuilder($qb, 100000);
+
+		$service->findPendingDeleteByAge(-1, null, 0);
+
+		$this->assertSame(1, $qb->maxResults);
+		$this->assertContains(['lte', 'deleted_at', 'param2'], $qb->conditions);
+		$this->assertNotContains(['gt', 'deleted_at', 'param3'], $qb->conditions);
+		$this->assertSame([
+			['param1', BindingService::STATE_PENDING_DELETE, null],
+			['param2', 100000, IQueryBuilder::PARAM_INT],
+		], $qb->parameters);
+	}
+
 	/** @param array<string,mixed>|null $binding */
 	private function buildServiceWithBinding(?array $binding): BindingService {
 		$db = $this->createMock(IDBConnection::class);
 		$logger = $this->createMock(LoggerInterface::class);
+		$timeFactory = $this->buildTimeFactory(100000);
 
-		return new class ($db, $logger, $binding) extends BindingService {
+		return new class ($db, $timeFactory, $logger, $binding) extends BindingService {
 			/** @param array<string,mixed>|null $binding */
-			public function __construct(IDBConnection $db, LoggerInterface $logger, private ?array $binding) {
-				parent::__construct($db, $logger);
+			public function __construct(
+				IDBConnection $db,
+				ITimeFactory $timeFactory,
+				LoggerInterface $logger,
+				private ?array $binding,
+			) {
+				parent::__construct($db, $timeFactory, $logger);
 			}
 
 			public function findByFileId(int $fileId): ?array {
 				return $this->binding;
 			}
 		};
+	}
+
+	private function buildServiceWithQueryBuilder(BindingServiceTestQueryBuilder $qb, int $now): BindingService {
+		$db = new class ($qb) implements IDBConnection {
+			public function __construct(private BindingServiceTestQueryBuilder $qb) {
+			}
+
+			public function getQueryBuilder(): IQueryBuilder {
+				return $this->qb;
+			}
+		};
+
+		return new BindingService($db, $this->buildTimeFactory($now), $this->createMock(LoggerInterface::class));
+	}
+
+	private function buildTimeFactory(int $now): ITimeFactory {
+		$timeFactory = $this->createMock(ITimeFactory::class);
+		$timeFactory->method('getTime')->willReturn($now);
+		return $timeFactory;
+	}
+}
+
+class BindingServiceTestQueryBuilder implements IQueryBuilder {
+	/** @var array<int,array{string,mixed,int|null}> */
+	public array $parameters = [];
+	/** @var array<int,array<int,string>> */
+	public array $conditions = [];
+	public int $maxResults = 0;
+	private int $parameterCounter = 0;
+
+	/** @param array<int,array<string,mixed>> $rows */
+	public function __construct(private array $rows) {
+	}
+
+	public function select(string $select): self {
+		return $this;
+	}
+
+	public function from(string $table): self {
+		return $this;
+	}
+
+	public function where(mixed $condition): self {
+		$this->conditions[] = $condition;
+		return $this;
+	}
+
+	public function andWhere(mixed $condition): self {
+		$this->conditions[] = $condition;
+		return $this;
+	}
+
+	public function orderBy(string $field, string $direction): self {
+		return $this;
+	}
+
+	public function setMaxResults(int $maxResults): self {
+		$this->maxResults = $maxResults;
+		return $this;
+	}
+
+	public function createNamedParameter(mixed $value, ?int $type = null): string {
+		$name = 'param' . ++$this->parameterCounter;
+		$this->parameters[] = [$name, $value, $type];
+		return $name;
+	}
+
+	public function expr(): BindingServiceTestExpressionBuilder {
+		return new BindingServiceTestExpressionBuilder();
+	}
+
+	public function executeQuery(): BindingServiceTestResult {
+		return new BindingServiceTestResult($this->rows);
+	}
+}
+
+class BindingServiceTestExpressionBuilder {
+	/** @return array{string,string,string} */
+	public function eq(string $field, string $parameter): array {
+		return ['eq', $field, $parameter];
+	}
+
+	/** @return array{string,string} */
+	public function isNotNull(string $field): array {
+		return ['isNotNull', $field];
+	}
+
+	/** @return array{string,string,string} */
+	public function lte(string $field, string $parameter): array {
+		return ['lte', $field, $parameter];
+	}
+
+	/** @return array{string,string,string} */
+	public function gt(string $field, string $parameter): array {
+		return ['gt', $field, $parameter];
+	}
+}
+
+class BindingServiceTestResult {
+	/** @param array<int,array<string,mixed>> $rows */
+	public function __construct(private array $rows) {
+	}
+
+	/** @return array<int,array<string,mixed>> */
+	public function fetchAll(): array {
+		return $this->rows;
+	}
+
+	public function closeCursor(): void {
 	}
 }

--- a/tests/phpunit/unit/PendingDeleteRetryJobTest.php
+++ b/tests/phpunit/unit/PendingDeleteRetryJobTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\EtherpadNextcloud\Tests\Unit;
+
+use OCA\EtherpadNextcloud\BackgroundJob\ColdPendingDeleteRetryJob;
+use OCA\EtherpadNextcloud\BackgroundJob\HotPendingDeleteRetryJob;
+use OCA\EtherpadNextcloud\BackgroundJob\WarmPendingDeleteRetryJob;
+use OCA\EtherpadNextcloud\Service\PendingDeleteRetryService;
+use OCP\AppFramework\Utility\ITimeFactory;
+use PHPUnit\Framework\TestCase;
+
+class PendingDeleteRetryJobTest extends TestCase {
+	public function testHotJobRetriesYoungRowsEveryFiveMinutes(): void {
+		$retry = $this->createMock(PendingDeleteRetryService::class);
+		$retry->expects($this->once())->method('retryByAge')->with(0, 3600, 200);
+
+		$job = new HotPendingDeleteRetryJob($this->createMock(ITimeFactory::class), $retry);
+
+		$this->assertSame(300, $job->getInterval());
+		$this->runJob($job);
+	}
+
+	public function testWarmJobRetriesRowsFromFirstDayHourly(): void {
+		$retry = $this->createMock(PendingDeleteRetryService::class);
+		$retry->expects($this->once())->method('retryByAge')->with(3600, 86400, 200);
+
+		$job = new WarmPendingDeleteRetryJob($this->createMock(ITimeFactory::class), $retry);
+
+		$this->assertSame(3600, $job->getInterval());
+		$this->runJob($job);
+	}
+
+	public function testColdJobRetriesOlderRowsDaily(): void {
+		$retry = $this->createMock(PendingDeleteRetryService::class);
+		$retry->expects($this->once())->method('retryByAge')->with(86400, null, 200);
+
+		$job = new ColdPendingDeleteRetryJob($this->createMock(ITimeFactory::class), $retry);
+
+		$this->assertSame(86400, $job->getInterval());
+		$this->runJob($job);
+	}
+
+	private function runJob(object $job): void {
+		$run = new \ReflectionMethod($job, 'run');
+		$run->invoke($job, null);
+	}
+}

--- a/tests/phpunit/unit/PendingDeleteRetryServiceTest.php
+++ b/tests/phpunit/unit/PendingDeleteRetryServiceTest.php
@@ -7,6 +7,7 @@ namespace OCA\EtherpadNextcloud\Tests\Unit;
 use OCA\EtherpadNextcloud\Service\BindingService;
 use OCA\EtherpadNextcloud\Service\EtherpadClient;
 use OCA\EtherpadNextcloud\Service\PendingDeleteRetryService;
+use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\IDBConnection;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
@@ -63,6 +64,7 @@ class PendingDeleteRetryServiceTest extends TestCase {
 	private function buildBindingService(array $ageRows): BindingService {
 		return new class (
 			$this->createMock(IDBConnection::class),
+			$this->createMock(ITimeFactory::class),
 			$this->createMock(LoggerInterface::class),
 			$ageRows,
 		) extends BindingService {
@@ -73,10 +75,11 @@ class PendingDeleteRetryServiceTest extends TestCase {
 			/** @param array<int,array<string,mixed>> $ageRows */
 			public function __construct(
 				IDBConnection $db,
+				ITimeFactory $timeFactory,
 				LoggerInterface $logger,
 				private array $ageRows,
 			) {
-				parent::__construct($db, $logger);
+				parent::__construct($db, $timeFactory, $logger);
 			}
 
 			public function findPendingDeleteByAge(int $minAgeSeconds, ?int $maxAgeSeconds, int $limit = 100): array {

--- a/tests/phpunit/unit/PendingDeleteRetryServiceTest.php
+++ b/tests/phpunit/unit/PendingDeleteRetryServiceTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\EtherpadNextcloud\Tests\Unit;
+
+use OCA\EtherpadNextcloud\Service\BindingService;
+use OCA\EtherpadNextcloud\Service\EtherpadClient;
+use OCA\EtherpadNextcloud\Service\PendingDeleteRetryService;
+use OCP\IDBConnection;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+class PendingDeleteRetryServiceTest extends TestCase {
+	public function testRetryByAgeUsesAgeScopedRows(): void {
+		$binding = $this->buildBindingService([
+			['file_id' => 10, 'pad_id' => 'pad-a'],
+			['file_id' => 11, 'pad_id' => 'pad-b'],
+		]);
+		$etherpad = $this->createMock(EtherpadClient::class);
+		$deletedPads = [];
+		$etherpad->expects($this->exactly(2))
+			->method('deletePad')
+			->willReturnCallback(static function (string $padId) use (&$deletedPads): void {
+				$deletedPads[] = $padId;
+			});
+
+		$result = (new PendingDeleteRetryService(
+			$binding,
+			$etherpad,
+			$this->createMock(LoggerInterface::class),
+		))->retryByAge(3600, 86400, 50);
+
+		$this->assertSame([3600, 86400, 50], $binding->lastAgeQuery);
+		$this->assertSame(['pad-a', 'pad-b'], $deletedPads);
+		$this->assertSame([
+			'attempted' => 2,
+			'resolved' => 2,
+			'failed' => 0,
+			'remaining' => 0,
+		], $result);
+	}
+
+	public function testAlreadyDeletedPadResolvesPendingBinding(): void {
+		$binding = $this->buildBindingService([
+			['file_id' => 12, 'pad_id' => 'pad-gone'],
+		]);
+		$etherpad = $this->createMock(EtherpadClient::class);
+		$etherpad->method('deletePad')->willThrowException(new \RuntimeException('padID does not exist'));
+
+		$result = (new PendingDeleteRetryService(
+			$binding,
+			$etherpad,
+			$this->createMock(LoggerInterface::class),
+		))->retryByAge(86400, null, 10);
+
+		$this->assertSame(1, $binding->deletedBindings);
+		$this->assertSame(1, $result['resolved']);
+		$this->assertSame(0, $result['failed']);
+	}
+
+	/** @param array<int,array<string,mixed>> $ageRows */
+	private function buildBindingService(array $ageRows): BindingService {
+		return new class (
+			$this->createMock(IDBConnection::class),
+			$this->createMock(LoggerInterface::class),
+			$ageRows,
+		) extends BindingService {
+			/** @var array{int,int|null,int}|null */
+			public ?array $lastAgeQuery = null;
+			public int $deletedBindings = 0;
+
+			/** @param array<int,array<string,mixed>> $ageRows */
+			public function __construct(
+				IDBConnection $db,
+				LoggerInterface $logger,
+				private array $ageRows,
+			) {
+				parent::__construct($db, $logger);
+			}
+
+			public function findPendingDeleteByAge(int $minAgeSeconds, ?int $maxAgeSeconds, int $limit = 100): array {
+				$this->lastAgeQuery = [$minAgeSeconds, $maxAgeSeconds, $limit];
+				return $this->ageRows;
+			}
+
+			public function deletePendingDeleteBinding(int $fileId, string $padId): bool {
+				$this->deletedBindings++;
+				return true;
+			}
+
+			public function countByState(string $state): int {
+				return 0;
+			}
+		};
+	}
+}


### PR DESCRIPTION
## Summary

- add hot/warm/cold pending-delete retry jobs for age-based cleanup
- add `BindingService::findPendingDeleteByAge()` and `PendingDeleteRetryService::retryByAge()`
- register the three new jobs while keeping the legacy retry job as an unregistered compatibility shim
- document the bucketed retry behavior
- add unit tests for retry bucket delegation and pending-delete resolution

## Related

Part of #16. This does not close #16 yet; the remaining work is final issue cleanup/status updates and any remaining lifecycle hardening.

## Tests

- `composer test:phpunit`