### PR TITLE
Refactor lifecycle service after external pad binding removal

### DIFF
--- a/lib/Service/BindingService.php
+++ b/lib/Service/BindingService.php
@@ -185,6 +185,11 @@ class BindingService {
 		}
 	}
 
+	/**
+	 * Transitions `pending_delete → active` only. Any other state raises
+	 * `BindingStateConflictException` so concurrent restores can't double-flip.
+	 * For the no-binding-row recovery path use `createBinding` instead.
+	 */
 	public function markRestored(int $fileId, string $newPadId): void {
 		$qb = $this->db->getQueryBuilder();
 		$qb->update(self::TABLE)

--- a/lib/Service/LifecycleService.php
+++ b/lib/Service/LifecycleService.php
@@ -61,9 +61,6 @@ class LifecycleService {
 			return $this->buildSkippedResult('binding_not_found', $fileId);
 		}
 		$padId = (string)$binding['pad_id'];
-		if (str_starts_with($padId, 'ext.')) {
-			return $this->buildSkippedResult('external_pad', $fileId, $padId);
-		}
 		if ((string)$binding['state'] !== BindingService::STATE_ACTIVE) {
 			return $this->buildSkippedResult('binding_not_active', $fileId, $padId);
 		}
@@ -92,11 +89,6 @@ class LifecycleService {
 			if ($canPersistSnapshotToFile && $currentContent !== '') {
 				$updatedContent = null;
 				try {
-					$parsed = $this->padFileService->parsePadFile($currentContent);
-					$frontmatter = $parsed['frontmatter'];
-					if ($this->padFileService->isExternalFrontmatter($frontmatter, $padId)) {
-						return $this->buildSkippedResult('external_pad', $fileId, $padId);
-					}
 					$snapshot = $this->etherpadClient->getText($padId);
 					$html = $this->etherpadClient->getHTML($padId);
 					$revision = $this->etherpadClient->getRevisionsCount($padId);
@@ -212,9 +204,6 @@ class LifecycleService {
 		}
 		$bindingState = (string)$binding['state'];
 		$oldPadId = (string)$binding['pad_id'];
-		if (str_starts_with($oldPadId, 'ext.')) {
-			return $this->buildSkippedResult('external_pad', $fileId, $oldPadId);
-		}
 		if ($bindingState !== BindingService::STATE_PENDING_DELETE) {
 			return $this->buildSkippedResult('binding_not_pending_delete', $fileId, $oldPadId);
 		}
@@ -233,22 +222,7 @@ class LifecycleService {
 			$snapshot = $this->padFileService->getTextSnapshotForRestore($currentContent);
 			$htmlSnapshot = $this->padFileService->getHtmlSnapshotForRestore($currentContent);
 
-			if (trim($htmlSnapshot) !== '') {
-				try {
-					$this->etherpadClient->setHTML($newPadId, $htmlSnapshot);
-				} catch (\Throwable $htmlRestoreError) {
-					$this->logger->warning('HTML restore failed, falling back to plain text snapshot.', [
-						'app' => 'etherpad_nextcloud',
-						'fileId' => $fileId,
-						'oldPadId' => $oldPadId,
-						'newPadId' => $newPadId,
-						'exception' => $htmlRestoreError,
-					]);
-					$this->etherpadClient->setText($newPadId, $snapshot);
-				}
-			} else {
-				$this->etherpadClient->setText($newPadId, $snapshot);
-			}
+			$this->restoreSnapshotToManagedPad($fileId, $oldPadId, $newPadId, $snapshot, $htmlSnapshot);
 
 			$updatedContent = $this->padFileService->withStateAndSnapshot(
 				$currentContent,
@@ -467,9 +441,12 @@ class LifecycleService {
 		return str_ends_with(strtolower($file->getName()), '.pad');
 	}
 
-	private function isExternalPadFile(File $file): bool {
+	/** Callers that already have `getContent()` can pass it to skip a re-read. */
+	private function isExternalPadFile(File $file, ?string $content = null): bool {
 		try {
-			$content = (string)$file->getContent();
+			if ($content === null) {
+				$content = (string)$file->getContent();
+			}
 			$parsed = $this->padFileService->parsePadFile($content);
 			$frontmatter = $parsed['frontmatter'];
 			$meta = $this->padFileService->extractPadMetadata($frontmatter);

--- a/tests/phpunit/unit/LifecycleServiceTest.php
+++ b/tests/phpunit/unit/LifecycleServiceTest.php
@@ -72,19 +72,8 @@ class LifecycleServiceTest extends TestCase {
 			);
 
 		$padFileService = $this->createMock(PadFileService::class);
-		$padFileService->expects($this->once())
-			->method('parsePadFile')
-			->with('doc-current')
-			->willReturn([
-				'frontmatter' => [
-					'pad_id' => $padId,
-					'access_mode' => BindingService::ACCESS_PUBLIC,
-				],
-				'body' => '',
-			]);
-		$padFileService->expects($this->once())
-			->method('isExternalFrontmatter')
-			->willReturn(false);
+		$padFileService->expects($this->never())->method('parsePadFile');
+		$padFileService->expects($this->never())->method('isExternalFrontmatter');
 		$padFileService->expects($this->once())
 			->method('withExportSnapshot')
 			->with('doc-current', 'snapshot-text', '<p>snapshot-html</p>', 7)
@@ -176,58 +165,6 @@ class LifecycleServiceTest extends TestCase {
 		$result = $service->handleTrash($file);
 		$this->assertSame(LifecycleService::RESULT_SKIPPED, $result['status']);
 		$this->assertSame('binding_state_transition_conflict', $result['reason']);
-		$this->assertSame($fileId, $result['file_id']);
-		$this->assertSame($padId, $result['pad_id']);
-	}
-
-	public function testHandleTrashTreatsExtPrefixAsExternalWhenMetadataIsIncomplete(): void {
-		$fileId = 64;
-		$padId = 'ext.incomplete';
-
-		$bindingService = $this->createMock(BindingService::class);
-		$bindingService->expects($this->once())
-			->method('findByFileId')
-			->with($fileId)
-			->willReturn([
-				'file_id' => $fileId,
-				'pad_id' => $padId,
-				'access_mode' => BindingService::ACCESS_PUBLIC,
-				'state' => BindingService::STATE_ACTIVE,
-			]);
-		$bindingService->expects($this->never())->method('deleteByFileId');
-		$bindingService->expects($this->never())->method('markPendingDelete');
-
-		$padFileService = $this->createMock(PadFileService::class);
-		$padFileService->expects($this->never())->method('parsePadFile');
-		$padFileService->expects($this->never())->method('isExternalFrontmatter');
-		$padFileService->expects($this->never())->method('withExportSnapshot');
-
-		$etherpadClient = $this->createMock(EtherpadClient::class);
-		$etherpadClient->expects($this->never())->method('getText');
-		$etherpadClient->expects($this->never())->method('getHTML');
-		$etherpadClient->expects($this->never())->method('getRevisionsCount');
-		$etherpadClient->expects($this->never())->method('deletePad');
-
-		$file = $this->createMock(File::class);
-		$file->method('getId')->willReturn($fileId);
-		$file->method('getName')->willReturn('External.pad');
-		$file->expects($this->never())->method('getContent');
-		$file->expects($this->never())->method('putContent');
-
-		$logger = $this->createMock(LoggerInterface::class);
-		$logger->expects($this->never())->method('warning');
-
-		$result = (new LifecycleService(
-			$bindingService,
-			$padFileService,
-			$etherpadClient,
-			$this->buildDeleteOnTrashEnabledConfig(),
-			$logger,
-			$this->createMock(ISecureRandom::class),
-		))->handleTrash($file);
-
-		$this->assertSame(LifecycleService::RESULT_SKIPPED, $result['status']);
-		$this->assertSame('external_pad', $result['reason']);
 		$this->assertSame($fileId, $result['file_id']);
 		$this->assertSame($padId, $result['pad_id']);
 	}


### PR DESCRIPTION
Closes #37.

Cleanup of the trash / restore flows that #36 left behind once external pads stopped having a binding row.

## What changes

### `LifecycleService::handleTrash`

- **Removed dead defence:** the `str_starts_with($binding['pad_id'], 'ext.')` early-return is gone. `Version000003Date20260512230000` deletes those rows at upgrade time, so a binding in this flow is by definition a managed internal pad. The check was a vestigial from-before-the-migration guard.
- **Removed inline re-parse:** the snapshot block used to re-parse the `.pad` content and call `isExternalFrontmatter()` again. With the binding-active invariant, that branch was unreachable. One fewer `parsePadFile()` on the happy path.
- `isExternalPadFile()` accepts an optional pre-read `$content` so the no-binding branch doesn't re-read what later code already loaded.

### `LifecycleService::handleRestore`

- Same dead `ext.*` binding-side check removed.
- The pending-delete restore path used to inline its own `setHTML`-then-`setText` fallback. That logic already lives in `restoreSnapshotToManagedPad()`, which the no-binding restore path (`restoreWithoutBinding`) uses. Call site collapsed to the shared helper — the two restore flows now share the snapshot-push step.

### `BindingService::markRestored`

Docblock added (the bullet-4 ask in the issue): explicit about the `pending_delete → active` contract, why that state predicate is there (concurrent-restore guard via row-count check), and that the no-row recovery case uses `createBinding` via `LifecycleService::restoreWithoutBinding` instead.

### `LifecycleService::restoreWithoutBinding`

Kept untouched — its frontmatter `pad_id`-based `ext.*` check (not a binding check) is still the only authoritative external-pad detection on that path.

## Why these changes are safe

- The migration `Version000003Date20260512230000` runs on app enable and removes every `ext.%` binding row. New external pad creates skip the binding step entirely (`PadCreationService::createFromUrl` doesn't call `createBinding` for ext pads). So no code path produces an `ext.*` binding row.
- The trash / restore flows are still gated by `isPadFile()` and the binding lookup; only the redundant secondary checks are gone.

## Tests

- PHP 354 → 353 (−1).
  - `testHandleTrashTreatsExtPrefixAsExternalWhenMetadataIsIncomplete` removed: the state it asserted on cannot exist after the migration.
  - `testHandleTrashMarksPendingDeleteWhenEtherpadDeleteFails` updated to expect zero `parsePadFile` / `isExternalFrontmatter` calls on the binding-active path; the `withExportSnapshot` expectation is unchanged.
- All other tests pass unchanged.

## Numbers

- `LifecycleService` net −13 LOC, `LifecycleServiceTest` net −66 LOC (the removed test + the trimmed expectations).
- `BindingService` +13 LOC (the docblock).

## Manual verification

- [ ] Trash an internal pad → goes to trash, Etherpad pad deleted, binding cleared. No regression.
- [ ] Trash an external `.pad` → file goes to trash, remote Etherpad pad untouched, response `status: skipped, reason: external_pad`.
- [ ] Restore a trashed internal pad (still in pending_delete window) → new pad provisioned, snapshot replayed, viewer opens with content.
- [ ] Restore a `.pad` file with no binding row (WebDAV upload of an old backup, `occ files:scan`) → `restoreWithoutBinding` flow takes over, new pad provisioned, viewer opens.