### PR TITLE
Use value objects for internal pad service responses

### DIFF
--- a/lib/Controller/PadController.php
+++ b/lib/Controller/PadController.php
@@ -17,6 +17,7 @@ use OCA\EtherpadNextcloud\Service\PadInitializationService;
 use OCA\EtherpadNextcloud\Service\PadLifecycleOperationService;
 use OCA\EtherpadNextcloud\Service\PadMetadataService;
 use OCA\EtherpadNextcloud\Service\PadOpenService;
+use OCA\EtherpadNextcloud\Service\PadOpenTarget;
 use OCA\EtherpadNextcloud\Service\PadResponseService;
 use OCA\EtherpadNextcloud\Service\PadSyncService;
 use OCP\AppFramework\Controller;
@@ -96,8 +97,8 @@ class PadController extends Controller {
 	#[\OCP\AppFramework\Http\Attribute\NoAdminRequired]
 	public function open(string $file): DataResponse {
 		return $this->runForUser(
-			fn(IUser $user): array => $this->padOpenService->openByPath($user->getUID(), $user->getDisplayName(), $file),
-			fn(array $result): DataResponse => $this->padResponses->openResponse($result),
+			fn(IUser $user): PadOpenTarget => $this->padOpenService->openByPath($user->getUID(), $user->getDisplayName(), $file),
+			fn(PadOpenTarget $result): DataResponse => $this->padResponses->openResponse($result),
 			[
 				'invalid_argument' => $this->l10n->t('Invalid file path.'),
 				'not_found' => $this->l10n->t('Cannot open selected .pad file.'),
@@ -109,8 +110,8 @@ class PadController extends Controller {
 	#[\OCP\AppFramework\Http\Attribute\NoAdminRequired]
 	public function openById(int $fileId): DataResponse {
 		return $this->runForUser(
-			fn(IUser $user): array => $this->padOpenService->openById($user->getUID(), $user->getDisplayName(), $this->requireFileId($fileId)),
-			fn(array $result): DataResponse => $this->padResponses->openResponse($result),
+			fn(IUser $user): PadOpenTarget => $this->padOpenService->openById($user->getUID(), $user->getDisplayName(), $this->requireFileId($fileId)),
+			fn(PadOpenTarget $result): DataResponse => $this->padResponses->openResponse($result),
 			[
 				'not_found' => $this->l10n->t('Cannot open selected .pad file.'),
 				'generic' => $this->l10n->t('Could not open pad.'),

--- a/lib/Controller/PadController.php
+++ b/lib/Controller/PadController.php
@@ -23,6 +23,8 @@ use OCA\EtherpadNextcloud\Service\PadOpenTarget;
 use OCA\EtherpadNextcloud\Service\PadOriginalLookup;
 use OCA\EtherpadNextcloud\Service\PadResolution;
 use OCA\EtherpadNextcloud\Service\PadResponseService;
+use OCA\EtherpadNextcloud\Service\PadSyncResult;
+use OCA\EtherpadNextcloud\Service\PadSyncStatus;
 use OCA\EtherpadNextcloud\Service\PadSyncService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
@@ -188,8 +190,8 @@ class PadController extends Controller {
 		$force = in_array(strtolower($forceParam), ['1', 'true', 'yes'], true);
 
 		return $this->runForUser(
-			fn(IUser $user): array => $this->padSyncService->syncById($user->getUID(), $this->requireFileId($fileId), $force),
-			fn(array $result): DataResponse => new DataResponse($result),
+			fn(IUser $user): PadSyncResult => $this->padSyncService->syncById($user->getUID(), $this->requireFileId($fileId), $force),
+			fn(PadSyncResult $result): DataResponse => new DataResponse($this->padResponses->syncResponse($result)),
 			[
 				'not_found' => $this->l10n->t('Cannot resolve file path for file ID.'),
 				'generic' => $this->l10n->t('Could not sync pad content.'),
@@ -201,8 +203,8 @@ class PadController extends Controller {
 	#[\OCP\AppFramework\Http\Attribute\NoCSRFRequired]
 	public function syncStatusById(int $fileId): DataResponse {
 		return $this->runForUser(
-			fn(IUser $user): array => $this->padSyncService->syncStatusById($user->getUID(), $this->requireFileId($fileId)),
-			fn(array $result): DataResponse => new DataResponse($result),
+			fn(IUser $user): PadSyncStatus => $this->padSyncService->syncStatusById($user->getUID(), $this->requireFileId($fileId)),
+			fn(PadSyncStatus $result): DataResponse => new DataResponse($this->padResponses->syncStatusResponse($result)),
 			[
 				'not_found' => $this->l10n->t('Cannot read selected .pad file.'),
 				'generic' => $this->l10n->t('Could not check pad sync status.'),

--- a/lib/Controller/PadController.php
+++ b/lib/Controller/PadController.php
@@ -13,6 +13,7 @@ use OCA\EtherpadNextcloud\Exception\ControllerBadRequestException;
 use OCA\EtherpadNextcloud\Exception\UnauthorizedRequestException;
 use OCA\EtherpadNextcloud\Service\BindingService;
 use OCA\EtherpadNextcloud\Service\PadCreationService;
+use OCA\EtherpadNextcloud\Service\PadInitializationResult;
 use OCA\EtherpadNextcloud\Service\PadInitializationService;
 use OCA\EtherpadNextcloud\Service\PadLifecycleOperationService;
 use OCA\EtherpadNextcloud\Service\PadMetadataService;
@@ -122,8 +123,8 @@ class PadController extends Controller {
 	#[\OCP\AppFramework\Http\Attribute\NoAdminRequired]
 	public function initialize(string $file): DataResponse {
 		return $this->runForUser(
-			fn(IUser $user): array => $this->padInitializationService->initializeByPath($user->getUID(), $file),
-			fn(array $result): DataResponse => new DataResponse($result),
+			fn(IUser $user): PadInitializationResult => $this->padInitializationService->initializeByPath($user->getUID(), $file),
+			fn(PadInitializationResult $result): DataResponse => new DataResponse($this->padResponses->initializationResponse($result)),
 			[
 				'invalid_argument' => $this->l10n->t('Invalid file path.'),
 				'not_found' => $this->l10n->t('Cannot open selected .pad file.'),
@@ -139,8 +140,8 @@ class PadController extends Controller {
 	#[\OCP\AppFramework\Http\Attribute\NoAdminRequired]
 	public function initializeById(int $fileId): DataResponse {
 		return $this->runForUser(
-			fn(IUser $user): array => $this->padInitializationService->initializeById($user->getUID(), $this->requireFileId($fileId)),
-			fn(array $result): DataResponse => new DataResponse($result),
+			fn(IUser $user): PadInitializationResult => $this->padInitializationService->initializeById($user->getUID(), $this->requireFileId($fileId)),
+			fn(PadInitializationResult $result): DataResponse => new DataResponse($this->padResponses->initializationResponse($result)),
 			[
 				'not_found' => $this->l10n->t('Cannot open selected .pad file.'),
 				'generic' => $this->l10n->t('Could not initialize pad file.'),

--- a/lib/Controller/PadController.php
+++ b/lib/Controller/PadController.php
@@ -16,9 +16,12 @@ use OCA\EtherpadNextcloud\Service\PadCreationService;
 use OCA\EtherpadNextcloud\Service\PadInitializationResult;
 use OCA\EtherpadNextcloud\Service\PadInitializationService;
 use OCA\EtherpadNextcloud\Service\PadLifecycleOperationService;
+use OCA\EtherpadNextcloud\Service\PadMeta;
 use OCA\EtherpadNextcloud\Service\PadMetadataService;
 use OCA\EtherpadNextcloud\Service\PadOpenService;
 use OCA\EtherpadNextcloud\Service\PadOpenTarget;
+use OCA\EtherpadNextcloud\Service\PadOriginalLookup;
+use OCA\EtherpadNextcloud\Service\PadResolution;
 use OCA\EtherpadNextcloud\Service\PadResponseService;
 use OCA\EtherpadNextcloud\Service\PadSyncService;
 use OCP\AppFramework\Controller;
@@ -157,12 +160,8 @@ class PadController extends Controller {
 	#[\OCP\AppFramework\Http\Attribute\NoCSRFRequired]
 	public function metaById(int $fileId): DataResponse {
 		return $this->runForUser(
-			fn(IUser $user): array => $this->padMetadataService->metaById($user->getUID(), $this->requireFileId($fileId)),
-			fn(array $data): DataResponse => new DataResponse(
-				($data['is_pad'] ?? false) === true
-					? $this->padResponses->withViewerAndEmbedUrls($data)
-					: $data
-			),
+			fn(IUser $user): PadMeta => $this->padMetadataService->metaById($user->getUID(), $this->requireFileId($fileId)),
+			fn(PadMeta $meta): DataResponse => new DataResponse($this->padResponses->metaResponse($meta)),
 			[
 				'not_found' => $this->l10n->t('Cannot resolve selected .pad file.'),
 				'generic' => $this->l10n->t('Could not read pad metadata.'),
@@ -174,12 +173,8 @@ class PadController extends Controller {
 	#[\OCP\AppFramework\Http\Attribute\NoCSRFRequired]
 	public function resolveById(int $fileId = 0, string $file = ''): DataResponse {
 		return $this->runForUser(
-			fn(IUser $user): array => $this->padMetadataService->resolve($user->getUID(), $fileId, $file),
-			fn(array $data): DataResponse => new DataResponse(
-				($data['is_pad'] ?? false) === true
-					? $this->padResponses->withViewerUrl($data)
-					: $data
-			),
+			fn(IUser $user): PadResolution => $this->padMetadataService->resolve($user->getUID(), $fileId, $file),
+			fn(PadResolution $resolution): DataResponse => new DataResponse($this->padResponses->resolveResponse($resolution)),
 			[
 				'invalid_argument' => $this->l10n->t('Invalid file path.'),
 				'generic' => $this->l10n->t('Could not resolve pad file.'),
@@ -236,15 +231,11 @@ class PadController extends Controller {
 	#[\OCP\AppFramework\Http\Attribute\NoCSRFRequired]
 	public function findOriginalByFileId(int $fileId): DataResponse {
 		return $this->runForUser(
-			fn(IUser $user): array => $this->padMetadataService->findOriginalForCopy(
+			fn(IUser $user): PadOriginalLookup => $this->padMetadataService->findOriginalForCopy(
 				$user->getUID(),
 				$this->requireFileId($fileId),
 			),
-			fn(array $data): DataResponse => new DataResponse(
-				($data['found'] ?? false) === true
-					? $this->padResponses->withViewerAndEmbedUrls($data)
-					: $data
-			),
+			fn(PadOriginalLookup $lookup): DataResponse => new DataResponse($this->padResponses->originalLookupResponse($lookup)),
 			[
 				'generic' => $this->l10n->t('Could not look up the original pad.'),
 			],

--- a/lib/Service/PadInitializationResult.php
+++ b/lib/Service/PadInitializationResult.php
@@ -17,11 +17,11 @@ namespace OCA\EtherpadNextcloud\Service;
  */
 class PadInitializationResult {
 	public function __construct(
-		public string $status,
-		public string $file,
-		public int $fileId,
-		public string $padId,
-		public string $accessMode,
+		public readonly string $status,
+		public readonly string $file,
+		public readonly int $fileId,
+		public readonly string $padId,
+		public readonly string $accessMode,
 	) {
 	}
 }

--- a/lib/Service/PadInitializationResult.php
+++ b/lib/Service/PadInitializationResult.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Copyright (c) 2026 Jacob Bühler
+ */
+
+namespace OCA\EtherpadNextcloud\Service;
+
+/**
+ * Result of a `.pad` frontmatter initialization. The `$status` field is one
+ * of {@see PadInitializationService}'s STATUS_* constants and tells the
+ * caller whether the frontmatter was already present (no write happened) or
+ * was bootstrapped (file was rewritten).
+ */
+class PadInitializationResult {
+	public function __construct(
+		public string $status,
+		public string $file,
+		public int $fileId,
+		public string $padId,
+		public string $accessMode,
+	) {
+	}
+}

--- a/lib/Service/PadInitializationService.php
+++ b/lib/Service/PadInitializationService.php
@@ -27,10 +27,9 @@ class PadInitializationService {
 	}
 
 	/**
-	 * @return array{status:string,file:string,file_id:int,pad_id:string,access_mode:string}
 	 * @throws NotFoundException
 	 */
-	public function initializeByPath(string $uid, string $file): array {
+	public function initializeByPath(string $uid, string $file): PadInitializationResult {
 		$path = $this->padPaths->normalizeViewerFilePath($file);
 		if ($path === '') {
 			throw new \InvalidArgumentException('Invalid file path.');
@@ -41,16 +40,14 @@ class PadInitializationService {
 	}
 
 	/**
-	 * @return array{status:string,file:string,file_id:int,pad_id:string,access_mode:string}
 	 * @throws NotFoundException
 	 */
-	public function initializeById(string $uid, int $fileId): array {
+	public function initializeById(string $uid, int $fileId): PadInitializationResult {
 		$node = $this->userNodeResolver->resolveUserFileNodeById($uid, $fileId);
 		return $this->initializeNode($uid, $node);
 	}
 
-	/** @return array{status:string,file:string,file_id:int,pad_id:string,access_mode:string} */
-	private function initializeNode(string $uid, File $node): array {
+	private function initializeNode(string $uid, File $node): PadInitializationResult {
 		$fileId = (int)$node->getId();
 		if ($fileId <= 0) {
 			throw new \RuntimeException('Could not resolve file ID.');
@@ -59,20 +56,19 @@ class PadInitializationService {
 		return $this->initialize($uid, $node, (string)$node->getContent());
 	}
 
-	/** @return array{status:string,file:string,file_id:int,pad_id:string,access_mode:string} */
-	public function initialize(string $uid, File $file, string $content): array {
+	public function initialize(string $uid, File $file, string $content): PadInitializationResult {
 		$fileId = (int)$file->getId();
 		$path = $this->userNodeResolver->toUserAbsolutePath($uid, $file);
 		try {
 			$parsed = $this->padFileService->parsePadFile($content);
 			$meta = $parsed['frontmatter'];
-			return [
-				'status' => self::STATUS_ALREADY_INITIALIZED,
-				'file' => $path,
-				'file_id' => $fileId,
-				'pad_id' => (string)$meta['pad_id'],
-				'access_mode' => (string)$meta['access_mode'],
-			];
+			return new PadInitializationResult(
+				status: self::STATUS_ALREADY_INITIALIZED,
+				file: $path,
+				fileId: $fileId,
+				padId: (string)$meta['pad_id'],
+				accessMode: (string)$meta['access_mode'],
+			);
 		} catch (MissingFrontmatterException) {
 			// Explicitly continue with bootstrap flow for legacy or empty .pad files.
 		} catch (PadFileFormatException $e) {
@@ -84,12 +80,12 @@ class PadInitializationService {
 		$parsed = $this->padFileService->parsePadFile((string)$updatedContent);
 		$meta = $parsed['frontmatter'];
 
-		return [
-			'status' => self::STATUS_INITIALIZED,
-			'file' => $path,
-			'file_id' => $fileId,
-			'pad_id' => (string)$meta['pad_id'],
-			'access_mode' => (string)$meta['access_mode'],
-		];
+		return new PadInitializationResult(
+			status: self::STATUS_INITIALIZED,
+			file: $path,
+			fileId: $fileId,
+			padId: (string)$meta['pad_id'],
+			accessMode: (string)$meta['access_mode'],
+		);
 	}
 }

--- a/lib/Service/PadMeta.php
+++ b/lib/Service/PadMeta.php
@@ -13,19 +13,26 @@ namespace OCA\EtherpadNextcloud\Service;
  * Full metadata read for a file, used by the meta-by-id endpoint. The
  * file itself is always resolved (fileId / name / path are populated);
  * the pad-specific fields are only meaningful when `$isPad` is true.
+ *
+ * Variants:
+ *
+ * - `$isPad === false` → fileId, name, path populated; pad-specific
+ *   fields stay at their defaults and should not be read.
+ * - `$isPad === true`  → fileId, name, path, isPadMime, accessMode,
+ *   isExternal, padId, padUrl, publicOpenUrl all populated.
  */
 class PadMeta {
 	public function __construct(
-		public bool $isPad,
-		public int $fileId,
-		public string $name,
-		public string $path,
-		public bool $isPadMime = false,
-		public string $accessMode = '',
-		public bool $isExternal = false,
-		public string $padId = '',
-		public string $padUrl = '',
-		public string $publicOpenUrl = '',
+		public readonly bool $isPad,
+		public readonly int $fileId,
+		public readonly string $name,
+		public readonly string $path,
+		public readonly bool $isPadMime = false,
+		public readonly string $accessMode = '',
+		public readonly bool $isExternal = false,
+		public readonly string $padId = '',
+		public readonly string $padUrl = '',
+		public readonly string $publicOpenUrl = '',
 	) {
 	}
 }

--- a/lib/Service/PadMeta.php
+++ b/lib/Service/PadMeta.php
@@ -13,13 +13,6 @@ namespace OCA\EtherpadNextcloud\Service;
  * Full metadata read for a file, used by the meta-by-id endpoint. The
  * file itself is always resolved (fileId / name / path are populated);
  * the pad-specific fields are only meaningful when `$isPad` is true.
- *
- * Variants:
- *
- * - `$isPad === false` → fileId, name, path populated; pad-specific
- *   fields stay at their defaults and should not be read.
- * - `$isPad === true`  → fileId, name, path, isPadMime, accessMode,
- *   isExternal, padId, padUrl, publicOpenUrl all populated.
  */
 class PadMeta {
 	public function __construct(

--- a/lib/Service/PadMeta.php
+++ b/lib/Service/PadMeta.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Copyright (c) 2026 Jacob Bühler
+ */
+
+namespace OCA\EtherpadNextcloud\Service;
+
+/**
+ * Full metadata read for a file, used by the meta-by-id endpoint. The
+ * file itself is always resolved (fileId / name / path are populated);
+ * the pad-specific fields are only meaningful when `$isPad` is true.
+ */
+class PadMeta {
+	public function __construct(
+		public bool $isPad,
+		public int $fileId,
+		public string $name,
+		public string $path,
+		public bool $isPadMime = false,
+		public string $accessMode = '',
+		public bool $isExternal = false,
+		public string $padId = '',
+		public string $padUrl = '',
+		public string $publicOpenUrl = '',
+	) {
+	}
+}

--- a/lib/Service/PadMetadataService.php
+++ b/lib/Service/PadMetadataService.php
@@ -38,17 +38,15 @@ class PadMetadataService {
 	 * it is only emitted when the requester can already read the bound file
 	 * (gated by UserNodeResolver). This means a crafted frontmatter cannot
 	 * be used to probe for `.pad` files in other users' accounts.
-	 *
-	 * @return array{found:false}|array{found:true,file_id:int,path:string}
 	 */
-	public function findOriginalForCopy(string $uid, int $fileId): array {
+	public function findOriginalForCopy(string $uid, int $fileId): PadOriginalLookup {
 		try {
 			$node = $this->userNodeResolver->resolveUserFileNodeById($uid, $fileId);
 		} catch (NotFoundException) {
-			return ['found' => false];
+			return new PadOriginalLookup(found: false);
 		}
 		if (!str_ends_with(strtolower($node->getName()), '.pad')) {
-			return ['found' => false];
+			return new PadOriginalLookup(found: false);
 		}
 
 		$padId = '';
@@ -58,55 +56,53 @@ class PadMetadataService {
 			$meta = $this->padFileService->extractPadMetadata($parsed['frontmatter']);
 			$padId = (string)($meta['pad_id'] ?? '');
 		} catch (\Throwable) {
-			return ['found' => false];
+			return new PadOriginalLookup(found: false);
 		}
 		if ($padId === '' || str_starts_with($padId, 'ext.')) {
-			return ['found' => false];
+			return new PadOriginalLookup(found: false);
 		}
 
 		$binding = $this->bindingService->findByPadId($padId, BindingService::STATE_ACTIVE);
 		if ($binding === null) {
-			return ['found' => false];
+			return new PadOriginalLookup(found: false);
 		}
 
 		$boundFileId = (int)$binding['file_id'];
 		if ($boundFileId <= 0 || $boundFileId === $fileId) {
-			return ['found' => false];
+			return new PadOriginalLookup(found: false);
 		}
 
 		try {
 			$originalNode = $this->userNodeResolver->resolveUserFileNodeById($uid, $boundFileId);
 		} catch (NotFoundException) {
-			return ['found' => false];
+			return new PadOriginalLookup(found: false);
 		}
 
-		return [
-			'found' => true,
-			'file_id' => $boundFileId,
-			'path' => $this->userNodeResolver->toUserAbsolutePath($uid, $originalNode),
-		];
+		return new PadOriginalLookup(
+			found: true,
+			fileId: $boundFileId,
+			path: $this->userNodeResolver->toUserAbsolutePath($uid, $originalNode),
+		);
 	}
 
 	/**
-	 * @return array{is_pad:false,file_id:int,name:string,path:string}|array{is_pad:true,is_pad_mime:bool,file_id:int,name:string,path:string,access_mode:string,is_external:bool,pad_id:string,pad_url:string,public_open_url:string}
 	 * @throws NotFoundException
 	 * @throws LockedException
 	 */
-	public function metaById(string $uid, int $fileId): array {
+	public function metaById(string $uid, int $fileId): PadMeta {
 		$node = $this->userNodeResolver->resolveUserFileNodeById($uid, $fileId);
 		$absolutePath = $this->userNodeResolver->toUserAbsolutePath($uid, $node);
 		return $this->buildMeta($node, $absolutePath);
 	}
 
-	/** @return array{is_pad:false,file_id?:int,path?:string}|array{is_pad:true,is_pad_mime:bool,file_id:int,path:string,access_mode:string,is_external:bool,public_open_url:string} */
-	public function resolve(string $uid, int $fileId = 0, string $file = ''): array {
+	public function resolve(string $uid, int $fileId = 0, string $file = ''): PadResolution {
 		$resolvedFileId = $fileId;
 		if ($resolvedFileId > 0) {
 			try {
 				$node = $this->userNodeResolver->resolveUserFileNodeById($uid, $resolvedFileId);
 				$normalizedPath = $this->userNodeResolver->toUserAbsolutePath($uid, $node);
 			} catch (NotFoundException) {
-				return ['is_pad' => false, 'file_id' => $resolvedFileId];
+				return new PadResolution(isPad: false, fileId: $resolvedFileId);
 			}
 		} else {
 			$requestedPath = $this->padPaths->normalizeViewerFilePath($file);
@@ -117,71 +113,69 @@ class PadMetadataService {
 			try {
 				$node = $this->userNodeResolver->resolveUserFileNodeByPath($uid, $requestedPath);
 			} catch (NotFoundException) {
-				return ['is_pad' => false, 'path' => $requestedPath];
+				return new PadResolution(isPad: false, path: $requestedPath);
 			}
 
 			$resolvedFileId = (int)$node->getId();
 			if ($resolvedFileId <= 0) {
-				return ['is_pad' => false, 'path' => $requestedPath];
+				return new PadResolution(isPad: false, path: $requestedPath);
 			}
 			$normalizedPath = $this->userNodeResolver->toUserAbsolutePath($uid, $node);
 		}
 
 		if (!str_ends_with(strtolower($normalizedPath), '.pad')) {
-			return ['is_pad' => false, 'file_id' => $resolvedFileId, 'path' => $normalizedPath];
+			return new PadResolution(isPad: false, fileId: $resolvedFileId, path: $normalizedPath);
 		}
 
 		return $this->buildResolve($node, $resolvedFileId, $normalizedPath);
 	}
 
 	/**
-	 * @return array{is_pad:false,file_id:int,name:string,path:string}|array{is_pad:true,is_pad_mime:bool,file_id:int,name:string,path:string,access_mode:string,is_external:bool,pad_id:string,pad_url:string,public_open_url:string}
 	 * @throws LockedException
 	 */
-	private function buildMeta(File $node, string $absolutePath): array {
+	private function buildMeta(File $node, string $absolutePath): PadMeta {
 		$fileId = (int)$node->getId();
 		if ($fileId <= 0) {
 			throw new \RuntimeException('Could not resolve file ID.');
 		}
 
 		if (!str_ends_with(strtolower($absolutePath), '.pad')) {
-			return [
-				'is_pad' => false,
-				'file_id' => $fileId,
-				'name' => $node->getName(),
-				'path' => $absolutePath,
-			];
+			return new PadMeta(
+				isPad: false,
+				fileId: $fileId,
+				name: $node->getName(),
+				path: $absolutePath,
+			);
 		}
 
 		$metadata = $this->readPadMetadata($node, $fileId, $absolutePath, true, 'Pad meta parse skipped');
 
-		return [
-			'is_pad' => true,
-			'is_pad_mime' => (string)$node->getMimeType() === 'application/x-etherpad-nextcloud',
-			'file_id' => $fileId,
-			'name' => $node->getName(),
-			'path' => $absolutePath,
-			'access_mode' => $metadata['access_mode'],
-			'is_external' => $metadata['is_external'],
-			'pad_id' => $metadata['pad_id'],
-			'pad_url' => $metadata['pad_url'],
-			'public_open_url' => $metadata['public_open_url'],
-		];
+		return new PadMeta(
+			isPad: true,
+			fileId: $fileId,
+			name: $node->getName(),
+			path: $absolutePath,
+			isPadMime: (string)$node->getMimeType() === 'application/x-etherpad-nextcloud',
+			accessMode: $metadata['access_mode'],
+			isExternal: $metadata['is_external'],
+			padId: $metadata['pad_id'],
+			padUrl: $metadata['pad_url'],
+			publicOpenUrl: $metadata['public_open_url'],
+		);
 	}
 
-	/** @return array{is_pad:true,is_pad_mime:bool,file_id:int,path:string,access_mode:string,is_external:bool,public_open_url:string} */
-	private function buildResolve(File $node, int $fileId, string $absolutePath): array {
+	private function buildResolve(File $node, int $fileId, string $absolutePath): PadResolution {
 		$metadata = $this->readPadMetadata($node, $fileId, $absolutePath, false, 'Pad resolve metadata parse skipped');
 
-		return [
-			'is_pad' => true,
-			'is_pad_mime' => (string)$node->getMimeType() === 'application/x-etherpad-nextcloud',
-			'file_id' => $fileId,
-			'path' => $absolutePath,
-			'access_mode' => $metadata['access_mode'],
-			'is_external' => $metadata['is_external'],
-			'public_open_url' => $metadata['public_open_url'],
-		];
+		return new PadResolution(
+			isPad: true,
+			fileId: $fileId,
+			path: $absolutePath,
+			isPadMime: (string)$node->getMimeType() === 'application/x-etherpad-nextcloud',
+			accessMode: $metadata['access_mode'],
+			isExternal: $metadata['is_external'],
+			publicOpenUrl: $metadata['public_open_url'],
+		);
 	}
 
 	/** @return array{access_mode:string,is_external:bool,pad_id:string,pad_url:string,public_open_url:string} */

--- a/lib/Service/PadOpenService.php
+++ b/lib/Service/PadOpenService.php
@@ -32,10 +32,9 @@ class PadOpenService {
 	}
 
 	/**
-	 * @return array{file:string,file_id:int,pad_id:string,access_mode:string,pad_url:string,is_external:bool,original_pad_url:string,snapshot_text:string,snapshot_html:string,url:string,cookie_header:string}
 	 * @throws NotFoundException
 	 */
-	public function openByPath(string $uid, string $displayName, string $file): array {
+	public function openByPath(string $uid, string $displayName, string $file): PadOpenTarget {
 		$path = $this->padPaths->normalizeViewerFilePath($file);
 		if ($path === '') {
 			throw new \InvalidArgumentException('Invalid file path.');
@@ -46,23 +45,21 @@ class PadOpenService {
 	}
 
 	/**
-	 * @return array{file:string,file_id:int,pad_id:string,access_mode:string,pad_url:string,is_external:bool,original_pad_url:string,snapshot_text:string,snapshot_html:string,url:string,cookie_header:string}
 	 * @throws NotFoundException
 	 */
-	public function openById(string $uid, string $displayName, int $fileId): array {
+	public function openById(string $uid, string $displayName, int $fileId): PadOpenTarget {
 		$node = $this->userNodeResolver->resolveUserFileNodeById($uid, $fileId);
 		$absolutePath = $this->userNodeResolver->toUserAbsolutePath($uid, $node);
 		return $this->openNode($uid, $displayName, $node, $absolutePath);
 	}
 
 	/**
-	 * @return array{file:string,file_id:int,pad_id:string,access_mode:string,pad_url:string,is_external:bool,original_pad_url:string,snapshot_text:string,snapshot_html:string,url:string,cookie_header:string}
 	 * @throws BindingException
 	 * @throws EtherpadClientException
 	 * @throws LockedException
 	 * @throws PadFileFormatException
 	 */
-	private function openNode(string $uid, string $displayName, File $node, string $absolutePath): array {
+	private function openNode(string $uid, string $displayName, File $node, string $absolutePath): PadOpenTarget {
 		try {
 			$content = $this->lockRetryService->readContentWithOpenLockRetry($node);
 			$fileId = (int)$node->getId();
@@ -107,7 +104,6 @@ class PadOpenService {
 		}
 	}
 
-	/** @return array{file:string,file_id:int,pad_id:string,access_mode:string,pad_url:string,is_external:bool,original_pad_url:string,snapshot_text:string,snapshot_html:string,url:string,cookie_header:string} */
 	private function buildOpenContext(
 		string $uid,
 		string $displayName,
@@ -119,7 +115,7 @@ class PadOpenService {
 		bool $isExternal = false,
 		string $snapshotText = '',
 		string $snapshotHtml = ''
-	): array {
+	): PadOpenTarget {
 		if ($isExternal && $accessMode !== BindingService::ACCESS_PUBLIC) {
 			throw new EtherpadClientException('External pad metadata requires public access_mode.');
 		}
@@ -149,18 +145,18 @@ class PadOpenService {
 			$url = $effectivePadUrl;
 		}
 
-		return [
-			'file' => $path,
-			'file_id' => $fileId,
-			'pad_id' => $padId,
-			'access_mode' => $accessMode,
-			'pad_url' => $effectivePadUrl,
-			'is_external' => $isExternal,
-			'original_pad_url' => $originalPadUrl,
-			'snapshot_text' => $isExternal ? $snapshotText : '',
-			'snapshot_html' => $isExternal ? $snapshotHtml : '',
-			'url' => $url,
-			'cookie_header' => $cookieHeader,
-		];
+		return new PadOpenTarget(
+			file: $path,
+			fileId: $fileId,
+			padId: $padId,
+			accessMode: $accessMode,
+			padUrl: $effectivePadUrl,
+			isExternal: $isExternal,
+			originalPadUrl: $originalPadUrl,
+			snapshotText: $isExternal ? $snapshotText : '',
+			snapshotHtml: $isExternal ? $snapshotHtml : '',
+			url: $url,
+			cookieHeader: $cookieHeader,
+		);
 	}
 }

--- a/lib/Service/PadOpenTarget.php
+++ b/lib/Service/PadOpenTarget.php
@@ -18,17 +18,17 @@ namespace OCA\EtherpadNextcloud\Service;
  */
 class PadOpenTarget {
 	public function __construct(
-		public string $file,
-		public int $fileId,
-		public string $padId,
-		public string $accessMode,
-		public string $padUrl,
-		public bool $isExternal,
-		public string $originalPadUrl,
-		public string $snapshotText,
-		public string $snapshotHtml,
-		public string $url,
-		public string $cookieHeader,
+		public readonly string $file,
+		public readonly int $fileId,
+		public readonly string $padId,
+		public readonly string $accessMode,
+		public readonly string $padUrl,
+		public readonly bool $isExternal,
+		public readonly string $originalPadUrl,
+		public readonly string $snapshotText,
+		public readonly string $snapshotHtml,
+		public readonly string $url,
+		public readonly string $cookieHeader,
 	) {
 	}
 }

--- a/lib/Service/PadOpenTarget.php
+++ b/lib/Service/PadOpenTarget.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Copyright (c) 2026 Jacob Bühler
+ */
+
+namespace OCA\EtherpadNextcloud\Service;
+
+/**
+ * Outcome of an authenticated `.pad` open. Kept separate from
+ * `PublicPadOpenTarget`: the internal flow always carries the bound
+ * `pad_id` / `access_mode` and the file's userspace path, while the
+ * public flow can degrade to a read-only snapshot payload that has
+ * none of those fields.
+ */
+class PadOpenTarget {
+	public function __construct(
+		public string $file,
+		public int $fileId,
+		public string $padId,
+		public string $accessMode,
+		public string $padUrl,
+		public bool $isExternal,
+		public string $originalPadUrl,
+		public string $snapshotText,
+		public string $snapshotHtml,
+		public string $url,
+		public string $cookieHeader,
+	) {
+	}
+}

--- a/lib/Service/PadOriginalLookup.php
+++ b/lib/Service/PadOriginalLookup.php
@@ -13,12 +13,20 @@ namespace OCA\EtherpadNextcloud\Service;
  * Result of looking up the original `.pad` file behind a copy. When
  * `$found` is false the other fields are unset on purpose — see the
  * authorization design in `PadMetadataService::findOriginalForCopy`.
+ *
+ * Variants:
+ *
+ * - `$found === false` → fileId and path stay null. The response is
+ *   identical for every miss path; the absence of payload data is the
+ *   authorization-leak guarantee.
+ * - `$found === true`  → fileId and path are guaranteed non-null even
+ *   though the type allows null.
  */
 class PadOriginalLookup {
 	public function __construct(
-		public bool $found,
-		public ?int $fileId = null,
-		public ?string $path = null,
+		public readonly bool $found,
+		public readonly ?int $fileId = null,
+		public readonly ?string $path = null,
 	) {
 	}
 }

--- a/lib/Service/PadOriginalLookup.php
+++ b/lib/Service/PadOriginalLookup.php
@@ -13,14 +13,6 @@ namespace OCA\EtherpadNextcloud\Service;
  * Result of looking up the original `.pad` file behind a copy. When
  * `$found` is false the other fields are unset on purpose — see the
  * authorization design in `PadMetadataService::findOriginalForCopy`.
- *
- * Variants:
- *
- * - `$found === false` → fileId and path stay null. The response is
- *   identical for every miss path; the absence of payload data is the
- *   authorization-leak guarantee.
- * - `$found === true`  → fileId and path are guaranteed non-null even
- *   though the type allows null.
  */
 class PadOriginalLookup {
 	public function __construct(

--- a/lib/Service/PadOriginalLookup.php
+++ b/lib/Service/PadOriginalLookup.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Copyright (c) 2026 Jacob Bühler
+ */
+
+namespace OCA\EtherpadNextcloud\Service;
+
+/**
+ * Result of looking up the original `.pad` file behind a copy. When
+ * `$found` is false the other fields are unset on purpose — see the
+ * authorization design in `PadMetadataService::findOriginalForCopy`.
+ */
+class PadOriginalLookup {
+	public function __construct(
+		public bool $found,
+		public ?int $fileId = null,
+		public ?string $path = null,
+	) {
+	}
+}

--- a/lib/Service/PadResolution.php
+++ b/lib/Service/PadResolution.php
@@ -13,17 +13,28 @@ namespace OCA\EtherpadNextcloud\Service;
  * Lightweight resolve result for the resolve endpoint. The file is not
  * always reachable — the not-found branch can return either fileId or
  * path depending on what the caller passed in, hence both are nullable.
- * Pad-specific fields are only meaningful when `$isPad` is true.
+ *
+ * Variants:
+ *
+ * - `$isPad === false`, fileId-only → caller asked by file ID, file did
+ *   not resolve. fileId is the requested input; path is null.
+ * - `$isPad === false`, path-only → caller asked by path, file did not
+ *   resolve or did not exist. path is the requested input; fileId is
+ *   null.
+ * - `$isPad === false`, both set → file exists but is not a `.pad`.
+ * - `$isPad === true` → fileId, path, isPadMime, accessMode, isExternal,
+ *   publicOpenUrl all populated. fileId / path are guaranteed non-null
+ *   in this branch even though the type allows null.
  */
 class PadResolution {
 	public function __construct(
-		public bool $isPad,
-		public ?int $fileId = null,
-		public ?string $path = null,
-		public bool $isPadMime = false,
-		public string $accessMode = '',
-		public bool $isExternal = false,
-		public string $publicOpenUrl = '',
+		public readonly bool $isPad,
+		public readonly ?int $fileId = null,
+		public readonly ?string $path = null,
+		public readonly bool $isPadMime = false,
+		public readonly string $accessMode = '',
+		public readonly bool $isExternal = false,
+		public readonly string $publicOpenUrl = '',
 	) {
 	}
 }

--- a/lib/Service/PadResolution.php
+++ b/lib/Service/PadResolution.php
@@ -13,18 +13,7 @@ namespace OCA\EtherpadNextcloud\Service;
  * Lightweight resolve result for the resolve endpoint. The file is not
  * always reachable — the not-found branch can return either fileId or
  * path depending on what the caller passed in, hence both are nullable.
- *
- * Variants:
- *
- * - `$isPad === false`, fileId-only → caller asked by file ID, file did
- *   not resolve. fileId is the requested input; path is null.
- * - `$isPad === false`, path-only → caller asked by path, file did not
- *   resolve or did not exist. path is the requested input; fileId is
- *   null.
- * - `$isPad === false`, both set → file exists but is not a `.pad`.
- * - `$isPad === true` → fileId, path, isPadMime, accessMode, isExternal,
- *   publicOpenUrl all populated. fileId / path are guaranteed non-null
- *   in this branch even though the type allows null.
+ * Pad-specific fields are only meaningful when `$isPad` is true.
  */
 class PadResolution {
 	public function __construct(

--- a/lib/Service/PadResolution.php
+++ b/lib/Service/PadResolution.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Copyright (c) 2026 Jacob Bühler
+ */
+
+namespace OCA\EtherpadNextcloud\Service;
+
+/**
+ * Lightweight resolve result for the resolve endpoint. The file is not
+ * always reachable — the not-found branch can return either fileId or
+ * path depending on what the caller passed in, hence both are nullable.
+ * Pad-specific fields are only meaningful when `$isPad` is true.
+ */
+class PadResolution {
+	public function __construct(
+		public bool $isPad,
+		public ?int $fileId = null,
+		public ?string $path = null,
+		public bool $isPadMime = false,
+		public string $accessMode = '',
+		public bool $isExternal = false,
+		public string $publicOpenUrl = '',
+	) {
+	}
+}

--- a/lib/Service/PadResponseService.php
+++ b/lib/Service/PadResponseService.php
@@ -83,15 +83,17 @@ class PadResponseService {
 				$payload['file_id'] = $resolution->fileId;
 			}
 			if ($resolution->path !== null) {
-				$payload['path' ] = $resolution->path;
+				$payload['path'] = $resolution->path;
 			}
 			return $payload;
 		}
 		return $this->withViewerUrl([
 			'is_pad' => true,
 			'is_pad_mime' => $resolution->isPadMime,
-			'file_id' => (int)$resolution->fileId,
-			'path' => (string)$resolution->path,
+			'file_id' => $resolution->fileId
+				?? throw new \LogicException('PadResolution::fileId must be set when isPad is true.'),
+			'path' => $resolution->path
+				?? throw new \LogicException('PadResolution::path must be set when isPad is true.'),
 			'access_mode' => $resolution->accessMode,
 			'is_external' => $resolution->isExternal,
 			'public_open_url' => $resolution->publicOpenUrl,
@@ -105,14 +107,21 @@ class PadResponseService {
 		}
 		return $this->withViewerAndEmbedUrls([
 			'found' => true,
-			'file_id' => (int)$lookup->fileId,
-			'path' => (string)$lookup->path,
+			'file_id' => $lookup->fileId
+				?? throw new \LogicException('PadOriginalLookup::fileId must be set when found is true.'),
+			'path' => $lookup->path
+				?? throw new \LogicException('PadOriginalLookup::path must be set when found is true.'),
 		]);
 	}
 
 	/** @return array<string,mixed> */
 	public function syncStatusResponse(PadSyncStatus $status): array {
 		$payload = ['status' => $status->status];
+		// inSync is intentionally emitted unconditionally: the viewer's
+		// polling loop branches on `in_sync === null` to distinguish the
+		// "no revision available" status (external / unavailable) from the
+		// regular synced/out-of-sync states. Serializing null preserves
+		// that signal.
 		$payload['in_sync'] = $status->inSync;
 		if ($status->snapshotRev !== null) {
 			$payload['snapshot_rev'] = $status->snapshotRev;

--- a/lib/Service/PadResponseService.php
+++ b/lib/Service/PadResponseService.php
@@ -52,6 +52,65 @@ class PadResponseService {
 	}
 
 	/** @return array<string,mixed> */
+	public function metaResponse(PadMeta $meta): array {
+		if (!$meta->isPad) {
+			return [
+				'is_pad' => false,
+				'file_id' => $meta->fileId,
+				'name' => $meta->name,
+				'path' => $meta->path,
+			];
+		}
+		return $this->withViewerAndEmbedUrls([
+			'is_pad' => true,
+			'is_pad_mime' => $meta->isPadMime,
+			'file_id' => $meta->fileId,
+			'name' => $meta->name,
+			'path' => $meta->path,
+			'access_mode' => $meta->accessMode,
+			'is_external' => $meta->isExternal,
+			'pad_id' => $meta->padId,
+			'pad_url' => $meta->padUrl,
+			'public_open_url' => $meta->publicOpenUrl,
+		]);
+	}
+
+	/** @return array<string,mixed> */
+	public function resolveResponse(PadResolution $resolution): array {
+		if (!$resolution->isPad) {
+			$payload = ['is_pad' => false];
+			if ($resolution->fileId !== null) {
+				$payload['file_id'] = $resolution->fileId;
+			}
+			if ($resolution->path !== null) {
+				$payload['path' ] = $resolution->path;
+			}
+			return $payload;
+		}
+		return $this->withViewerUrl([
+			'is_pad' => true,
+			'is_pad_mime' => $resolution->isPadMime,
+			'file_id' => (int)$resolution->fileId,
+			'path' => (string)$resolution->path,
+			'access_mode' => $resolution->accessMode,
+			'is_external' => $resolution->isExternal,
+			'public_open_url' => $resolution->publicOpenUrl,
+		]);
+	}
+
+	/** @return array<string,mixed> */
+	public function originalLookupResponse(PadOriginalLookup $lookup): array {
+		if (!$lookup->found) {
+			return ['found' => false];
+		}
+		return $this->withViewerAndEmbedUrls([
+			'found' => true,
+			'file_id' => (int)$lookup->fileId,
+			'path' => (string)$lookup->path,
+		]);
+	}
+
+	/** @return array<string,mixed> */
 	public function initializationResponse(PadInitializationResult $result): array {
 		return [
 			'status' => $result->status,

--- a/lib/Service/PadResponseService.php
+++ b/lib/Service/PadResponseService.php
@@ -51,19 +51,26 @@ class PadResponseService {
 		return new DataResponse($data, $status);
 	}
 
-	/** @param array<string,mixed> $data */
-	public function openResponse(array $data): DataResponse {
-		$cookieHeader = (string)($data['cookie_header'] ?? '');
-		unset($data['cookie_header']);
+	public function openResponse(PadOpenTarget $target): DataResponse {
+		$payload = [
+			'file' => $target->file,
+			'file_id' => $target->fileId,
+			'pad_id' => $target->padId,
+			'access_mode' => $target->accessMode,
+			'pad_url' => $target->padUrl,
+			'is_external' => $target->isExternal,
+			'original_pad_url' => $target->originalPadUrl,
+			'snapshot_text' => $target->snapshotText,
+			'snapshot_html' => $target->snapshotHtml,
+			'url' => $target->url,
+			'sync_url' => $this->urlGenerator->linkToRoute('etherpad_nextcloud.pad.syncById', ['fileId' => $target->fileId]),
+			'sync_status_url' => $this->urlGenerator->linkToRoute('etherpad_nextcloud.pad.syncStatusById', ['fileId' => $target->fileId]),
+			'sync_interval_seconds' => $this->appConfigService->getSyncIntervalSeconds(),
+		];
 
-		$fileId = (int)$data['file_id'];
-		$data['sync_url'] = $this->urlGenerator->linkToRoute('etherpad_nextcloud.pad.syncById', ['fileId' => $fileId]);
-		$data['sync_status_url'] = $this->urlGenerator->linkToRoute('etherpad_nextcloud.pad.syncStatusById', ['fileId' => $fileId]);
-		$data['sync_interval_seconds'] = $this->appConfigService->getSyncIntervalSeconds();
-
-		$response = new DataResponse($data);
-		if ($cookieHeader !== '') {
-			$response->addHeader('Set-Cookie', $cookieHeader);
+		$response = new DataResponse($payload);
+		if ($target->cookieHeader !== '') {
+			$response->addHeader('Set-Cookie', $target->cookieHeader);
 		}
 		return $response;
 	}

--- a/lib/Service/PadResponseService.php
+++ b/lib/Service/PadResponseService.php
@@ -111,6 +111,46 @@ class PadResponseService {
 	}
 
 	/** @return array<string,mixed> */
+	public function syncStatusResponse(PadSyncStatus $status): array {
+		$payload = ['status' => $status->status];
+		$payload['in_sync'] = $status->inSync;
+		if ($status->snapshotRev !== null) {
+			$payload['snapshot_rev'] = $status->snapshotRev;
+		}
+		if ($status->currentRev !== null) {
+			$payload['current_rev'] = $status->currentRev;
+		}
+		if ($status->reason !== null) {
+			$payload['reason'] = $status->reason;
+		}
+		return $payload;
+	}
+
+	/** @return array<string,mixed> */
+	public function syncResponse(PadSyncResult $result): array {
+		$payload = [
+			'status' => $result->status,
+			'file_id' => $result->fileId,
+			'pad_id' => $result->padId,
+			'external' => $result->external,
+			'forced' => $result->forced,
+		];
+		if ($result->snapshotRev !== null) {
+			$payload['snapshot_rev'] = $result->snapshotRev;
+		}
+		if ($result->currentRev !== null) {
+			$payload['current_rev'] = $result->currentRev;
+		}
+		if ($result->lockRetries !== null) {
+			$payload['lock_retries'] = $result->lockRetries;
+		}
+		if ($result->retryable) {
+			$payload['retryable'] = true;
+		}
+		return $payload;
+	}
+
+	/** @return array<string,mixed> */
 	public function initializationResponse(PadInitializationResult $result): array {
 		return [
 			'status' => $result->status,

--- a/lib/Service/PadResponseService.php
+++ b/lib/Service/PadResponseService.php
@@ -117,11 +117,7 @@ class PadResponseService {
 	/** @return array<string,mixed> */
 	public function syncStatusResponse(PadSyncStatus $status): array {
 		$payload = ['status' => $status->status];
-		// inSync is intentionally emitted unconditionally: the viewer's
-		// polling loop branches on `in_sync === null` to distinguish the
-		// "no revision available" status (external / unavailable) from the
-		// regular synced/out-of-sync states. Serializing null preserves
-		// that signal.
+		// Emitted unconditionally — the viewer treats null as a distinct state.
 		$payload['in_sync'] = $status->inSync;
 		if ($status->snapshotRev !== null) {
 			$payload['snapshot_rev'] = $status->snapshotRev;

--- a/lib/Service/PadResponseService.php
+++ b/lib/Service/PadResponseService.php
@@ -51,6 +51,17 @@ class PadResponseService {
 		return new DataResponse($data, $status);
 	}
 
+	/** @return array<string,mixed> */
+	public function initializationResponse(PadInitializationResult $result): array {
+		return [
+			'status' => $result->status,
+			'file' => $result->file,
+			'file_id' => $result->fileId,
+			'pad_id' => $result->padId,
+			'access_mode' => $result->accessMode,
+		];
+	}
+
 	public function openResponse(PadOpenTarget $target): DataResponse {
 		$payload = [
 			'file' => $target->file,

--- a/lib/Service/PadSyncResult.php
+++ b/lib/Service/PadSyncResult.php
@@ -21,15 +21,15 @@ namespace OCA\EtherpadNextcloud\Service;
  */
 class PadSyncResult {
 	public function __construct(
-		public string $status,
-		public int $fileId,
-		public string $padId,
-		public bool $external,
-		public bool $forced,
-		public ?int $snapshotRev = null,
-		public ?int $currentRev = null,
-		public ?int $lockRetries = null,
-		public bool $retryable = false,
+		public readonly string $status,
+		public readonly int $fileId,
+		public readonly string $padId,
+		public readonly bool $external,
+		public readonly bool $forced,
+		public readonly ?int $snapshotRev = null,
+		public readonly ?int $currentRev = null,
+		public readonly ?int $lockRetries = null,
+		public readonly bool $retryable = false,
 	) {
 	}
 }

--- a/lib/Service/PadSyncResult.php
+++ b/lib/Service/PadSyncResult.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Copyright (c) 2026 Jacob Bühler
+ */
+
+namespace OCA\EtherpadNextcloud\Service;
+
+/**
+ * Result of an authenticated sync run. Common fields are always
+ * populated; the optional ones depend on which `$status` branch fired:
+ *
+ * - STATUS_UPDATED for an external pad → `$snapshotRev` + `$lockRetries`
+ * - STATUS_UPDATED for an internal pad → `$snapshotRev` + `$lockRetries`
+ * - STATUS_UNCHANGED for an internal pad → `$snapshotRev` + `$currentRev`
+ * - STATUS_UNCHANGED for an external pad → nothing extra
+ * - STATUS_LOCKED → `$lockRetries` + `$retryable = true`
+ */
+class PadSyncResult {
+	public function __construct(
+		public string $status,
+		public int $fileId,
+		public string $padId,
+		public bool $external,
+		public bool $forced,
+		public ?int $snapshotRev = null,
+		public ?int $currentRev = null,
+		public ?int $lockRetries = null,
+		public bool $retryable = false,
+	) {
+	}
+}

--- a/lib/Service/PadSyncService.php
+++ b/lib/Service/PadSyncService.php
@@ -37,10 +37,9 @@ class PadSyncService {
 	}
 
 	/**
-	 * @return array<string,mixed>
 	 * @throws NotFoundException
 	 */
-	public function syncById(string $uid, int $fileId, bool $force): array {
+	public function syncById(string $uid, int $fileId, bool $force): PadSyncResult {
 		$node = $this->userNodeResolver->resolveUserFileNodeById($uid, $fileId);
 		$absolutePath = $this->userNodeResolver->toUserAbsolutePath($uid, $node);
 		if (!str_ends_with(strtolower($node->getName()), '.pad')) {
@@ -90,10 +89,9 @@ class PadSyncService {
 	}
 
 	/**
-	 * @return array{status:string,in_sync:null,reason:string}|array{status:string,in_sync:bool,snapshot_rev:int,current_rev:int}
 	 * @throws NotFoundException
 	 */
-	public function syncStatusById(string $uid, int $fileId): array {
+	public function syncStatusById(string $uid, int $fileId): PadSyncStatus {
 		$node = $this->userNodeResolver->resolveUserFileNodeById($uid, $fileId);
 
 		try {
@@ -108,23 +106,23 @@ class PadSyncService {
 				$this->bindingService->assertConsistentMapping($fileId, $padId, $accessMode);
 			}
 			if ($isExternal) {
-				return [
-					'status' => self::STATUS_UNAVAILABLE,
-					'in_sync' => null,
-					'reason' => 'external_no_revision',
-				];
+				return new PadSyncStatus(
+					status: self::STATUS_UNAVAILABLE,
+					inSync: null,
+					reason: 'external_no_revision',
+				);
 			}
 
 			$currentRev = $this->etherpadClient->getRevisionsCount($padId);
 			$snapshotRev = $this->padFileService->getSnapshotRevision((string)$content);
 			$inSync = $snapshotRev >= $currentRev;
 
-			return [
-				'status' => $inSync ? self::STATUS_SYNCED : self::STATUS_OUT_OF_SYNC,
-				'in_sync' => $inSync,
-				'snapshot_rev' => $snapshotRev,
-				'current_rev' => $currentRev,
-			];
+			return new PadSyncStatus(
+				status: $inSync ? self::STATUS_SYNCED : self::STATUS_OUT_OF_SYNC,
+				inSync: $inSync,
+				snapshotRev: $snapshotRev,
+				currentRev: $currentRev,
+			);
 		} catch (BindingException|PadFileFormatException|EtherpadClientException $e) {
 			throw $e;
 		} catch (\Throwable $e) {
@@ -137,7 +135,6 @@ class PadSyncService {
 		}
 	}
 
-	/** @return array{status:string,file_id:int,pad_id:string,external:true,forced:bool}|array{status:string,file_id:int,pad_id:string,external:true,forced:bool,snapshot_rev:int,lock_retries:int} */
 	private function syncExternalPad(
 		File $node,
 		int $fileId,
@@ -145,7 +142,7 @@ class PadSyncService {
 		string $padUrl,
 		string $currentContent,
 		bool $force,
-	): array {
+	): PadSyncResult {
 		if ($padUrl === '') {
 			throw new EtherpadClientException('External pad URL metadata is missing or invalid.');
 		}
@@ -156,13 +153,13 @@ class PadSyncService {
 
 		$existingText = $this->padFileService->getTextSnapshotForRestore($currentContent);
 		if ($existingText === $text) {
-			return [
-				'status' => self::STATUS_UNCHANGED,
-				'file_id' => $fileId,
-				'pad_id' => $padId,
-				'external' => true,
-				'forced' => $force,
-			];
+			return new PadSyncResult(
+				status: self::STATUS_UNCHANGED,
+				fileId: $fileId,
+				padId: $padId,
+				external: true,
+				forced: $force,
+			);
 		}
 
 		$previousRev = $this->padFileService->getSnapshotRevision($currentContent);
@@ -170,37 +167,36 @@ class PadSyncService {
 		$updatedContent = $this->padFileService->withExportSnapshot($currentContent, $text, '', $nextRev, false);
 		$lockRetries = $this->lockRetryService->putContentWithSyncLockRetry($node, $updatedContent);
 
-		return [
-			'status' => self::STATUS_UPDATED,
-			'file_id' => $fileId,
-			'pad_id' => $padId,
-			'external' => true,
-			'forced' => $force,
-			'snapshot_rev' => $nextRev,
-			'lock_retries' => $lockRetries,
-		];
+		return new PadSyncResult(
+			status: self::STATUS_UPDATED,
+			fileId: $fileId,
+			padId: $padId,
+			external: true,
+			forced: $force,
+			snapshotRev: $nextRev,
+			lockRetries: $lockRetries,
+		);
 	}
 
-	/** @return array{status:string,file_id:int,pad_id:string,external:false,forced:bool,snapshot_rev:int,current_rev:int}|array{status:string,file_id:int,pad_id:string,external:false,forced:bool,snapshot_rev:int,lock_retries:int} */
 	private function syncInternalPad(
 		File $node,
 		int $fileId,
 		string $padId,
 		string $currentContent,
 		bool $force,
-	): array {
+	): PadSyncResult {
 		$currentRev = $this->etherpadClient->getRevisionsCount($padId);
 		$snapshotRev = $this->padFileService->getSnapshotRevision($currentContent);
 		if (!$force && $snapshotRev >= $currentRev) {
-			return [
-				'status' => self::STATUS_UNCHANGED,
-				'file_id' => $fileId,
-				'pad_id' => $padId,
-				'external' => false,
-				'forced' => false,
-				'snapshot_rev' => $snapshotRev,
-				'current_rev' => $currentRev,
-			];
+			return new PadSyncResult(
+				status: self::STATUS_UNCHANGED,
+				fileId: $fileId,
+				padId: $padId,
+				external: false,
+				forced: false,
+				snapshotRev: $snapshotRev,
+				currentRev: $currentRev,
+			);
 		}
 
 		$text = $this->etherpadClient->getText($padId);
@@ -210,33 +206,32 @@ class PadSyncService {
 			$existingText = $this->padFileService->getTextSnapshotForRestore($currentContent);
 			$existingHtml = $this->padFileService->getHtmlSnapshotForRestore($currentContent);
 			if ($existingText === $text && $existingHtml === $html) {
-				return [
-					'status' => self::STATUS_UNCHANGED,
-					'file_id' => $fileId,
-					'pad_id' => $padId,
-					'external' => false,
-					'forced' => true,
-					'snapshot_rev' => $snapshotRev,
-					'current_rev' => $currentRev,
-				];
+				return new PadSyncResult(
+					status: self::STATUS_UNCHANGED,
+					fileId: $fileId,
+					padId: $padId,
+					external: false,
+					forced: true,
+					snapshotRev: $snapshotRev,
+					currentRev: $currentRev,
+				);
 			}
 		}
 
 		$updatedContent = $this->padFileService->withExportSnapshot($currentContent, $text, $html, $currentRev);
 		$lockRetries = $this->lockRetryService->putContentWithSyncLockRetry($node, $updatedContent);
 
-		return [
-			'status' => self::STATUS_UPDATED,
-			'file_id' => $fileId,
-			'pad_id' => $padId,
-			'external' => false,
-			'forced' => $force,
-			'snapshot_rev' => $currentRev,
-			'lock_retries' => $lockRetries,
-		];
+		return new PadSyncResult(
+			status: self::STATUS_UPDATED,
+			fileId: $fileId,
+			padId: $padId,
+			external: false,
+			forced: $force,
+			snapshotRev: $currentRev,
+			lockRetries: $lockRetries,
+		);
 	}
 
-	/** @return array{status:string,file_id:int,pad_id:string,external:bool,forced:bool,lock_retries:int,retryable:true} */
 	private function lockedSyncResponse(
 		LockedException $e,
 		int $fileId,
@@ -246,7 +241,7 @@ class PadSyncService {
 		bool $isExternal,
 		bool $force,
 		int $lockRetries,
-	): array {
+	): PadSyncResult {
 		$this->logger->info('Pad sync deferred because .pad file is locked', [
 			'app' => 'etherpad_nextcloud',
 			'fileId' => $fileId,
@@ -259,14 +254,14 @@ class PadSyncService {
 			'exception' => $e,
 		]);
 
-		return [
-			'status' => self::STATUS_LOCKED,
-			'file_id' => $fileId,
-			'pad_id' => $padId,
-			'external' => $isExternal,
-			'forced' => $force,
-			'lock_retries' => $lockRetries,
-			'retryable' => true,
-		];
+		return new PadSyncResult(
+			status: self::STATUS_LOCKED,
+			fileId: $fileId,
+			padId: $padId,
+			external: $isExternal,
+			forced: $force,
+			lockRetries: $lockRetries,
+			retryable: true,
+		);
 	}
 }

--- a/lib/Service/PadSyncStatus.php
+++ b/lib/Service/PadSyncStatus.php
@@ -17,11 +17,11 @@ namespace OCA\EtherpadNextcloud\Service;
  */
 class PadSyncStatus {
 	public function __construct(
-		public string $status,
-		public ?bool $inSync = null,
-		public ?int $snapshotRev = null,
-		public ?int $currentRev = null,
-		public ?string $reason = null,
+		public readonly string $status,
+		public readonly ?bool $inSync = null,
+		public readonly ?int $snapshotRev = null,
+		public readonly ?int $currentRev = null,
+		public readonly ?string $reason = null,
 	) {
 	}
 }

--- a/lib/Service/PadSyncStatus.php
+++ b/lib/Service/PadSyncStatus.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Copyright (c) 2026 Jacob Bühler
+ */
+
+namespace OCA\EtherpadNextcloud\Service;
+
+/**
+ * Result of the lightweight sync-status check used by the viewer's
+ * polling loop. The unavailable / external branches set `$inSync = null`
+ * and supply `$reason`; the live branches set `$inSync = bool` and the
+ * `$snapshotRev` / `$currentRev` pair instead.
+ */
+class PadSyncStatus {
+	public function __construct(
+		public string $status,
+		public ?bool $inSync = null,
+		public ?int $snapshotRev = null,
+		public ?int $currentRev = null,
+		public ?string $reason = null,
+	) {
+	}
+}

--- a/lib/Service/PublicPadOpenTarget.php
+++ b/lib/Service/PublicPadOpenTarget.php
@@ -11,12 +11,12 @@ namespace OCA\EtherpadNextcloud\Service;
 
 class PublicPadOpenTarget {
 	public function __construct(
-		public string $url,
-		public string $originalPadUrl,
-		public string $cookieHeader,
-		public bool $isReadOnlySnapshot,
-		public string $snapshotText,
-		public string $snapshotHtml,
+		public readonly string $url,
+		public readonly string $originalPadUrl,
+		public readonly string $cookieHeader,
+		public readonly bool $isReadOnlySnapshot,
+		public readonly string $snapshotText,
+		public readonly string $snapshotHtml,
 	) {
 	}
 }

--- a/tests/phpunit/unit/PadInitializationServiceTest.php
+++ b/tests/phpunit/unit/PadInitializationServiceTest.php
@@ -50,9 +50,9 @@ class PadInitializationServiceTest extends TestCase {
 		$result = (new PadInitializationService($padFileService, $padPaths, $userNodeResolver, $bootstrap))
 			->initializeByPath('alice', '/Existing.pad');
 
-		$this->assertSame(PadInitializationService::STATUS_ALREADY_INITIALIZED, $result['status']);
-		$this->assertSame('/Existing.pad', $result['file']);
-		$this->assertSame(42, $result['file_id']);
+		$this->assertSame(PadInitializationService::STATUS_ALREADY_INITIALIZED, $result->status);
+		$this->assertSame('/Existing.pad', $result->file);
+		$this->assertSame(42, $result->fileId);
 	}
 
 	public function testInitializeByIdResolvesFileAndReadsContent(): void {
@@ -85,9 +85,9 @@ class PadInitializationServiceTest extends TestCase {
 		$result = (new PadInitializationService($padFileService, $this->createMock(PadPathService::class), $userNodeResolver, $bootstrap))
 			->initializeById('alice', 42);
 
-		$this->assertSame(PadInitializationService::STATUS_ALREADY_INITIALIZED, $result['status']);
-		$this->assertSame('/Existing.pad', $result['file']);
-		$this->assertSame(42, $result['file_id']);
+		$this->assertSame(PadInitializationService::STATUS_ALREADY_INITIALIZED, $result->status);
+		$this->assertSame('/Existing.pad', $result->file);
+		$this->assertSame(42, $result->fileId);
 	}
 
 	public function testInitializeByPathRejectsEmptyPath(): void {
@@ -130,13 +130,11 @@ class PadInitializationServiceTest extends TestCase {
 		$result = (new PadInitializationService($padFileService, $this->createMock(PadPathService::class), $userNodeResolver, $bootstrap))
 			->initialize('alice', $file, 'content');
 
-		$this->assertSame([
-			'status' => PadInitializationService::STATUS_ALREADY_INITIALIZED,
-			'file' => '/Existing.pad',
-			'file_id' => 42,
-			'pad_id' => 'g.ABC$pad',
-			'access_mode' => BindingService::ACCESS_PUBLIC,
-		], $result);
+		$this->assertSame(PadInitializationService::STATUS_ALREADY_INITIALIZED, $result->status);
+		$this->assertSame('/Existing.pad', $result->file);
+		$this->assertSame(42, $result->fileId);
+		$this->assertSame('g.ABC$pad', $result->padId);
+		$this->assertSame(BindingService::ACCESS_PUBLIC, $result->accessMode);
 	}
 
 	public function testInitializeBootstrapsMissingFrontmatter(): void {
@@ -173,12 +171,10 @@ class PadInitializationServiceTest extends TestCase {
 		$result = (new PadInitializationService($padFileService, $this->createMock(PadPathService::class), $userNodeResolver, $bootstrap))
 			->initialize('alice', $file, 'legacy-content');
 
-		$this->assertSame([
-			'status' => PadInitializationService::STATUS_INITIALIZED,
-			'file' => '/Legacy.pad',
-			'file_id' => 42,
-			'pad_id' => 'g.XYZ$pad',
-			'access_mode' => BindingService::ACCESS_PROTECTED,
-		], $result);
+		$this->assertSame(PadInitializationService::STATUS_INITIALIZED, $result->status);
+		$this->assertSame('/Legacy.pad', $result->file);
+		$this->assertSame(42, $result->fileId);
+		$this->assertSame('g.XYZ$pad', $result->padId);
+		$this->assertSame(BindingService::ACCESS_PROTECTED, $result->accessMode);
 	}
 }

--- a/tests/phpunit/unit/PadMetadataServiceTest.php
+++ b/tests/phpunit/unit/PadMetadataServiceTest.php
@@ -52,18 +52,16 @@ class PadMetadataServiceTest extends TestCase {
 		$result = $this->buildService($padFileService, userNodeResolver: $userNodeResolver, lockRetryService: $lockRetryService, etherpadClient: $etherpadClient)
 			->metaById('alice', 138);
 
-		$this->assertSame([
-			'is_pad' => true,
-			'is_pad_mime' => true,
-			'file_id' => 138,
-			'name' => 'External.pad',
-			'path' => '/External.pad',
-			'access_mode' => BindingService::ACCESS_PUBLIC,
-			'is_external' => true,
-			'pad_id' => 'ext.remote',
-			'pad_url' => 'https://pad.example.test/p/External',
-			'public_open_url' => 'https://pad.example.test/p/External',
-		], $result);
+		$this->assertTrue($result->isPad);
+		$this->assertTrue($result->isPadMime);
+		$this->assertSame(138, $result->fileId);
+		$this->assertSame('External.pad', $result->name);
+		$this->assertSame('/External.pad', $result->path);
+		$this->assertSame(BindingService::ACCESS_PUBLIC, $result->accessMode);
+		$this->assertTrue($result->isExternal);
+		$this->assertSame('ext.remote', $result->padId);
+		$this->assertSame('https://pad.example.test/p/External', $result->padUrl);
+		$this->assertSame('https://pad.example.test/p/External', $result->publicOpenUrl);
 	}
 
 	public function testResolveReturnsFalseWhenFileIdIsMissing(): void {
@@ -75,7 +73,8 @@ class PadMetadataServiceTest extends TestCase {
 		$result = $this->buildService(userNodeResolver: $userNodeResolver)
 			->resolve('alice', 404);
 
-		$this->assertSame(['is_pad' => false, 'file_id' => 404], $result);
+		$this->assertFalse($result->isPad);
+		$this->assertSame(404, $result->fileId);
 	}
 
 	public function testResolveReturnsPublicOpenUrlForInternalPublicPad(): void {
@@ -110,15 +109,13 @@ class PadMetadataServiceTest extends TestCase {
 		$result = $this->buildService($padFileService, userNodeResolver: $userNodeResolver, etherpadClient: $etherpadClient)
 			->resolve('alice', 138);
 
-		$this->assertSame([
-			'is_pad' => true,
-			'is_pad_mime' => true,
-			'file_id' => 138,
-			'path' => '/Public.pad',
-			'access_mode' => BindingService::ACCESS_PUBLIC,
-			'is_external' => false,
-			'public_open_url' => 'https://pad.example.test/p/g.ABC$pad',
-		], $result);
+		$this->assertTrue($result->isPad);
+		$this->assertTrue($result->isPadMime);
+		$this->assertSame(138, $result->fileId);
+		$this->assertSame('/Public.pad', $result->path);
+		$this->assertSame(BindingService::ACCESS_PUBLIC, $result->accessMode);
+		$this->assertFalse($result->isExternal);
+		$this->assertSame('https://pad.example.test/p/g.ABC$pad', $result->publicOpenUrl);
 	}
 
 	public function testFindOriginalForCopyReturnsFoundWhenBoundFileIsReadableByRequester(): void {
@@ -148,7 +145,9 @@ class PadMetadataServiceTest extends TestCase {
 			bindingService: $bindingService,
 		)->findOriginalForCopy('alice', 701);
 
-		$this->assertSame(['found' => true, 'file_id' => 42, 'path' => '/Folder/Original.pad'], $result);
+		$this->assertTrue($result->found);
+		$this->assertSame(42, $result->fileId);
+		$this->assertSame('/Folder/Original.pad', $result->path);
 	}
 
 	public function testFindOriginalForCopyMissesWhenBoundFileNotInRequestersUserspace(): void {
@@ -182,7 +181,7 @@ class PadMetadataServiceTest extends TestCase {
 			bindingService: $bindingService,
 		)->findOriginalForCopy('alice', 702);
 
-		$this->assertSame(['found' => false], $result);
+		$this->assertFalse($result->found);
 	}
 
 	public function testFindOriginalForCopyMissesWhenNoBindingForPadId(): void {
@@ -203,7 +202,7 @@ class PadMetadataServiceTest extends TestCase {
 			bindingService: $bindingService,
 		)->findOriginalForCopy('alice', 703);
 
-		$this->assertSame(['found' => false], $result);
+		$this->assertFalse($result->found);
 	}
 
 	public function testFindOriginalForCopyMissesForExternalPadId(): void {
@@ -226,7 +225,7 @@ class PadMetadataServiceTest extends TestCase {
 			bindingService: $bindingService,
 		)->findOriginalForCopy('alice', 704);
 
-		$this->assertSame(['found' => false], $result);
+		$this->assertFalse($result->found);
 	}
 
 	public function testFindOriginalForCopyMissesForNonPadFile(): void {
@@ -245,7 +244,7 @@ class PadMetadataServiceTest extends TestCase {
 			bindingService: $bindingService,
 		)->findOriginalForCopy('alice', 705);
 
-		$this->assertSame(['found' => false], $result);
+		$this->assertFalse($result->found);
 	}
 
 	public function testFindOriginalForCopyMissesWhenOrphanResolverThrows(): void {
@@ -260,7 +259,7 @@ class PadMetadataServiceTest extends TestCase {
 			bindingService: $bindingService,
 		)->findOriginalForCopy('alice', 706);
 
-		$this->assertSame(['found' => false], $result);
+		$this->assertFalse($result->found);
 	}
 
 	public function testFindOriginalForCopyMissesWhenBindingPointsAtSameFile(): void {
@@ -284,7 +283,7 @@ class PadMetadataServiceTest extends TestCase {
 			bindingService: $bindingService,
 		)->findOriginalForCopy('alice', 707);
 
-		$this->assertSame(['found' => false], $result);
+		$this->assertFalse($result->found);
 	}
 
 	private function buildPadNode(int $fileId, string $name, string $content): File {

--- a/tests/phpunit/unit/PadResponseServiceTest.php
+++ b/tests/phpunit/unit/PadResponseServiceTest.php
@@ -49,11 +49,20 @@ class PadResponseServiceTest extends TestCase {
 		$appConfigService = $this->createMock(AppConfigService::class);
 		$appConfigService->method('getSyncIntervalSeconds')->willReturn(45);
 
-		$response = (new PadResponseService($urlGenerator, $appConfigService, $this->l10nEcho()))->openResponse([
-			'file_id' => 42,
-			'url' => 'https://pad.example.test/p/test',
-			'cookie_header' => 'sessionID=s.test; Path=/',
-		]);
+		$target = new \OCA\EtherpadNextcloud\Service\PadOpenTarget(
+			file: '/Test.pad',
+			fileId: 42,
+			padId: 'test',
+			accessMode: 'protected',
+			padUrl: 'https://pad.example.test/p/test',
+			isExternal: false,
+			originalPadUrl: '',
+			snapshotText: '',
+			snapshotHtml: '',
+			url: 'https://pad.example.test/p/test',
+			cookieHeader: 'sessionID=s.test; Path=/',
+		);
+		$response = (new PadResponseService($urlGenerator, $appConfigService, $this->l10nEcho()))->openResponse($target);
 
 		$data = $response->getData();
 		$this->assertArrayNotHasKey('cookie_header', $data);

--- a/tests/phpunit/unit/PadSyncServiceTest.php
+++ b/tests/phpunit/unit/PadSyncServiceTest.php
@@ -42,11 +42,9 @@ class PadSyncServiceTest extends TestCase {
 		$result = $this->buildService($padFileService, $userNodeResolver, $bindingService)
 			->syncStatusById('alice', 138);
 
-		$this->assertSame([
-			'status' => PadSyncService::STATUS_UNAVAILABLE,
-			'in_sync' => null,
-			'reason' => 'external_no_revision',
-		], $result);
+		$this->assertSame(PadSyncService::STATUS_UNAVAILABLE, $result->status);
+		$this->assertNull($result->inSync);
+		$this->assertSame('external_no_revision', $result->reason);
 	}
 
 	public function testSyncStatusReportsOutOfSyncInternalPad(): void {
@@ -85,12 +83,10 @@ class PadSyncServiceTest extends TestCase {
 		$result = $this->buildService($padFileService, $userNodeResolver, $bindingService, $etherpadClient)
 			->syncStatusById('alice', 138);
 
-		$this->assertSame([
-			'status' => PadSyncService::STATUS_OUT_OF_SYNC,
-			'in_sync' => false,
-			'snapshot_rev' => 3,
-			'current_rev' => 5,
-		], $result);
+		$this->assertSame(PadSyncService::STATUS_OUT_OF_SYNC, $result->status);
+		$this->assertFalse($result->inSync);
+		$this->assertSame(3, $result->snapshotRev);
+		$this->assertSame(5, $result->currentRev);
 	}
 
 	public function testSyncExternalPadStoresOnlyTextSnapshot(): void {
@@ -151,15 +147,13 @@ class PadSyncServiceTest extends TestCase {
 		$result = $this->buildService($padFileService, $userNodeResolver, $bindingService, $etherpadClient, $lockRetryService)
 			->syncById('alice', 138, true);
 
-		$this->assertSame([
-			'status' => PadSyncService::STATUS_UPDATED,
-			'file_id' => 138,
-			'pad_id' => 'ext.remote',
-			'external' => true,
-			'forced' => true,
-			'snapshot_rev' => 5,
-			'lock_retries' => 1,
-		], $result);
+		$this->assertSame(PadSyncService::STATUS_UPDATED, $result->status);
+		$this->assertSame(138, $result->fileId);
+		$this->assertSame('ext.remote', $result->padId);
+		$this->assertTrue($result->external);
+		$this->assertTrue($result->forced);
+		$this->assertSame(5, $result->snapshotRev);
+		$this->assertSame(1, $result->lockRetries);
 	}
 
 	private function buildService(


### PR DESCRIPTION
Closes #18.

Replaces the associative-array + \`array{...}\`-PHPDoc shapes that the internal pad services returned with typed value objects. Mirrors how \`PublicPadOpenService\` already returns \`PublicPadOpenTarget\`.

## Why value objects

- **No typo / wrong-key surface.** \`\$result->fileId\` is a real property; \`\$result['fileId']\` (vs the correct \`['file_id']\`) used to silently return \`null\`.
- **Real typed contracts.** Each return value declares its type up front; the PHPDoc \`array{...}\` shapes drift was no longer visible to the static analysers.
- **Cleaner controller wiring.** Lambdas type-hint the VO directly; the response service has named helpers per VO (\`metaResponse\`, \`syncResponse\`, …) that build the wire payload in one place.

## What stays exactly the same

Endpoint response shapes are byte-identical to before. The frontend (viewer, embed, files-main) does not need any change.

## Refactor surface

Six new value objects, all under \`OCA\\EtherpadNextcloud\\Service\\\`:

| Service | Old return shape | New value object |
|---|---|---|
| \`PadOpenService::openByPath / openById\` | array of 11 fields | \`PadOpenTarget\` |
| \`PadInitializationService::initialize* \` | array of 5 fields | \`PadInitializationResult\` |
| \`PadMetadataService::metaById\` | union of two shapes | \`PadMeta\` (with \`isPad\` discriminator) |
| \`PadMetadataService::resolve\` | union of two shapes | \`PadResolution\` (with \`isPad\` discriminator) |
| \`PadMetadataService::findOriginalForCopy\` | union of two shapes | \`PadOriginalLookup\` (with \`found\` discriminator) |
| \`PadSyncService::syncStatusById\` | union of two shapes | \`PadSyncStatus\` |
| \`PadSyncService::syncById\` (with internal helpers) | five overlapping shapes | \`PadSyncResult\` |

\`PadResponseService\` exposes a matching helper for each: \`openResponse\`, \`initializationResponse\`, \`metaResponse\`, \`resolveResponse\`, \`originalLookupResponse\`, \`syncStatusResponse\`, \`syncResponse\`.

## Commits

Four logical steps, each independently tested:

1. **\`PadOpenTarget\`** — authenticated open path (mirrors the existing public-pad target).
2. **\`PadInitializationResult\`** — initialise-by-path / by-id flow.
3. **\`PadMeta\` / \`PadResolution\` / \`PadOriginalLookup\`** — three VOs across the metadata service. Keeps the discriminator-with-optional-fields shape that already worked, just typed.
4. **\`PadSyncStatus\` / \`PadSyncResult\`** — sync-status + sync result; the most variant-rich service (locked retry / external / internal × forced / unchanged). The response helper only emits the keys that were actually set, preserving the byte-level JSON shape.

## Why some VOs allow nullable fields instead of subclassing

PHP doesn't have nice sealed unions. Two design points worth noting:

- For \`PadMeta\` / \`PadResolution\` / \`PadOriginalLookup\` / \`PadSyncStatus\` the discriminator (\`isPad\` / \`found\` / \`status\`) plus nullable fields stays consistent with how \`PublicPadOpenTarget\` already mixed the snapshot flag with optional fields. Adding subclasses would force every caller to type-switch on the variant for no real ergonomic gain.
- For \`PadSyncResult\` the five variants share six common fields and three optional ones; subclasses would have been mostly duplicate plus three thin specialisations.

If we later regret this, splitting them is a localised change.

## Tests

- PHP 354 → 354. The shape of the wire-level response is unchanged, so endpoint-level tests in \`PadControllerTest\` work without modification. The service-level tests in \`PadInitializationServiceTest\`, \`PadMetadataServiceTest\`, \`PadSyncServiceTest\`, and \`PadResponseServiceTest\` were updated to read VO properties instead of array offsets.
- Assertion count grew (1471 → 1508) because property-based reads tend to be one assertion per field instead of one identical-array assertion.

## Manual verification

- [ ] Open a `.pad` in the viewer → unchanged behaviour.
- [ ] Polling sync-status returns the same JSON the viewer reads (`status`, `in_sync`, `snapshot_rev`, `current_rev`).
- [ ] Trigger a sync force / unchanged / locked-retry path — payload shape identical to before.