### PR TITLE
Refactor EmbedController and ViewerController to ErrorMapper pattern

### DIFF
--- a/lib/Controller/EmbedController.php
+++ b/lib/Controller/EmbedController.php
@@ -8,31 +8,30 @@ declare(strict_types=1);
 
 namespace OCA\EtherpadNextcloud\Controller;
 
-use OC\Security\CSRF\CsrfTokenManager;
-use OCA\EtherpadNextcloud\Service\AppConfigService;
+use OCA\EtherpadNextcloud\Exception\ControllerBadRequestException;
+use OCA\EtherpadNextcloud\Exception\NotAPadFileException;
+use OCA\EtherpadNextcloud\Exception\PadParentFolderNotWritableException;
+use OCA\EtherpadNextcloud\Exception\UnauthorizedRequestException;
+use OCA\EtherpadNextcloud\Service\EmbedResponseBuilder;
 use OCA\EtherpadNextcloud\Service\UserNodeResolver;
 use OCP\AppFramework\Controller;
-use OCP\AppFramework\Http\ContentSecurityPolicy;
 use OCP\AppFramework\Http\TemplateResponse;
-use OCP\Files\NotFoundException;
 use OCP\IL10N;
 use OCP\IRequest;
 use OCP\IURLGenerator;
+use OCP\IUser;
 use OCP\IUserSession;
 
 class EmbedController extends Controller {
-	/** @var array{requesttoken:string,trusted_embed_origins:list<string>}|null */
-	private ?array $embedBaseData = null;
-
 	public function __construct(
 		string $appName,
 		IRequest $request,
 		private IUserSession $userSession,
 		private IURLGenerator $urlGenerator,
 		private IL10N $l10n,
-		private CsrfTokenManager $csrfTokenManager,
-		private AppConfigService $appConfigService,
+		private EmbedResponseBuilder $responseBuilder,
 		private UserNodeResolver $userNodeResolver,
+		private EmbedControllerErrorMapper $errors,
 	) {
 		parent::__construct($appName, $request);
 	}
@@ -40,132 +39,84 @@ class EmbedController extends Controller {
 	#[\OCP\AppFramework\Http\Attribute\NoAdminRequired]
 	#[\OCP\AppFramework\Http\Attribute\NoCSRFRequired]
 	public function showById(mixed $fileId): TemplateResponse {
-		$user = $this->userSession->getUser();
-		if ($user === null) {
-			return $this->errorResponse('Authentication required.');
-		}
-		if (!is_numeric($fileId)) {
-			return $this->errorResponse('Invalid file ID.');
-		}
-
-		$id = (int)$fileId;
-		if ($id <= 0) {
-			return $this->errorResponse('Invalid file ID.');
-		}
-
-		try {
-			$fileNode = $this->userNodeResolver->resolveUserFileNodeById($user->getUID(), $id);
-		} catch (NotFoundException) {
-			return $this->errorResponse('Cannot open selected .pad file.');
-		}
-
-		if (!str_ends_with(strtolower($fileNode->getName()), '.pad')) {
-			return $this->errorResponse('Selected file is not a .pad file.');
-		}
-
-		return $this->buildEmbedTemplateResponse('embed', [
-			'file_id' => $id,
-			'open_by_id_url' => $this->urlGenerator->linkToRoute($this->appName . '.pad.openById'),
-			'initialize_by_id_url_template' => $this->urlGenerator->linkToRoute(
-				$this->appName . '.pad.initializeById',
-				['fileId' => '__FILE_ID__']
-			),
-			'l10n' => [
-				'loading' => $this->l10n->t('Loading pad...'),
-				'error_title' => $this->l10n->t('Unable to open pad'),
-				'external_title' => $this->l10n->t('Pad from another server'),
-				'external_message' => $this->l10n->t('Read-only snapshot from the .pad file.'),
-				'external_empty' => $this->l10n->t('No synced snapshot is stored in this .pad file yet.'),
-				'external_link' => $this->l10n->t('Open original pad'),
-			],
-		]);
+		return $this->errors->runForTemplate(
+			function () use ($fileId): array {
+				$user = $this->requireUser();
+				$id = $this->requireNumericFileId($fileId);
+				$fileNode = $this->userNodeResolver->resolveUserFileNodeById($user->getUID(), $id);
+				if (!str_ends_with(strtolower($fileNode->getName()), '.pad')) {
+					throw new NotAPadFileException($this->l10n->t('Selected file is not a .pad file.'));
+				}
+				return ['file_id' => $id];
+			},
+			fn(array $resolved): TemplateResponse => $this->responseBuilder->build('embed', [
+				'file_id' => $resolved['file_id'],
+				'open_by_id_url' => $this->urlGenerator->linkToRoute($this->appName . '.pad.openById'),
+				'initialize_by_id_url_template' => $this->urlGenerator->linkToRoute(
+					$this->appName . '.pad.initializeById',
+					['fileId' => '__FILE_ID__']
+				),
+				'l10n' => [
+					'loading' => $this->l10n->t('Loading pad...'),
+					'error_title' => $this->l10n->t('Unable to open pad'),
+					'external_title' => $this->l10n->t('Pad from another server'),
+					'external_message' => $this->l10n->t('Read-only snapshot from the .pad file.'),
+					'external_empty' => $this->l10n->t('No synced snapshot is stored in this .pad file yet.'),
+					'external_link' => $this->l10n->t('Open original pad'),
+				],
+			]),
+			errorTitle: $this->l10n->t('Unable to open pad'),
+		);
 	}
 
 	#[\OCP\AppFramework\Http\Attribute\NoAdminRequired]
 	#[\OCP\AppFramework\Http\Attribute\NoCSRFRequired]
 	public function createByParent(mixed $parentFolderId): TemplateResponse {
-		$createErrorTitle = $this->l10n->t('Unable to create pad');
+		return $this->errors->runForTemplate(
+			function () use ($parentFolderId): array {
+				$user = $this->requireUser();
+				$id = $this->requirePositiveInt($parentFolderId, $this->l10n->t('Invalid parent folder ID.'));
+				$parentFolder = $this->userNodeResolver->resolveUserFolderNodeById($user->getUID(), $id);
+				if (!$parentFolder->isCreatable()) {
+					throw new PadParentFolderNotWritableException();
+				}
+				return ['parent_folder_id' => $id];
+			},
+			fn(array $resolved): TemplateResponse => $this->responseBuilder->build('embed-create', [
+				'parent_folder_id' => $resolved['parent_folder_id'],
+				'create_by_parent_url' => $this->urlGenerator->linkToRoute($this->appName . '.pad.createByParent'),
+				'l10n' => [
+					'loading' => $this->l10n->t('Creating pad...'),
+					'error_title' => $this->l10n->t('Unable to create pad'),
+					'missing_name' => $this->l10n->t('Pad name is required.'),
+					'invalid_access_mode' => $this->l10n->t('Invalid access mode.'),
+					'incomplete_config' => $this->l10n->t('Embed configuration is incomplete.'),
+				],
+			]),
+			errorTitle: $this->l10n->t('Unable to create pad'),
+		);
+	}
+
+	private function requireUser(): IUser {
 		$user = $this->userSession->getUser();
 		if ($user === null) {
-			return $this->errorResponse('Authentication required.', $createErrorTitle);
+			throw new UnauthorizedRequestException();
 		}
-		if (!is_numeric($parentFolderId)) {
-			return $this->errorResponse('Invalid parent folder ID.', $createErrorTitle);
-		}
+		return $user;
+	}
 
-		$id = (int)$parentFolderId;
+	private function requireNumericFileId(mixed $candidate): int {
+		return $this->requirePositiveInt($candidate, $this->l10n->t('Invalid file ID.'));
+	}
+
+	private function requirePositiveInt(mixed $candidate, string $message): int {
+		if (!is_numeric($candidate)) {
+			throw new ControllerBadRequestException($message);
+		}
+		$id = (int)$candidate;
 		if ($id <= 0) {
-			return $this->errorResponse('Invalid parent folder ID.', $createErrorTitle);
+			throw new ControllerBadRequestException($message);
 		}
-
-		try {
-			$parentFolder = $this->userNodeResolver->resolveUserFolderNodeById($user->getUID(), $id);
-		} catch (NotFoundException) {
-			return $this->errorResponse('Cannot resolve selected parent folder.', $createErrorTitle);
-		}
-
-		if (!$parentFolder->isCreatable()) {
-			return $this->errorResponse('Selected parent folder is not writable.', $createErrorTitle);
-		}
-
-		return $this->buildEmbedTemplateResponse('embed-create', [
-			'parent_folder_id' => $id,
-			'create_by_parent_url' => $this->urlGenerator->linkToRoute($this->appName . '.pad.createByParent'),
-			'l10n' => [
-				'loading' => $this->l10n->t('Creating pad...'),
-				'error_title' => $this->l10n->t('Unable to create pad'),
-				'missing_name' => $this->l10n->t('Pad name is required.'),
-				'invalid_access_mode' => $this->l10n->t('Invalid access mode.'),
-				'incomplete_config' => $this->l10n->t('Embed configuration is incomplete.'),
-			],
-		]);
-	}
-
-	private function errorResponse(string $error, ?string $title = null): TemplateResponse {
-		return $this->buildEmbedTemplateResponse('noviewer', [
-			'error' => $error,
-			'title' => $title ?? $this->l10n->t('Unable to open pad'),
-		]);
-	}
-
-	/** @param array<string,mixed> $data */
-	private function buildEmbedTemplateResponse(string $template, array $data): TemplateResponse {
-		$response = new TemplateResponse(
-			$this->appName,
-			$template,
-			array_merge($this->getEmbedBaseData(), $data),
-			'blank'
-		);
-
-		return $this->applyEmbedPolicy($response);
-	}
-
-	/** @return array{requesttoken:string,trusted_embed_origins:list<string>} */
-	private function getEmbedBaseData(): array {
-		if ($this->embedBaseData !== null) {
-			return $this->embedBaseData;
-		}
-
-		$this->embedBaseData = [
-			// Intentional use of the internal manager:
-			// blank embed templates do not get the normal Nextcloud layout bootstrap,
-			// so OC.requestToken is not auto-injected there. In this NC version there is
-			// no public OCP CSRF-token service for this use-case, so the encrypted token
-			// has to be passed manually into the blank template.
-			'requesttoken' => $this->csrfTokenManager->getToken()->getEncryptedValue(),
-			'trusted_embed_origins' => $this->appConfigService->getTrustedEmbedOrigins(),
-		];
-
-		return $this->embedBaseData;
-	}
-
-	private function applyEmbedPolicy(TemplateResponse $response): TemplateResponse {
-		$policy = new ContentSecurityPolicy();
-		foreach ($this->getEmbedBaseData()['trusted_embed_origins'] as $origin) {
-			$policy->addAllowedFrameAncestorDomain($origin);
-		}
-		$response->setContentSecurityPolicy($policy);
-
-		return $response;
+		return $id;
 	}
 }

--- a/lib/Controller/EmbedController.php
+++ b/lib/Controller/EmbedController.php
@@ -94,6 +94,7 @@ class EmbedController extends Controller {
 				],
 			]),
 			errorTitle: $this->l10n->t('Unable to create pad'),
+			notFoundMessage: $this->l10n->t('Cannot resolve selected parent folder.'),
 		);
 	}
 

--- a/lib/Controller/EmbedControllerErrorMapper.php
+++ b/lib/Controller/EmbedControllerErrorMapper.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * Copyright (c) 2026 Jacob Bühler
+ */
+
+namespace OCA\EtherpadNextcloud\Controller;
+
+use OCA\EtherpadNextcloud\AppInfo\Application;
+use OCA\EtherpadNextcloud\Exception\ControllerBadRequestException;
+use OCA\EtherpadNextcloud\Exception\NotAPadFileException;
+use OCA\EtherpadNextcloud\Exception\PadParentFolderNotWritableException;
+use OCA\EtherpadNextcloud\Exception\UnauthorizedRequestException;
+use OCA\EtherpadNextcloud\Service\EmbedResponseBuilder;
+use OCP\AppFramework\Http\TemplateResponse;
+use OCP\Files\NotFoundException;
+use OCP\IL10N;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Maps embed-controller exceptions to embed-shaped TemplateResponses.
+ *
+ * Endpoints provide an `error_title` so the noviewer template can show a
+ * context-appropriate heading (e.g. "Unable to open pad" vs. "Unable to create
+ * pad"). Unhandled errors are logged and rendered with a generic message.
+ */
+class EmbedControllerErrorMapper {
+	public function __construct(
+		private EmbedResponseBuilder $responseBuilder,
+		private IL10N $l10n,
+		private LoggerInterface $logger,
+	) {
+	}
+
+	/**
+	 * @param callable(): mixed $action
+	 * @param callable(mixed): TemplateResponse $success
+	 */
+	public function runForTemplate(
+		callable $action,
+		callable $success,
+		string $errorTitle,
+	): TemplateResponse {
+		try {
+			return $success($action());
+		} catch (UnauthorizedRequestException) {
+			return $this->errorTemplate($this->l10n->t('Authentication required.'), $errorTitle);
+		} catch (ControllerBadRequestException $e) {
+			return $this->errorTemplate(
+				$e->getMessage() !== '' ? $e->getMessage() : $this->l10n->t('Invalid input.'),
+				$errorTitle,
+			);
+		} catch (NotFoundException) {
+			return $this->errorTemplate(
+				$this->l10n->t('Cannot open selected .pad file.'),
+				$errorTitle,
+			);
+		} catch (NotAPadFileException $e) {
+			return $this->errorTemplate(
+				$e->getMessage() !== '' ? $e->getMessage() : $this->l10n->t('Selected file is not a .pad file.'),
+				$errorTitle,
+			);
+		} catch (PadParentFolderNotWritableException) {
+			return $this->errorTemplate(
+				$this->l10n->t('Selected parent folder is not writable.'),
+				$errorTitle,
+			);
+		} catch (\Throwable $e) {
+			$this->logger->error('Unhandled embed controller error', [
+				'app' => Application::APP_ID,
+				'exception' => $e,
+			]);
+			return $this->errorTemplate($this->l10n->t('Unable to open pad.'), $errorTitle);
+		}
+	}
+
+	private function errorTemplate(string $error, string $title): TemplateResponse {
+		return $this->responseBuilder->build('noviewer', [
+			'error' => $error,
+			'title' => $title,
+		]);
+	}
+}

--- a/lib/Controller/EmbedControllerErrorMapper.php
+++ b/lib/Controller/EmbedControllerErrorMapper.php
@@ -37,11 +37,14 @@ class EmbedControllerErrorMapper {
 	/**
 	 * @param callable(): mixed $action
 	 * @param callable(mixed): TemplateResponse $success
+	 * @param string $errorTitle title rendered in the noviewer template on failure
+	 * @param string|null $notFoundMessage context-specific message for `NotFoundException`; defaults to the open-pad wording
 	 */
 	public function runForTemplate(
 		callable $action,
 		callable $success,
 		string $errorTitle,
+		?string $notFoundMessage = null,
 	): TemplateResponse {
 		try {
 			return $success($action());
@@ -54,7 +57,7 @@ class EmbedControllerErrorMapper {
 			);
 		} catch (NotFoundException) {
 			return $this->errorTemplate(
-				$this->l10n->t('Cannot open selected .pad file.'),
+				$notFoundMessage ?? $this->l10n->t('Cannot open selected .pad file.'),
 				$errorTitle,
 			);
 		} catch (NotAPadFileException $e) {

--- a/lib/Controller/ViewerController.php
+++ b/lib/Controller/ViewerController.php
@@ -10,15 +10,17 @@ declare(strict_types=1);
 
 namespace OCA\EtherpadNextcloud\Controller;
 
+use OCA\EtherpadNextcloud\Exception\ControllerBadRequestException;
+use OCA\EtherpadNextcloud\Exception\UnauthorizedRequestException;
 use OCA\EtherpadNextcloud\Service\UserNodeResolver;
 use OCA\EtherpadNextcloud\Util\PathNormalizer;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\RedirectResponse;
 use OCP\AppFramework\Http\TemplateResponse;
-use OCP\Files\File;
-use OCP\Files\NotFoundException;
+use OCP\IL10N;
 use OCP\IRequest;
 use OCP\IURLGenerator;
+use OCP\IUser;
 use OCP\IUserSession;
 
 class ViewerController extends Controller {
@@ -27,8 +29,10 @@ class ViewerController extends Controller {
 		IRequest $request,
 		private IURLGenerator $urlGenerator,
 		private IUserSession $userSession,
+		private IL10N $l10n,
 		private PathNormalizer $pathNormalizer,
 		private UserNodeResolver $userNodeResolver,
+		private ViewerControllerErrorMapper $errors,
 	) {
 		parent::__construct($appName, $request);
 	}
@@ -36,57 +40,67 @@ class ViewerController extends Controller {
 	#[\OCP\AppFramework\Http\Attribute\PublicPage]
 	#[\OCP\AppFramework\Http\Attribute\NoCSRFRequired]
 	public function showPad(mixed $file = ''): TemplateResponse|RedirectResponse {
-		$user = $this->userSession->getUser();
-		if ($user === null) {
-			return $this->errorResponse('Authentication required.');
-		}
-
-		try {
-			$normalizedFile = $this->pathNormalizer->normalizeViewerFilePath($file);
-		} catch (\Throwable) {
-			return $this->errorResponse('Invalid file path.');
-		}
-		if ($normalizedFile === '') {
-			return new RedirectResponse($this->urlGenerator->linkToRoute('files.view.index'));
-		}
-
-		try {
-			$fileNode = $this->resolveUserFileNode($user->getUID(), $normalizedFile);
-		} catch (NotFoundException) {
-			return $this->errorResponse('Cannot open selected .pad file.');
-		}
-
-		return new RedirectResponse($this->buildFilesOpenUrl((int)$fileNode->getId(), $normalizedFile));
+		return $this->errors->runForTemplate(
+			function () use ($file): array|RedirectResponse {
+				$user = $this->requireUser();
+				$normalizedFile = $this->normalizeOrThrow($file);
+				if ($normalizedFile === '') {
+					return new RedirectResponse($this->urlGenerator->linkToRoute('files.view.index'));
+				}
+				$fileNode = $this->userNodeResolver->resolveUserFileNodeByPath($user->getUID(), $normalizedFile);
+				return [
+					'file_id' => (int)$fileNode->getId(),
+					'path' => $normalizedFile,
+				];
+			},
+			fn(array|RedirectResponse $result): RedirectResponse => $result instanceof RedirectResponse
+				? $result
+				: new RedirectResponse($this->buildFilesOpenUrl($result['file_id'], $result['path'])),
+		);
 	}
 
 	#[\OCP\AppFramework\Http\Attribute\PublicPage]
 	#[\OCP\AppFramework\Http\Attribute\NoCSRFRequired]
 	public function showPadById(mixed $fileId): TemplateResponse|RedirectResponse {
-		$user = $this->userSession->getUser();
-		if ($user === null) {
-			return $this->errorResponse('Authentication required.');
-		}
-		if (!is_numeric($fileId)) {
-			return $this->errorResponse('Invalid file ID.');
-		}
-
-		$id = (int)$fileId;
-		if ($id <= 0) {
-			return $this->errorResponse('Invalid file ID.');
-		}
-
-		try {
-			$fileNode = $this->userNodeResolver->resolveUserFileNodeById($user->getUID(), $id);
-			$path = $this->userNodeResolver->toUserAbsolutePath($user->getUID(), $fileNode);
-		} catch (NotFoundException) {
-			return $this->errorResponse('Cannot resolve file path for file ID.');
-		}
-
-		return new RedirectResponse($this->buildFilesOpenUrl($id, $path));
+		return $this->errors->runForTemplate(
+			function () use ($fileId): array {
+				$user = $this->requireUser();
+				$id = $this->requireFileId($fileId);
+				$fileNode = $this->userNodeResolver->resolveUserFileNodeById($user->getUID(), $id);
+				$path = $this->userNodeResolver->toUserAbsolutePath($user->getUID(), $fileNode);
+				return ['file_id' => $id, 'path' => $path];
+			},
+			fn(array $resolved): RedirectResponse => new RedirectResponse(
+				$this->buildFilesOpenUrl($resolved['file_id'], $resolved['path'])
+			),
+		);
 	}
 
-	private function errorResponse(string $error): TemplateResponse {
-		return new TemplateResponse($this->appName, 'noviewer', ['error' => $error], 'blank');
+	private function requireUser(): IUser {
+		$user = $this->userSession->getUser();
+		if ($user === null) {
+			throw new UnauthorizedRequestException();
+		}
+		return $user;
+	}
+
+	private function requireFileId(mixed $candidate): int {
+		if (!is_numeric($candidate)) {
+			throw new ControllerBadRequestException($this->l10n->t('Invalid file ID.'));
+		}
+		$id = (int)$candidate;
+		if ($id <= 0) {
+			throw new ControllerBadRequestException($this->l10n->t('Invalid file ID.'));
+		}
+		return $id;
+	}
+
+	private function normalizeOrThrow(mixed $file): string {
+		try {
+			return $this->pathNormalizer->normalizeViewerFilePath($file);
+		} catch (\Throwable) {
+			throw new ControllerBadRequestException($this->l10n->t('Invalid file path.'));
+		}
 	}
 
 	private function buildFilesOpenUrl(int $fileId, string $absoluteFilePath): string {
@@ -99,12 +113,4 @@ class ViewerController extends Controller {
 			. '?dir=' . rawurlencode($dir)
 			. '&editing=false&openfile=true';
 	}
-
-	/**
-	 * @throws NotFoundException
-	 */
-	private function resolveUserFileNode(string $uid, string $absolutePath): File {
-		return $this->userNodeResolver->resolveUserFileNodeByPath($uid, $absolutePath);
-	}
-
 }

--- a/lib/Controller/ViewerController.php
+++ b/lib/Controller/ViewerController.php
@@ -73,6 +73,7 @@ class ViewerController extends Controller {
 			fn(array $resolved): RedirectResponse => new RedirectResponse(
 				$this->buildFilesOpenUrl($resolved['file_id'], $resolved['path'])
 			),
+			notFoundMessage: $this->l10n->t('Cannot resolve file path for file ID.'),
 		);
 	}
 

--- a/lib/Controller/ViewerControllerErrorMapper.php
+++ b/lib/Controller/ViewerControllerErrorMapper.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * Copyright (c) 2026 Jacob Bühler
+ */
+
+namespace OCA\EtherpadNextcloud\Controller;
+
+use OCA\EtherpadNextcloud\AppInfo\Application;
+use OCA\EtherpadNextcloud\Exception\ControllerBadRequestException;
+use OCA\EtherpadNextcloud\Exception\UnauthorizedRequestException;
+use OCP\AppFramework\Http\RedirectResponse;
+use OCP\AppFramework\Http\TemplateResponse;
+use OCP\Files\NotFoundException;
+use OCP\IL10N;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Maps viewer-controller exceptions to noviewer-shaped TemplateResponses.
+ *
+ * The viewer controller's normal success outcome is a RedirectResponse into
+ * the Nextcloud files viewer; only error paths surface as TemplateResponse.
+ */
+class ViewerControllerErrorMapper {
+	public function __construct(
+		private IL10N $l10n,
+		private LoggerInterface $logger,
+	) {
+	}
+
+	/**
+	 * @param callable(): mixed $action
+	 * @param callable(mixed): RedirectResponse|TemplateResponse $success
+	 */
+	public function runForTemplate(
+		callable $action,
+		callable $success,
+	): RedirectResponse|TemplateResponse {
+		try {
+			return $success($action());
+		} catch (UnauthorizedRequestException) {
+			return $this->errorTemplate($this->l10n->t('Authentication required.'));
+		} catch (ControllerBadRequestException $e) {
+			return $this->errorTemplate(
+				$e->getMessage() !== '' ? $e->getMessage() : $this->l10n->t('Invalid input.')
+			);
+		} catch (NotFoundException) {
+			return $this->errorTemplate($this->l10n->t('Cannot open selected .pad file.'));
+		} catch (\Throwable $e) {
+			$this->logger->error('Unhandled viewer controller error', [
+				'app' => Application::APP_ID,
+				'exception' => $e,
+			]);
+			return $this->errorTemplate($this->l10n->t('Unable to open pad.'));
+		}
+	}
+
+	private function errorTemplate(string $error): TemplateResponse {
+		return new TemplateResponse(Application::APP_ID, 'noviewer', ['error' => $error], 'blank');
+	}
+}

--- a/lib/Controller/ViewerControllerErrorMapper.php
+++ b/lib/Controller/ViewerControllerErrorMapper.php
@@ -33,10 +33,12 @@ class ViewerControllerErrorMapper {
 	/**
 	 * @param callable(): mixed $action
 	 * @param callable(mixed): RedirectResponse|TemplateResponse $success
+	 * @param string|null $notFoundMessage context-specific message for `NotFoundException`; defaults to the open-pad wording
 	 */
 	public function runForTemplate(
 		callable $action,
 		callable $success,
+		?string $notFoundMessage = null,
 	): RedirectResponse|TemplateResponse {
 		try {
 			return $success($action());
@@ -47,7 +49,9 @@ class ViewerControllerErrorMapper {
 				$e->getMessage() !== '' ? $e->getMessage() : $this->l10n->t('Invalid input.')
 			);
 		} catch (NotFoundException) {
-			return $this->errorTemplate($this->l10n->t('Cannot open selected .pad file.'));
+			return $this->errorTemplate(
+				$notFoundMessage ?? $this->l10n->t('Cannot open selected .pad file.')
+			);
 		} catch (\Throwable $e) {
 			$this->logger->error('Unhandled viewer controller error', [
 				'app' => Application::APP_ID,

--- a/lib/Service/EmbedResponseBuilder.php
+++ b/lib/Service/EmbedResponseBuilder.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * Copyright (c) 2026 Jacob Bühler
+ */
+
+namespace OCA\EtherpadNextcloud\Service;
+
+use OC\Security\CSRF\CsrfTokenManager;
+use OCA\EtherpadNextcloud\AppInfo\Application;
+use OCP\AppFramework\Http\ContentSecurityPolicy;
+use OCP\AppFramework\Http\TemplateResponse;
+
+/**
+ * Builds embed-template responses for the EmbedController.
+ *
+ * Encapsulates the embed-specific plumbing: per-request caching of the embed
+ * base data (request token + trusted embed origins), template assembly via the
+ * blank renderer, and frame-ancestor CSP application.
+ */
+class EmbedResponseBuilder {
+	/** @var array{requesttoken:string,trusted_embed_origins:list<string>}|null */
+	private ?array $embedBaseData = null;
+
+	public function __construct(
+		// Intentional use of the internal manager:
+		// blank embed templates do not get the normal Nextcloud layout bootstrap,
+		// so OC.requestToken is not auto-injected there. In this NC version there
+		// is no public OCP CSRF-token service for this use-case, so the encrypted
+		// token has to be passed manually into the blank template.
+		private CsrfTokenManager $csrfTokenManager,
+		private AppConfigService $appConfigService,
+	) {
+	}
+
+	/** @param array<string,mixed> $data */
+	public function build(string $template, array $data): TemplateResponse {
+		$response = new TemplateResponse(
+			Application::APP_ID,
+			$template,
+			array_merge($this->getBaseData(), $data),
+			'blank'
+		);
+
+		return $this->applyEmbedPolicy($response);
+	}
+
+	/** @return array{requesttoken:string,trusted_embed_origins:list<string>} */
+	private function getBaseData(): array {
+		if ($this->embedBaseData !== null) {
+			return $this->embedBaseData;
+		}
+
+		$this->embedBaseData = [
+			'requesttoken' => $this->csrfTokenManager->getToken()->getEncryptedValue(),
+			'trusted_embed_origins' => $this->appConfigService->getTrustedEmbedOrigins(),
+		];
+
+		return $this->embedBaseData;
+	}
+
+	private function applyEmbedPolicy(TemplateResponse $response): TemplateResponse {
+		$policy = new ContentSecurityPolicy();
+		foreach ($this->getBaseData()['trusted_embed_origins'] as $origin) {
+			$policy->addAllowedFrameAncestorDomain($origin);
+		}
+		$response->setContentSecurityPolicy($policy);
+
+		return $response;
+	}
+}

--- a/tests/phpunit/unit/EmbedControllerErrorMapperTest.php
+++ b/tests/phpunit/unit/EmbedControllerErrorMapperTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\EtherpadNextcloud\Tests\Unit;
+
+use OC\Security\CSRF\CsrfToken;
+use OC\Security\CSRF\CsrfTokenManager;
+use OCA\EtherpadNextcloud\Controller\EmbedControllerErrorMapper;
+use OCA\EtherpadNextcloud\Exception\ControllerBadRequestException;
+use OCA\EtherpadNextcloud\Exception\NotAPadFileException;
+use OCA\EtherpadNextcloud\Exception\PadParentFolderNotWritableException;
+use OCA\EtherpadNextcloud\Exception\UnauthorizedRequestException;
+use OCA\EtherpadNextcloud\Service\AppConfigService;
+use OCA\EtherpadNextcloud\Service\EmbedResponseBuilder;
+use OCP\AppFramework\Http\TemplateResponse;
+use OCP\Files\NotFoundException;
+use OCP\IL10N;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+class EmbedControllerErrorMapperTest extends TestCase {
+	public function testRunReturnsSuccessTemplateWhenActionSucceeds(): void {
+		$mapper = $this->buildMapper();
+
+		$response = $mapper->runForTemplate(
+			static fn (): string => 'payload',
+			static fn (string $value): TemplateResponse => new TemplateResponse('etherpad_nextcloud', 'embed', ['value' => $value], 'blank'),
+			errorTitle: 'Unable to open pad',
+		);
+
+		$this->assertSame('embed', $response->getTemplateName());
+		$this->assertSame('payload', $response->getParams()['value']);
+	}
+
+	public function testRunMapsUnauthorizedToNoviewer(): void {
+		$response = $this->buildMapper()->runForTemplate(
+			static fn (): never => throw new UnauthorizedRequestException(),
+			static fn ($value) => $this->fail('success handler must not run on error'),
+			errorTitle: 'Unable to open pad',
+		);
+
+		$this->assertSame('noviewer', $response->getTemplateName());
+		$this->assertSame('Authentication required.', $response->getParams()['error']);
+		$this->assertSame('Unable to open pad', $response->getParams()['title']);
+	}
+
+	public function testRunMapsControllerBadRequestUsingException(): void {
+		$response = $this->buildMapper()->runForTemplate(
+			static fn (): never => throw new ControllerBadRequestException('Invalid file ID.'),
+			static fn ($value) => $this->fail('unreachable'),
+			errorTitle: 'Unable to open pad',
+		);
+
+		$this->assertSame('Invalid file ID.', $response->getParams()['error']);
+	}
+
+	public function testRunMapsNotFoundExceptionToNoviewer(): void {
+		$response = $this->buildMapper()->runForTemplate(
+			static fn (): never => throw new NotFoundException(),
+			static fn ($value) => $this->fail('unreachable'),
+			errorTitle: 'Unable to open pad',
+		);
+
+		$this->assertSame('Cannot open selected .pad file.', $response->getParams()['error']);
+	}
+
+	public function testRunMapsNotAPadFile(): void {
+		$response = $this->buildMapper()->runForTemplate(
+			static fn (): never => throw new NotAPadFileException('Selected file is not a .pad file.'),
+			static fn ($value) => $this->fail('unreachable'),
+			errorTitle: 'Unable to open pad',
+		);
+
+		$this->assertSame('Selected file is not a .pad file.', $response->getParams()['error']);
+	}
+
+	public function testRunMapsParentFolderNotWritable(): void {
+		$response = $this->buildMapper()->runForTemplate(
+			static fn (): never => throw new PadParentFolderNotWritableException(),
+			static fn ($value) => $this->fail('unreachable'),
+			errorTitle: 'Unable to create pad',
+		);
+
+		$this->assertSame('Selected parent folder is not writable.', $response->getParams()['error']);
+		$this->assertSame('Unable to create pad', $response->getParams()['title']);
+	}
+
+	public function testRunLogsUnhandledExceptionAndReturnsGenericMessage(): void {
+		$logger = $this->createMock(LoggerInterface::class);
+		$logger->expects($this->once())
+			->method('error')
+			->with('Unhandled embed controller error', $this->callback(static fn (array $context): bool => ($context['exception'] ?? null) instanceof \RuntimeException));
+
+		$response = $this->buildMapper($logger)->runForTemplate(
+			static fn (): never => throw new \RuntimeException('Internal pipe burst'),
+			static fn ($value) => $this->fail('unreachable'),
+			errorTitle: 'Unable to open pad',
+		);
+
+		$this->assertSame('Unable to open pad.', $response->getParams()['error']);
+	}
+
+	private function buildMapper(?LoggerInterface $logger = null): EmbedControllerErrorMapper {
+		$appConfigService = $this->createMock(AppConfigService::class);
+		$appConfigService->method('getTrustedEmbedOrigins')->willReturn([]);
+		$responseBuilder = new EmbedResponseBuilder(
+			new CsrfTokenManager(new CsrfToken('csrf-token-value')),
+			$appConfigService,
+		);
+
+		$l10n = $this->createMock(IL10N::class);
+		$l10n->method('t')->willReturnCallback(static fn (string $text): string => $text);
+
+		return new EmbedControllerErrorMapper(
+			$responseBuilder,
+			$l10n,
+			$logger ?? $this->createMock(LoggerInterface::class),
+		);
+	}
+}

--- a/tests/phpunit/unit/EmbedControllerErrorMapperTest.php
+++ b/tests/phpunit/unit/EmbedControllerErrorMapperTest.php
@@ -65,6 +65,18 @@ class EmbedControllerErrorMapperTest extends TestCase {
 		$this->assertSame('Cannot open selected .pad file.', $response->getParams()['error']);
 	}
 
+	public function testRunUsesEndpointSpecificNotFoundMessageWhenProvided(): void {
+		$response = $this->buildMapper()->runForTemplate(
+			static fn (): never => throw new NotFoundException(),
+			static fn ($value) => $this->fail('unreachable'),
+			errorTitle: 'Unable to create pad',
+			notFoundMessage: 'Cannot resolve selected parent folder.',
+		);
+
+		$this->assertSame('Cannot resolve selected parent folder.', $response->getParams()['error']);
+		$this->assertSame('Unable to create pad', $response->getParams()['title']);
+	}
+
 	public function testRunMapsNotAPadFile(): void {
 		$response = $this->buildMapper()->runForTemplate(
 			static fn (): never => throw new NotAPadFileException('Selected file is not a .pad file.'),

--- a/tests/phpunit/unit/EmbedControllerTest.php
+++ b/tests/phpunit/unit/EmbedControllerTest.php
@@ -7,34 +7,22 @@ namespace OCA\EtherpadNextcloud\Tests\Unit;
 use OC\Security\CSRF\CsrfToken;
 use OC\Security\CSRF\CsrfTokenManager;
 use OCA\EtherpadNextcloud\Controller\EmbedController;
+use OCA\EtherpadNextcloud\Controller\EmbedControllerErrorMapper;
 use OCA\EtherpadNextcloud\Service\AppConfigService;
+use OCA\EtherpadNextcloud\Service\EmbedResponseBuilder;
 use OCA\EtherpadNextcloud\Service\UserNodeResolver;
 use OCP\Files\File;
+use OCP\Files\NotFoundException;
 use OCP\IL10N;
 use OCP\IRequest;
 use OCP\IURLGenerator;
 use OCP\IUser;
 use OCP\IUserSession;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 
 class EmbedControllerTest extends TestCase {
 	public function testShowByIdUsesInjectedCsrfTokenAndTrustedOriginsInTemplateData(): void {
-		$request = $this->createMock(IRequest::class);
-		$user = $this->createConfiguredMock(IUser::class, ['getUID' => 'alice']);
-		$userSession = $this->createConfiguredMock(IUserSession::class, ['getUser' => $user]);
-
-		$urlGenerator = $this->createMock(IURLGenerator::class);
-		$urlGenerator->method('linkToRoute')->willReturnMap([
-			['etherpad_nextcloud.pad.openById', [], '/open-by-id'],
-			['etherpad_nextcloud.pad.initializeById', ['fileId' => '__FILE_ID__'], '/initialize/__FILE_ID__'],
-		]);
-
-		$l10n = $this->createMock(IL10N::class);
-		$l10n->method('t')->willReturnCallback(static fn (string $text): string => $text);
-
-		$appConfigService = $this->createMock(AppConfigService::class);
-		$appConfigService->method('getTrustedEmbedOrigins')->willReturn(['https://portal.example.test']);
-
 		$file = $this->createMock(File::class);
 		$file->method('getName')->willReturn('Example.pad');
 
@@ -44,16 +32,7 @@ class EmbedControllerTest extends TestCase {
 			->with('alice', 42)
 			->willReturn($file);
 
-		$controller = new EmbedController(
-			'etherpad_nextcloud',
-			$request,
-			$userSession,
-			$urlGenerator,
-			$l10n,
-			new CsrfTokenManager(new CsrfToken('csrf-token-value')),
-			$appConfigService,
-			$userNodeResolver,
-		);
+		$controller = $this->buildController($userNodeResolver);
 
 		$response = $controller->showById(42);
 		$params = $response->getParams();
@@ -67,5 +46,146 @@ class EmbedControllerTest extends TestCase {
 			$params['open_by_id_url'],
 			$params['initialize_by_id_url_template'],
 		]);
+	}
+
+	public function testShowByIdReturnsNoviewerOnInvalidFileId(): void {
+		$controller = $this->buildController($this->createMock(UserNodeResolver::class));
+
+		$response = $controller->showById('not-a-number');
+		$params = $response->getParams();
+
+		$this->assertSame('noviewer', $response->getTemplateName());
+		$this->assertSame('Invalid file ID.', $params['error']);
+		$this->assertSame('Unable to open pad', $params['title']);
+	}
+
+	public function testShowByIdReturnsNoviewerWhenFileIsNotPad(): void {
+		$file = $this->createMock(File::class);
+		$file->method('getName')->willReturn('NotAPad.txt');
+		$resolver = $this->createMock(UserNodeResolver::class);
+		$resolver->method('resolveUserFileNodeById')->willReturn($file);
+
+		$controller = $this->buildController($resolver);
+
+		$response = $controller->showById(42);
+		$params = $response->getParams();
+
+		$this->assertSame('noviewer', $response->getTemplateName());
+		$this->assertSame('Selected file is not a .pad file.', $params['error']);
+		$this->assertSame('Unable to open pad', $params['title']);
+	}
+
+	public function testShowByIdReturnsNoviewerWhenFileCannotBeResolved(): void {
+		$resolver = $this->createMock(UserNodeResolver::class);
+		$resolver->method('resolveUserFileNodeById')
+			->willThrowException(new NotFoundException());
+
+		$controller = $this->buildController($resolver);
+
+		$response = $controller->showById(42);
+		$params = $response->getParams();
+
+		$this->assertSame('noviewer', $response->getTemplateName());
+		$this->assertSame('Cannot open selected .pad file.', $params['error']);
+		$this->assertSame('Unable to open pad', $params['title']);
+	}
+
+	public function testShowByIdReturnsNoviewerWhenNotLoggedIn(): void {
+		$userNodeResolver = $this->createMock(UserNodeResolver::class);
+		$controller = $this->buildController($userNodeResolver, anonymous: true);
+
+		$response = $controller->showById(42);
+		$params = $response->getParams();
+
+		$this->assertSame('noviewer', $response->getTemplateName());
+		$this->assertSame('Authentication required.', $params['error']);
+	}
+
+	public function testCreateByParentRejectsInvalidParentFolderId(): void {
+		$controller = $this->buildController($this->createMock(UserNodeResolver::class));
+
+		$response = $controller->createByParent(0);
+		$params = $response->getParams();
+
+		$this->assertSame('noviewer', $response->getTemplateName());
+		$this->assertSame('Invalid parent folder ID.', $params['error']);
+		$this->assertSame('Unable to create pad', $params['title']);
+	}
+
+	public function testCreateByParentReturnsNoviewerForNonWritableParent(): void {
+		$folder = $this->createMock(\OCP\Files\Folder::class);
+		$folder->method('isCreatable')->willReturn(false);
+
+		$resolver = $this->createMock(UserNodeResolver::class);
+		$resolver->method('resolveUserFolderNodeById')->willReturn($folder);
+
+		$controller = $this->buildController($resolver);
+
+		$response = $controller->createByParent(99);
+		$params = $response->getParams();
+
+		$this->assertSame('noviewer', $response->getTemplateName());
+		$this->assertSame('Selected parent folder is not writable.', $params['error']);
+		$this->assertSame('Unable to create pad', $params['title']);
+	}
+
+	public function testCreateByParentBuildsEmbedCreateTemplate(): void {
+		$folder = $this->createMock(\OCP\Files\Folder::class);
+		$folder->method('isCreatable')->willReturn(true);
+
+		$resolver = $this->createMock(UserNodeResolver::class);
+		$resolver->method('resolveUserFolderNodeById')->with('alice', 99)->willReturn($folder);
+
+		$controller = $this->buildController($resolver);
+
+		$response = $controller->createByParent(99);
+		$params = $response->getParams();
+
+		$this->assertSame('embed-create', $response->getTemplateName());
+		$this->assertSame(99, $params['parent_folder_id']);
+		$this->assertSame('csrf-token-value', $params['requesttoken']);
+	}
+
+	private function buildController(UserNodeResolver $userNodeResolver, bool $anonymous = false): EmbedController {
+		$request = $this->createMock(IRequest::class);
+
+		$user = $this->createConfiguredMock(IUser::class, ['getUID' => 'alice']);
+		$userSession = $this->createConfiguredMock(IUserSession::class, [
+			'getUser' => $anonymous ? null : $user,
+		]);
+
+		$urlGenerator = $this->createMock(IURLGenerator::class);
+		$urlGenerator->method('linkToRoute')->willReturnMap([
+			['etherpad_nextcloud.pad.openById', [], '/open-by-id'],
+			['etherpad_nextcloud.pad.initializeById', ['fileId' => '__FILE_ID__'], '/initialize/__FILE_ID__'],
+			['etherpad_nextcloud.pad.createByParent', [], '/create-by-parent'],
+		]);
+
+		$l10n = $this->createMock(IL10N::class);
+		$l10n->method('t')->willReturnCallback(static fn (string $text): string => $text);
+
+		$appConfigService = $this->createMock(AppConfigService::class);
+		$appConfigService->method('getTrustedEmbedOrigins')->willReturn(['https://portal.example.test']);
+
+		$responseBuilder = new EmbedResponseBuilder(
+			new CsrfTokenManager(new CsrfToken('csrf-token-value')),
+			$appConfigService,
+		);
+		$errorMapper = new EmbedControllerErrorMapper(
+			$responseBuilder,
+			$l10n,
+			$this->createMock(LoggerInterface::class),
+		);
+
+		return new EmbedController(
+			'etherpad_nextcloud',
+			$request,
+			$userSession,
+			$urlGenerator,
+			$l10n,
+			$responseBuilder,
+			$userNodeResolver,
+			$errorMapper,
+		);
 	}
 }

--- a/tests/phpunit/unit/EmbedControllerTest.php
+++ b/tests/phpunit/unit/EmbedControllerTest.php
@@ -129,6 +129,23 @@ class EmbedControllerTest extends TestCase {
 		$this->assertSame('Unable to create pad', $params['title']);
 	}
 
+	public function testCreateByParentReturnsParentFolderErrorWhenResolverThrowsNotFound(): void {
+		// Regression: createByParent must surface "Cannot resolve selected parent folder."
+		// rather than the open-pad default when the parent folder cannot be resolved.
+		$resolver = $this->createMock(UserNodeResolver::class);
+		$resolver->method('resolveUserFolderNodeById')
+			->willThrowException(new NotFoundException());
+
+		$controller = $this->buildController($resolver);
+
+		$response = $controller->createByParent(99);
+		$params = $response->getParams();
+
+		$this->assertSame('noviewer', $response->getTemplateName());
+		$this->assertSame('Cannot resolve selected parent folder.', $params['error']);
+		$this->assertSame('Unable to create pad', $params['title']);
+	}
+
 	public function testCreateByParentBuildsEmbedCreateTemplate(): void {
 		$folder = $this->createMock(\OCP\Files\Folder::class);
 		$folder->method('isCreatable')->willReturn(true);

--- a/tests/phpunit/unit/EmbedResponseBuilderTest.php
+++ b/tests/phpunit/unit/EmbedResponseBuilderTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\EtherpadNextcloud\Tests\Unit;
+
+use OC\Security\CSRF\CsrfToken;
+use OC\Security\CSRF\CsrfTokenManager;
+use OCA\EtherpadNextcloud\Service\AppConfigService;
+use OCA\EtherpadNextcloud\Service\EmbedResponseBuilder;
+use PHPUnit\Framework\TestCase;
+
+class EmbedResponseBuilderTest extends TestCase {
+	public function testBuildMergesBaseDataIntoTemplateParams(): void {
+		$builder = $this->buildBuilder(['https://portal.example.test']);
+
+		$response = $builder->build('embed', ['file_id' => 17]);
+		$params = $response->getParams();
+
+		$this->assertSame('embed', $response->getTemplateName());
+		$this->assertSame('blank', $response->getRenderAs());
+		$this->assertSame(17, $params['file_id']);
+		$this->assertSame('csrf-token-value', $params['requesttoken']);
+		$this->assertSame(['https://portal.example.test'], $params['trusted_embed_origins']);
+	}
+
+	public function testBuildAppliesFrameAncestorPolicyFromTrustedOrigins(): void {
+		$builder = $this->buildBuilder([
+			'https://portal-a.example.test',
+			'https://portal-b.example.test',
+		]);
+
+		$response = $builder->build('embed', []);
+		$policy = $response->getContentSecurityPolicy();
+
+		$this->assertNotNull($policy);
+		$this->assertSame(
+			['https://portal-a.example.test', 'https://portal-b.example.test'],
+			$policy->getAllowedFrameAncestorDomains(),
+		);
+	}
+
+	public function testBaseDataIsCachedAcrossMultipleBuildCalls(): void {
+		$appConfigService = $this->createMock(AppConfigService::class);
+		// Only called once even though build() runs twice.
+		$appConfigService->expects($this->once())
+			->method('getTrustedEmbedOrigins')
+			->willReturn(['https://portal.example.test']);
+
+		$builder = new EmbedResponseBuilder(
+			new CsrfTokenManager(new CsrfToken('csrf-token-value')),
+			$appConfigService,
+		);
+
+		$builder->build('embed', []);
+		$builder->build('embed-create', []);
+
+		$this->addToAssertionCount(1);
+	}
+
+	/** @param list<string> $trustedOrigins */
+	private function buildBuilder(array $trustedOrigins): EmbedResponseBuilder {
+		$appConfigService = $this->createMock(AppConfigService::class);
+		$appConfigService->method('getTrustedEmbedOrigins')->willReturn($trustedOrigins);
+
+		return new EmbedResponseBuilder(
+			new CsrfTokenManager(new CsrfToken('csrf-token-value')),
+			$appConfigService,
+		);
+	}
+}

--- a/tests/phpunit/unit/ViewerControllerErrorMapperTest.php
+++ b/tests/phpunit/unit/ViewerControllerErrorMapperTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\EtherpadNextcloud\Tests\Unit;
+
+use OCA\EtherpadNextcloud\Controller\ViewerControllerErrorMapper;
+use OCA\EtherpadNextcloud\Exception\ControllerBadRequestException;
+use OCA\EtherpadNextcloud\Exception\UnauthorizedRequestException;
+use OCP\AppFramework\Http\RedirectResponse;
+use OCP\AppFramework\Http\TemplateResponse;
+use OCP\Files\NotFoundException;
+use OCP\IL10N;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+class ViewerControllerErrorMapperTest extends TestCase {
+	public function testRunReturnsRedirectResponseFromSuccessHandler(): void {
+		$response = $this->buildMapper()->runForTemplate(
+			static fn (): string => '/target',
+			static fn (string $url): RedirectResponse => new RedirectResponse($url),
+		);
+
+		$this->assertInstanceOf(RedirectResponse::class, $response);
+		$this->assertSame('/target', $response->getRedirectURL());
+	}
+
+	public function testRunMapsUnauthorizedToNoviewerTemplate(): void {
+		$response = $this->buildMapper()->runForTemplate(
+			static fn (): never => throw new UnauthorizedRequestException(),
+			static fn ($value) => $this->fail('unreachable'),
+		);
+
+		$this->assertInstanceOf(TemplateResponse::class, $response);
+		$this->assertSame('noviewer', $response->getTemplateName());
+		$this->assertSame('Authentication required.', $response->getParams()['error']);
+	}
+
+	public function testRunMapsControllerBadRequestWithExceptionMessage(): void {
+		$response = $this->buildMapper()->runForTemplate(
+			static fn (): never => throw new ControllerBadRequestException('Invalid file path.'),
+			static fn ($value) => $this->fail('unreachable'),
+		);
+
+		$this->assertInstanceOf(TemplateResponse::class, $response);
+		$this->assertSame('Invalid file path.', $response->getParams()['error']);
+	}
+
+	public function testRunMapsNotFoundException(): void {
+		$response = $this->buildMapper()->runForTemplate(
+			static fn (): never => throw new NotFoundException(),
+			static fn ($value) => $this->fail('unreachable'),
+		);
+
+		$this->assertInstanceOf(TemplateResponse::class, $response);
+		$this->assertSame('Cannot open selected .pad file.', $response->getParams()['error']);
+	}
+
+	public function testRunLogsUnhandledExceptionAndReturnsGenericMessage(): void {
+		$logger = $this->createMock(LoggerInterface::class);
+		$logger->expects($this->once())
+			->method('error')
+			->with('Unhandled viewer controller error', $this->callback(static fn (array $context): bool => ($context['exception'] ?? null) instanceof \RuntimeException));
+
+		$response = $this->buildMapper($logger)->runForTemplate(
+			static fn (): never => throw new \RuntimeException('Internal pipe burst'),
+			static fn ($value) => $this->fail('unreachable'),
+		);
+
+		$this->assertInstanceOf(TemplateResponse::class, $response);
+		$this->assertSame('Unable to open pad.', $response->getParams()['error']);
+	}
+
+	private function buildMapper(?LoggerInterface $logger = null): ViewerControllerErrorMapper {
+		$l10n = $this->createMock(IL10N::class);
+		$l10n->method('t')->willReturnCallback(static fn (string $text): string => $text);
+
+		return new ViewerControllerErrorMapper(
+			$l10n,
+			$logger ?? $this->createMock(LoggerInterface::class),
+		);
+	}
+}

--- a/tests/phpunit/unit/ViewerControllerErrorMapperTest.php
+++ b/tests/phpunit/unit/ViewerControllerErrorMapperTest.php
@@ -56,6 +56,17 @@ class ViewerControllerErrorMapperTest extends TestCase {
 		$this->assertSame('Cannot open selected .pad file.', $response->getParams()['error']);
 	}
 
+	public function testRunUsesEndpointSpecificNotFoundMessageWhenProvided(): void {
+		$response = $this->buildMapper()->runForTemplate(
+			static fn (): never => throw new NotFoundException(),
+			static fn ($value) => $this->fail('unreachable'),
+			notFoundMessage: 'Cannot resolve file path for file ID.',
+		);
+
+		$this->assertInstanceOf(TemplateResponse::class, $response);
+		$this->assertSame('Cannot resolve file path for file ID.', $response->getParams()['error']);
+	}
+
 	public function testRunLogsUnhandledExceptionAndReturnsGenericMessage(): void {
 		$logger = $this->createMock(LoggerInterface::class);
 		$logger->expects($this->once())

--- a/tests/phpunit/unit/ViewerControllerTest.php
+++ b/tests/phpunit/unit/ViewerControllerTest.php
@@ -5,26 +5,22 @@ declare(strict_types=1);
 namespace OCA\EtherpadNextcloud\Tests\Unit;
 
 use OCA\EtherpadNextcloud\Controller\ViewerController;
+use OCA\EtherpadNextcloud\Controller\ViewerControllerErrorMapper;
 use OCA\EtherpadNextcloud\Service\UserNodeResolver;
 use OCA\EtherpadNextcloud\Util\PathNormalizer;
 use OCP\AppFramework\Http\RedirectResponse;
 use OCP\Files\File;
 use OCP\Files\NotFoundException;
+use OCP\IL10N;
 use OCP\IRequest;
 use OCP\IURLGenerator;
 use OCP\IUser;
 use OCP\IUserSession;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 
 class ViewerControllerTest extends TestCase {
 	public function testShowPadResolvesFileByPathViaUserNodeResolver(): void {
-		$request = $this->createConfiguredMock(IRequest::class, ['getParam' => '']);
-		$user = $this->createConfiguredMock(IUser::class, ['getUID' => 'alice']);
-		$userSession = $this->createConfiguredMock(IUserSession::class, ['getUser' => $user]);
-
-		$urlGenerator = $this->createMock(IURLGenerator::class);
-		$urlGenerator->method('linkToRoute')->with('files.view.index')->willReturn('/apps/files');
-
 		$file = $this->createMock(File::class);
 		$file->method('getId')->willReturn(138);
 
@@ -34,14 +30,7 @@ class ViewerControllerTest extends TestCase {
 			->with('alice', '/Folder/Test.pad')
 			->willReturn($file);
 
-		$controller = new ViewerController(
-			'etherpad_nextcloud',
-			$request,
-			$urlGenerator,
-			$userSession,
-			new PathNormalizer(),
-			$userNodeResolver,
-		);
+		$controller = $this->buildController($userNodeResolver);
 
 		$response = $controller->showPad('/Folder/Test.pad');
 
@@ -50,31 +39,104 @@ class ViewerControllerTest extends TestCase {
 	}
 
 	public function testShowPadReturnsErrorWhenResolverCannotFindPath(): void {
-		$request = $this->createConfiguredMock(IRequest::class, ['getParam' => '']);
-		$user = $this->createConfiguredMock(IUser::class, ['getUID' => 'alice']);
-		$userSession = $this->createConfiguredMock(IUserSession::class, ['getUser' => $user]);
-
-		$urlGenerator = $this->createMock(IURLGenerator::class);
-		$urlGenerator->method('linkToRoute')->with('files.view.index')->willReturn('/apps/files');
-
 		$userNodeResolver = $this->createMock(UserNodeResolver::class);
 		$userNodeResolver->expects($this->once())
 			->method('resolveUserFileNodeByPath')
 			->with('alice', '/Missing.pad')
 			->willThrowException(new NotFoundException('missing'));
 
-		$controller = new ViewerController(
-			'etherpad_nextcloud',
-			$request,
-			$urlGenerator,
-			$userSession,
-			new PathNormalizer(),
-			$userNodeResolver,
-		);
+		$controller = $this->buildController($userNodeResolver);
 
 		$response = $controller->showPad('/Missing.pad');
 
 		$this->assertSame('noviewer', $response->getTemplateName());
 		$this->assertSame('Cannot open selected .pad file.', $response->getParams()['error']);
+	}
+
+	public function testShowPadRedirectsToFilesIndexWhenFileIsEmpty(): void {
+		$userNodeResolver = $this->createMock(UserNodeResolver::class);
+		$userNodeResolver->expects($this->never())->method('resolveUserFileNodeByPath');
+
+		$controller = $this->buildController($userNodeResolver);
+
+		$response = $controller->showPad('');
+
+		$this->assertInstanceOf(RedirectResponse::class, $response);
+		$this->assertSame('/apps/files', $response->getRedirectURL());
+	}
+
+	public function testShowPadReturnsErrorWhenPathNormalizationFails(): void {
+		$userNodeResolver = $this->createMock(UserNodeResolver::class);
+		$userNodeResolver->expects($this->never())->method('resolveUserFileNodeByPath');
+
+		$controller = $this->buildController($userNodeResolver);
+
+		$response = $controller->showPad('/Apps/../secret.pad');
+
+		$this->assertSame('noviewer', $response->getTemplateName());
+		$this->assertSame('Invalid file path.', $response->getParams()['error']);
+	}
+
+	public function testShowPadReturnsErrorWhenNotLoggedIn(): void {
+		$userNodeResolver = $this->createMock(UserNodeResolver::class);
+		$controller = $this->buildController($userNodeResolver, anonymous: true);
+
+		$response = $controller->showPad('/Folder/Test.pad');
+
+		$this->assertSame('noviewer', $response->getTemplateName());
+		$this->assertSame('Authentication required.', $response->getParams()['error']);
+	}
+
+	public function testShowPadByIdResolvesFileFromUserAbsolutePath(): void {
+		$file = $this->createMock(File::class);
+		$userNodeResolver = $this->createMock(UserNodeResolver::class);
+		$userNodeResolver->method('resolveUserFileNodeById')->with('alice', 7)->willReturn($file);
+		$userNodeResolver->method('toUserAbsolutePath')->with('alice', $file)->willReturn('/Folder/Pad.pad');
+
+		$controller = $this->buildController($userNodeResolver);
+
+		$response = $controller->showPadById(7);
+
+		$this->assertInstanceOf(RedirectResponse::class, $response);
+		$this->assertSame('/apps/files/7?dir=%2FFolder&editing=false&openfile=true', $response->getRedirectURL());
+	}
+
+	public function testShowPadByIdRejectsInvalidFileId(): void {
+		$controller = $this->buildController($this->createMock(UserNodeResolver::class));
+
+		$response = $controller->showPadById('not-numeric');
+
+		$this->assertSame('noviewer', $response->getTemplateName());
+		$this->assertSame('Invalid file ID.', $response->getParams()['error']);
+	}
+
+	private function buildController(UserNodeResolver $userNodeResolver, bool $anonymous = false): ViewerController {
+		$request = $this->createConfiguredMock(IRequest::class, ['getParam' => '']);
+		$user = $this->createConfiguredMock(IUser::class, ['getUID' => 'alice']);
+		$userSession = $this->createConfiguredMock(IUserSession::class, [
+			'getUser' => $anonymous ? null : $user,
+		]);
+
+		$urlGenerator = $this->createMock(IURLGenerator::class);
+		$urlGenerator->method('linkToRoute')->with('files.view.index')->willReturn('/apps/files');
+
+		$l10n = $this->createMock(IL10N::class);
+		$l10n->method('t')->willReturnCallback(static fn (string $text): string => $text);
+
+		$errorMapper = new ViewerControllerErrorMapper(
+			$l10n,
+			$this->createMock(LoggerInterface::class),
+		);
+
+		return new ViewerController(
+			'etherpad_nextcloud',
+			$request,
+			$urlGenerator,
+			$userSession,
+			$l10n,
+			new PathNormalizer(),
+			$userNodeResolver,
+			$errorMapper,
+		);
 	}
 }

--- a/tests/phpunit/unit/ViewerControllerTest.php
+++ b/tests/phpunit/unit/ViewerControllerTest.php
@@ -101,6 +101,21 @@ class ViewerControllerTest extends TestCase {
 		$this->assertSame('/apps/files/7?dir=%2FFolder&editing=false&openfile=true', $response->getRedirectURL());
 	}
 
+	public function testShowPadByIdReturnsFileIdErrorWhenResolverThrowsNotFound(): void {
+		// Regression: showPadById must surface "Cannot resolve file path for file ID."
+		// rather than the open-pad default when the file ID cannot be resolved.
+		$resolver = $this->createMock(UserNodeResolver::class);
+		$resolver->method('resolveUserFileNodeById')
+			->willThrowException(new NotFoundException());
+
+		$controller = $this->buildController($resolver);
+
+		$response = $controller->showPadById(7);
+
+		$this->assertSame('noviewer', $response->getTemplateName());
+		$this->assertSame('Cannot resolve file path for file ID.', $response->getParams()['error']);
+	}
+
 	public function testShowPadByIdRejectsInvalidFileId(): void {
 		$controller = $this->buildController($this->createMock(UserNodeResolver::class));
 


### PR DESCRIPTION
## Summary

- new `EmbedResponseBuilder` service that owns embed-template assembly, base-data caching, and frame-ancestor CSP application
- new `EmbedControllerErrorMapper` and `ViewerControllerErrorMapper` with `runForTemplate(action, success, ...)` matching the existing `PublicViewerControllerErrorMapper` shape
- `EmbedController` and `ViewerController` rewritten on top of the mappers: manual try/catch ladders are gone, auth and ID validation now throws `UnauthorizedRequestException` / `ControllerBadRequestException` and the mapper handles the response shape
- existing controller tests rewritten to wire the new dependencies; new tests added for each mapper and the response builder

Closes #20.

## Why

`EmbedController` and `ViewerController` were the last two controllers still using the pre-refactor pattern (manual `try { … } catch (...) { return errorResponse(...) }`). After this PR all five controllers share the same orchestration shape:

- typed domain exceptions describe the failure
- error mapper translates them to the correct response type
- unhandled `\Throwable` is logged once via the injected `LoggerInterface` instead of slipping through silently

The embed-side response plumbing (base data, CSP) used to live as private methods on the controller itself, which meant the error path could not easily render through the same plumbing without duplicating it. Extracting `EmbedResponseBuilder` lets both controller success and mapper error paths use identical iframe framing.

## Behavior preservation

The visible behavior matches the previous implementation:

- successful `showById` / `createByParent` produce the same `embed` / `embed-create` template payload
- error cases still render `noviewer` with the appropriate error message and title
- `showPad` continues to redirect to the Files index when called without a `file` parameter
- non-pad files, missing IDs, traversal paths, anonymous access, and not-writable parent folders all surface the same error wording

## Tests

```
composer test:phpunit
# OK (312 tests, 1342 assertions)
```

- `EmbedControllerTest` grows from 1 to 8 cases (success path, invalid ID, non-pad file, not-found, anonymous, create-by-parent: invalid ID, not-writable, success)
- `ViewerControllerTest` grows from 2 to 7 cases (success path, not-found, empty redirect, invalid path, anonymous, by-id success, by-id invalid ID)
- new `EmbedControllerErrorMapperTest` (7 cases), `ViewerControllerErrorMapperTest` (5 cases), `EmbedResponseBuilderTest` (3 cases)

Net: 285 → 312 PHP tests (+27). JS suite unchanged at 67.

## Files

- `lib/Controller/EmbedController.php` — rewritten
- `lib/Controller/EmbedControllerErrorMapper.php` — new
- `lib/Controller/ViewerController.php` — rewritten
- `lib/Controller/ViewerControllerErrorMapper.php` — new
- `lib/Service/EmbedResponseBuilder.php` — new
- `tests/phpunit/unit/EmbedControllerTest.php` — rewritten
- `tests/phpunit/unit/EmbedControllerErrorMapperTest.php` — new
- `tests/phpunit/unit/EmbedResponseBuilderTest.php` — new
- `tests/phpunit/unit/ViewerControllerTest.php` — rewritten
- `tests/phpunit/unit/ViewerControllerErrorMapperTest.php` — new