### PR TITLE
Pad templates via NC /Templates folder with placeholder substitution

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -12,6 +12,7 @@ return ['routes' => [
 	['name' => 'pad#create', 'url' => '/api/v1/pads', 'verb' => 'POST'],
 	['name' => 'pad#createByParent', 'url' => '/api/v1/pads/create-by-parent', 'verb' => 'POST'],
 	['name' => 'pad#createFromUrl', 'url' => '/api/v1/pads/from-url', 'verb' => 'POST'],
+	['name' => 'pad#createFromTemplate', 'url' => '/api/v1/pads/from-template', 'verb' => 'POST'],
 	['name' => 'pad#metaById', 'url' => '/api/v1/pads/meta-by-id/{fileId}', 'verb' => 'GET'],
 	['name' => 'pad#resolveById', 'url' => '/api/v1/pads/resolve', 'verb' => 'GET'],
 	['name' => 'pad#open', 'url' => '/api/v1/pads/open', 'verb' => 'POST'],

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -113,6 +113,15 @@ Base: `/apps/etherpad_nextcloud`
     - external `/export/txt` responses are size-limited (5 MiB hard limit)
     - external sync accepts only safe text-oriented response content-types
 
+- `POST /api/v1/pads/from-template`
+  - Controller: `PadController::createFromTemplate`
+  - Params:
+    - `file` (required) — target path. Body placeholders (`{{date}}`, `{{user}}` etc.) are resolved server-side.
+    - `templateFileId` (required) — id of any `.pad` in the user's userspace; doesn't have to live in the *Templates* folder.
+  - Purpose: create-from-template path for custom frontends that need filename templating or want to pick the source file outside `/Templates`. Bypasses NC's `TemplateManager`.
+  - Behaviour: resolves `{{...}}` in `file` and template body, provisions a fresh Etherpad pad, writes the new `.pad` content + snapshot, creates the binding. Returns `viewer_url` alongside the regular create response shape.
+  - Errors: 400 (non-pad template / external template / empty), 404 (template id not found in userspace), 409 (filename collision).
+
 - `POST /api/v1/pads/open`
   - Controller: `PadController::open`
   - Params: `file=/path/file.pad`

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -34,19 +34,11 @@ Placeholders in the **body** and the **filename** are resolved when the new pad 
 
 Unknown directives stay as literal text (`{{forecast}}` → `{{forecast}}`). Unparseable date expressions also stay as literal so the user can fix the template without losing the file.
 
-## Filename templates
+## Filename templates (not supported in v1)
 
-Placeholders work in the template's filename too. A template named:
+Placeholders in the template's filename are **not** rewritten today. Nextcloud's `+ New pad` flow asks the user for a filename **before** showing the template picker, and `TemplateManager::createFromTemplate` re-fetches the new file by that user-typed path *after* our event fires. Renaming during the event causes a `NotFoundException` and NC returns 403 to the client.
 
-```
-Protokoll {{date:next monday|d.m.Y}}.pad
-```
-
-…produces a new file `Protokoll 18.05.2026.pad` when used on a Sunday — **regardless** of what filename the user types when Nextcloud first asks for one. Nextcloud's flow is filename-first, template-picker-second, so the user types some placeholder name (`Untitled`, or whatever the picker pre-fills), then picks the template. After the copy, the plugin renames the target to the resolved template filename.
-
-If the resolved name collides with an existing file in the target folder, Nextcloud's standard `(1)`, `(2)` suffix kicks in.
-
-If the template's filename contains no `{{...}}` token, the user's typed filename is kept as-is.
+Realistic workaround for now: type a meaningful filename when prompted. The body still gets its `{{date}}` / `{{user}}` placeholders resolved.
 
 ## Caveats
 

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -47,6 +47,43 @@ Placeholders in the template's filename are **not** rewritten. Nextcloud's `+ Ne
 
 The new file ends up at the name the user types into NC's filename dialog. Body placeholders still get resolved.
 
+## API for custom frontends
+
+Custom frontends that don't go through Nextcloud's native `+ New pad` menu can call our own endpoint instead, which bypasses NC's `TemplateManager` entirely:
+
+```
+POST /index.php/apps/etherpad_nextcloud/api/v1/pads/from-template
+Content-Type: application/x-www-form-urlencoded
+requesttoken: <csrf>
+
+file=/Meetings/Protokoll {{date:next monday|d.m.Y}}.pad&templateFileId=1234
+```
+
+Differences from the NC-native flow:
+
+- **Filename placeholders are applied.** Pass `{{date}}` / `{{user}}` tokens in `file` and the endpoint resolves them on the server side before creating the file. The NC web flow can't do this because of how `TemplateManager` re-fetches by the user-typed path.
+- **Any `.pad` in the user's userspace works as a template.** Pass any `templateFileId` the user has read access to; the source doesn't have to live in the *Templates* folder. Caller-side filtering (current folder, ancestor scan, explicit team list) is up to the frontend.
+- **Single atomic call.** The endpoint provisions the pad, writes the file, creates the binding, and returns `file_id` + `pad_id` + `viewer_url` in one response.
+
+Response shape on success (200):
+
+```json
+{
+  "file": "/Meetings/Protokoll 18.05.2026.pad",
+  "file_id": 4321,
+  "pad_id": "p-newpad",
+  "access_mode": "protected",
+  "pad_url": "https://pad.example.test/p/p-newpad",
+  "viewer_url": "/index.php/apps/files/files/4321?dir=%2FMeetings&editing=false&openfile=true"
+}
+```
+
+Error responses:
+- **400** — template is not a `.pad`, template is external (`ext.*`), template is empty, target path invalid
+- **404** — template file ID does not resolve in the user's userspace
+- **409** — target filename collides with an existing file (`A file with this name already exists.`)
+- **500** — Etherpad unreachable or other unexpected failure
+
 ## Caveats
 
 - **External pads (`ext.*`)** can't be used as templates — they hold only a snapshot, not Etherpad-side content. The new file is reset to empty and the user gets a clean blank pad instead.

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -1,0 +1,53 @@
+# Pad Templates
+
+Users can pre-fill new `.pad` files with content from a template they prepared once. Templates live in Nextcloud's standard `/Templates` folder; the plugin hooks into NC's existing template flow.
+
+## Creating a template
+
+1. Create or copy a `.pad` file into `/Templates`. Any `.pad` file there counts as a template.
+2. Edit the pad and write the boilerplate you want every new copy to start with.
+3. Optionally rename the template file with placeholders in the name (see "Filename templates" below).
+
+## Using a template
+
+When the user clicks **+ → New pad** in the Files app, Nextcloud's template picker lists every `.pad` in `/Templates`. Selecting one creates a new pad in the current folder with:
+
+- a freshly provisioned Etherpad pad on the server,
+- the template body copied across (placeholders resolved — see below),
+- a new binding row so the pad and the `.pad` file stay linked.
+
+If the user picks "Blank" instead of a template, the new file is empty and behaves like any normal "+ New pad" creation — frontmatter is initialised on first open.
+
+## Placeholder syntax
+
+Placeholders in the **body** and the **filename** are resolved when the new pad is created. Syntax: `{{<resolver>[:<arg>][|<format>]}}`.
+
+| Token | Result | Example |
+|---|---|---|
+| `{{date}}` | today, ISO `Y-m-d` | `2026-05-17` |
+| `{{date\|d.m.Y}}` | today, custom PHP date format | `17.05.2026` |
+| `{{date:next monday}}` | relative date via `strtotime`, ISO | `2026-05-18` |
+| `{{date:next monday\|d.m.Y}}` | relative date with custom format | `18.05.2026` |
+| `{{date:+7 days}}` | 7 days from today | `2026-05-24` |
+| `{{user}}` | current user's display name | `Jacob Bühler` |
+| `{{user.uid}}` | current user's UID | `jaggob` |
+
+Unknown directives stay as literal text (`{{forecast}}` → `{{forecast}}`). Unparseable date expressions also stay as literal so the user can fix the template without losing the file.
+
+## Filename templates
+
+Placeholders work in the template's filename too. A template named:
+
+```
+Protokoll {{date:next monday|d.m.Y}}.pad
+```
+
+…produces a new file `Protokoll 18.05.2026.pad` when used on a Sunday. Nextcloud's template picker pre-fills the filename input with the source basename so the user usually just hits Enter. Manual overrides at creation time bypass the placeholder rewrite (whatever the user types is what the file is named).
+
+If the placeholder-rewritten name collides with an existing file in the target folder, Nextcloud's standard `(1)`, `(2)` suffix kicks in.
+
+## Caveats
+
+- **External pads (`ext.*`)** can't be used as templates — they hold only a snapshot, not Etherpad-side content. The listener skips them and the new file behaves like an empty pad.
+- **Placeholder substitution applies to both the plain-text and the HTML snapshot in the body**. If a placeholder ends up inside an HTML attribute (`<a href="{{date}}">`), it gets resolved too — keep placeholders in human-readable locations to avoid surprises.
+- **No template registry** — every `.pad` in `/Templates` is a candidate. There's no separate "is a template" flag.

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -1,15 +1,23 @@
 # Pad Templates
 
-Users can pre-fill new `.pad` files with content from a template they prepared once. Templates live in Nextcloud's standard `/Templates` folder; the plugin hooks into NC's existing template flow.
+Users can pre-fill new `.pad` files with content from a template they prepared once. Templates live in Nextcloud's standard *Templates* folder (default path: `/Templates` in the user's userspace); the plugin hooks into NC's existing template flow.
+
+## Where templates live
+
+Each Nextcloud account has its own *Templates* folder. The default location is `/Templates` in the user's userspace, but the path is configurable per user in **Personal Settings → Files → Templates folder**.
+
+**Group folders also work.** Because Nextcloud mounts group folders into the user's virtual filesystem, a user can set their Templates folder to a group-folder path (e.g. `/MyTeam/Vorlagen`) and the team's shared `.pad` templates show up in the picker for everyone who points their Templates folder at the same path. Each user has to set this themselves — there is no automatic team-wide template registry, NC only looks at the single path configured per account.
+
+Read-only shares (a folder shared *to* the user from someone else's account) are not officially supported as a template source; results depend on how NC's virtual filesystem mounts the share. For team templates, prefer group folders.
 
 ## Creating a template
 
-1. Create or copy a `.pad` file into `/Templates`. Any `.pad` file there counts as a template.
+1. Create or copy a `.pad` file into the *Templates* folder (default `/Templates` or whatever the user configured).
 2. Edit the pad and write the boilerplate you want every new copy to start with.
 
 ## Using a template
 
-When the user clicks **+ → New pad** in the Files app, Nextcloud's template picker lists every `.pad` in `/Templates`. Selecting one creates a new pad in the current folder with:
+When the user clicks **+ → New pad** in the Files app, Nextcloud's template picker lists every `.pad` in their *Templates* folder. Selecting one creates a new pad in the current folder with:
 
 - a freshly provisioned Etherpad pad on the server,
 - the template body copied across (placeholders resolved — see below),
@@ -28,8 +36,8 @@ Placeholders in the **body** are resolved when the new pad is created. The templ
 | `{{date:next monday}}` | relative date via `strtotime`, ISO | `2026-05-18` |
 | `{{date:next monday\|d.m.Y}}` | relative date with custom format | `18.05.2026` |
 | `{{date:+7 days}}` | 7 days from today | `2026-05-24` |
-| `{{user}}` | current user's display name | `Jacob Bühler` |
-| `{{user.uid}}` | current user's UID | `jaggob` |
+| `{{user}}` | current user's display name | `Erika Mustermann` |
+| `{{user.uid}}` | current user's UID | `emustermann` |
 
 Unknown directives stay as literal text (`{{forecast}}` → `{{forecast}}`). Unparseable date expressions also stay as literal so the user can fix the template without losing the file.
 
@@ -44,4 +52,4 @@ The new file ends up at the name the user types into NC's filename dialog. Body 
 - **External pads (`ext.*`)** can't be used as templates — they hold only a snapshot, not Etherpad-side content. The new file is reset to empty and the user gets a clean blank pad instead.
 - **Failed template materialisation falls back to a blank pad.** If anything in the listener throws (binding race, Etherpad unreachable, malformed template), the byte-copy NC made is wiped and the new file behaves like a normal empty `.pad` — the regular missing-frontmatter init kicks in on first open.
 - **Placeholder substitution applies to both the plain-text and the HTML snapshot in the body**. If a placeholder ends up inside an HTML attribute (`<a href="{{date}}">`), it gets resolved too — keep placeholders in human-readable locations to avoid surprises.
-- **No template registry** — every `.pad` in `/Templates` is a candidate. There's no separate "is a template" flag.
+- **No template registry** — every `.pad` in the user's *Templates* folder is a candidate. There's no separate "is a template" flag.

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -6,7 +6,6 @@ Users can pre-fill new `.pad` files with content from a template they prepared o
 
 1. Create or copy a `.pad` file into `/Templates`. Any `.pad` file there counts as a template.
 2. Edit the pad and write the boilerplate you want every new copy to start with.
-3. Optionally rename the template file with placeholders in the name (see "Filename templates" below).
 
 ## Using a template
 
@@ -20,7 +19,7 @@ If the user picks "Blank" instead of a template, the new file is empty and behav
 
 ## Placeholder syntax
 
-Placeholders in the **body** and the **filename** are resolved when the new pad is created. Syntax: `{{<resolver>[:<arg>][|<format>]}}`.
+Placeholders in the **body** are resolved when the new pad is created. The template's filename is **not** rewritten — see the next section. Syntax: `{{<resolver>[:<arg>][|<format>]}}`.
 
 | Token | Result | Example |
 |---|---|---|
@@ -34,14 +33,15 @@ Placeholders in the **body** and the **filename** are resolved when the new pad 
 
 Unknown directives stay as literal text (`{{forecast}}` → `{{forecast}}`). Unparseable date expressions also stay as literal so the user can fix the template without losing the file.
 
-## Filename templates (not supported in v1)
+## Filename templates (not supported)
 
-Placeholders in the template's filename are **not** rewritten today. Nextcloud's `+ New pad` flow asks the user for a filename **before** showing the template picker, and `TemplateManager::createFromTemplate` re-fetches the new file by that user-typed path *after* our event fires. Renaming during the event causes a `NotFoundException` and NC returns 403 to the client.
+Placeholders in the template's filename are **not** rewritten. Nextcloud's `+ New pad` flow asks the user for a filename **before** showing the template picker, and `TemplateManager::createFromTemplate` re-fetches the new file by that user-typed path *after* our event fires. Renaming during the event causes NC's lookup to throw `NotFoundException` and the create call returns 403 to the client.
 
-Realistic workaround for now: type a meaningful filename when prompted. The body still gets its `{{date}}` / `{{user}}` placeholders resolved.
+The new file ends up at the name the user types into NC's filename dialog. Body placeholders still get resolved.
 
 ## Caveats
 
-- **External pads (`ext.*`)** can't be used as templates — they hold only a snapshot, not Etherpad-side content. The listener skips them and the new file behaves like an empty pad.
+- **External pads (`ext.*`)** can't be used as templates — they hold only a snapshot, not Etherpad-side content. The new file is reset to empty and the user gets a clean blank pad instead.
+- **Failed template materialisation falls back to a blank pad.** If anything in the listener throws (binding race, Etherpad unreachable, malformed template), the byte-copy NC made is wiped and the new file behaves like a normal empty `.pad` — the regular missing-frontmatter init kicks in on first open.
 - **Placeholder substitution applies to both the plain-text and the HTML snapshot in the body**. If a placeholder ends up inside an HTML attribute (`<a href="{{date}}">`), it gets resolved too — keep placeholders in human-readable locations to avoid surprises.
 - **No template registry** — every `.pad` in `/Templates` is a candidate. There's no separate "is a template" flag.

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -42,9 +42,11 @@ Placeholders work in the template's filename too. A template named:
 Protokoll {{date:next monday|d.m.Y}}.pad
 ```
 
-…produces a new file `Protokoll 18.05.2026.pad` when used on a Sunday. Nextcloud's template picker pre-fills the filename input with the source basename so the user usually just hits Enter. Manual overrides at creation time bypass the placeholder rewrite (whatever the user types is what the file is named).
+…produces a new file `Protokoll 18.05.2026.pad` when used on a Sunday — **regardless** of what filename the user types when Nextcloud first asks for one. Nextcloud's flow is filename-first, template-picker-second, so the user types some placeholder name (`Untitled`, or whatever the picker pre-fills), then picks the template. After the copy, the plugin renames the target to the resolved template filename.
 
-If the placeholder-rewritten name collides with an existing file in the target folder, Nextcloud's standard `(1)`, `(2)` suffix kicks in.
+If the resolved name collides with an existing file in the target folder, Nextcloud's standard `(1)`, `(2)` suffix kicks in.
+
+If the template's filename contains no `{{...}}` token, the user's typed filename is kept as-is.
 
 ## Caveats
 

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -17,6 +17,7 @@ use OCP\AppFramework\Bootstrap\IBootstrap;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
 use OCP\BackgroundJob\IJobList;
 use OCP\Files\IMimeTypeDetector;
+use OCP\Files\Template\FileCreatedFromTemplateEvent;
 use OCP\Files\Template\RegisterTemplateCreatorEvent;
 use OCP\Security\CSP\AddContentSecurityPolicyEvent;
 
@@ -45,6 +46,12 @@ class Application extends App implements IBootstrap {
 			$context->registerEventListener(
 				RegisterTemplateCreatorEvent::class,
 				\OCA\EtherpadNextcloud\Listeners\RegisterTemplateCreatorListener::class,
+			);
+		}
+		if (class_exists(FileCreatedFromTemplateEvent::class)) {
+			$context->registerEventListener(
+				FileCreatedFromTemplateEvent::class,
+				\OCA\EtherpadNextcloud\Listeners\FileCreatedFromTemplateListener::class,
 			);
 		}
 		if (class_exists('OCA\\Viewer\\Event\\LoadViewer')) {

--- a/lib/Controller/PadController.php
+++ b/lib/Controller/PadController.php
@@ -89,6 +89,26 @@ class PadController extends Controller {
 	}
 
 	#[\OCP\AppFramework\Http\Attribute\NoAdminRequired]
+	public function createFromTemplate(string $file, int $templateFileId): DataResponse {
+		return $this->runForUser(
+			fn(IUser $user): array => $this->padCreationService->createFromTemplate(
+				$user->getUID(),
+				$file,
+				$this->requireFileId($templateFileId),
+				$user,
+			),
+			fn(array $result): DataResponse => new DataResponse($this->padResponses->withViewerUrl($result)),
+			[
+				'invalid_argument' => $this->l10n->t('Invalid input.'),
+				'not_found' => $this->l10n->t('Template file not found.'),
+				'binding_message' => $this->l10n->t('A file with this name already exists.'),
+				'binding_status' => Http::STATUS_CONFLICT,
+				'generic' => $this->l10n->t('Could not create pad from template.'),
+			],
+		);
+	}
+
+	#[\OCP\AppFramework\Http\Attribute\NoAdminRequired]
 	public function createFromUrl(string $file, string $padUrl): DataResponse {
 		return $this->runForUser(
 			fn(IUser $user): array => $this->padCreationService->createFromUrl($user->getUID(), $file, $padUrl),

--- a/lib/Listeners/FileCreatedFromTemplateListener.php
+++ b/lib/Listeners/FileCreatedFromTemplateListener.php
@@ -116,8 +116,6 @@ class FileCreatedFromTemplateListener implements IEventListener {
 			$target->putContent($withSnapshot);
 			$this->bindingService->createBinding($targetFileId, $newPadId, $accessMode);
 			$padCreated = false;
-
-			$this->maybeRenameByPlaceholder($target, $template, $user);
 		} catch (\Throwable $e) {
 			if ($padCreated) {
 				try {
@@ -134,34 +132,4 @@ class FileCreatedFromTemplateListener implements IEventListener {
 		}
 	}
 
-	private function maybeRenameByPlaceholder(File $target, File $template, ?IUser $user): void {
-		// The placeholder lives in the *template's* filename. NC asks the user
-		// for a target filename before showing the template picker, so the
-		// target name is whatever the user typed and never carries `{{...}}`.
-		$templateName = $template->getName();
-		if (!str_contains($templateName, '{{')) {
-			return;
-		}
-		$rendered = $this->placeholderResolver->apply($templateName, $user);
-		if ($rendered === '' || $rendered === $templateName) {
-			return;
-		}
-		$parent = $target->getParent();
-		$candidate = $parent->getNonExistingName($rendered);
-		$currentName = $target->getName();
-		if ($candidate === $currentName) {
-			return;
-		}
-		try {
-			$target->move($parent->getPath() . '/' . $candidate);
-		} catch (\Throwable $e) {
-			$this->logger->warning('Could not rename pad after template-placeholder substitution.', [
-				'app' => 'etherpad_nextcloud',
-				'fileId' => (int)$target->getId(),
-				'from' => $currentName,
-				'to' => $candidate,
-				'exception' => $e,
-			]);
-		}
-	}
 }

--- a/lib/Listeners/FileCreatedFromTemplateListener.php
+++ b/lib/Listeners/FileCreatedFromTemplateListener.php
@@ -8,11 +8,7 @@ declare(strict_types=1);
 
 namespace OCA\EtherpadNextcloud\Listeners;
 
-use OCA\EtherpadNextcloud\Service\BindingService;
-use OCA\EtherpadNextcloud\Service\EtherpadClient;
-use OCA\EtherpadNextcloud\Service\PadBootstrapService;
-use OCA\EtherpadNextcloud\Service\PadFileService;
-use OCA\EtherpadNextcloud\Service\PadPlaceholderResolver;
+use OCA\EtherpadNextcloud\Service\PadCreationService;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\Files\File;
@@ -20,13 +16,21 @@ use OCP\Files\Template\FileCreatedFromTemplateEvent;
 use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
 
+/**
+ * Hooks into Nextcloud's native "+ New pad" template flow. NC has already
+ * byte-copied the template into the target path before this event fires, so
+ * the heavy lifting (parse → resolve placeholders → provision pad → seed
+ * snapshot → rewrite file with fresh frontmatter → create binding) is shared
+ * with `PadCreationService::materializeTemplateInto` to keep both entry
+ * points (NC native picker + custom-frontend API) in lockstep.
+ *
+ * On any skip or failure path the target is reset to empty so NC's normal
+ * missing-frontmatter init handles the file on first open instead of the
+ * user inheriting the template's source frontmatter/pad_id.
+ */
 class FileCreatedFromTemplateListener implements IEventListener {
 	public function __construct(
-		private PadFileService $padFileService,
-		private PadPlaceholderResolver $placeholderResolver,
-		private PadBootstrapService $padBootstrapService,
-		private BindingService $bindingService,
-		private EtherpadClient $etherpadClient,
+		private PadCreationService $padCreationService,
 		private IUserSession $userSession,
 		private LoggerInterface $logger,
 	) {
@@ -48,10 +52,24 @@ class FileCreatedFromTemplateListener implements IEventListener {
 			return;
 		}
 
+		$user = $this->userSession->getUser();
+		if ($user === null) {
+			// Template flow without a session is unexpected (NC always
+			// dispatches inside a logged-in request) but we refuse to render
+			// a half-resolved pad: wipe the byte-copy and let normal init
+			// kick in on first open.
+			$this->logger->warning('Template event fired without an active user — resetting target to empty.', [
+				'app' => 'etherpad_nextcloud',
+				'fileId' => (int)$target->getId(),
+			]);
+			$this->resetTargetToEmpty($target);
+			return;
+		}
+
 		try {
-			$this->materializeFromTemplate($target, $template);
+			$this->padCreationService->materializeTemplateInto($target, $template, $user);
 		} catch (\Throwable $e) {
-			$this->logger->error('Pad template materialization failed.', [
+			$this->logger->error('Pad template materialization failed — resetting target to empty.', [
 				'app' => 'etherpad_nextcloud',
 				'targetFileId' => (int)$target->getId(),
 				'templateFileId' => (int)$template->getId(),
@@ -60,75 +78,6 @@ class FileCreatedFromTemplateListener implements IEventListener {
 			// Wipe whatever NC byte-copied so the new file becomes a regular
 			// empty .pad and the next open initialises frontmatter normally.
 			$this->resetTargetToEmpty($target);
-		}
-	}
-
-	private function materializeFromTemplate(File $target, File $template): void {
-		$user = $this->userSession->getUser();
-		$content = (string)$template->getContent();
-		if (trim($content) === '') {
-			return;
-		}
-
-		try {
-			$parsed = $this->padFileService->parsePadFile($content);
-			$frontmatter = $parsed['frontmatter'];
-			$meta = $this->padFileService->extractPadMetadata($frontmatter);
-		} catch (\Throwable) {
-			$this->resetTargetToEmpty($target);
-			return;
-		}
-
-		$sourcePadId = (string)($meta['pad_id'] ?? '');
-		if ($sourcePadId === '' || str_starts_with($sourcePadId, 'ext.')
-			|| $this->padFileService->isExternalFrontmatter($frontmatter, $sourcePadId)) {
-			$this->resetTargetToEmpty($target);
-			return;
-		}
-
-		$accessMode = (string)($meta['access_mode'] ?? BindingService::ACCESS_PROTECTED);
-		if ($accessMode !== BindingService::ACCESS_PUBLIC && $accessMode !== BindingService::ACCESS_PROTECTED) {
-			$accessMode = BindingService::ACCESS_PROTECTED;
-		}
-
-		$snapshot = $this->padFileService->getSnapshotPartsFromBody((string)$parsed['body']);
-		$resolvedText = $this->placeholderResolver->apply($snapshot['text'], $user);
-		$resolvedHtml = $this->placeholderResolver->apply($snapshot['html'], $user);
-
-		$newPadId = $this->padBootstrapService->provisionPadId($accessMode);
-
-		try {
-			$this->padBootstrapService->pushInitialSnapshot($newPadId, $resolvedText, $resolvedHtml);
-
-			$targetFileId = (int)$target->getId();
-			$padUrl = $this->etherpadClient->buildPadUrl($newPadId);
-			$initialDoc = $this->padFileService->buildInitialDocument(
-				$targetFileId,
-				$newPadId,
-				$accessMode,
-				$resolvedText,
-				$padUrl,
-			);
-			$withSnapshot = $this->padFileService->withExportSnapshot(
-				$initialDoc,
-				$resolvedText,
-				$resolvedHtml,
-				0,
-				true,
-			);
-			$target->putContent($withSnapshot);
-			$this->bindingService->createBinding($targetFileId, $newPadId, $accessMode);
-		} catch (\Throwable $e) {
-			try {
-				$this->etherpadClient->deletePad($newPadId);
-			} catch (\Throwable $cleanupError) {
-				$this->logger->warning('Could not cleanup Etherpad pad after template materialization failed.', [
-					'app' => 'etherpad_nextcloud',
-					'padId' => $newPadId,
-					'exception' => $cleanupError,
-				]);
-			}
-			throw $e;
 		}
 	}
 

--- a/lib/Listeners/FileCreatedFromTemplateListener.php
+++ b/lib/Listeners/FileCreatedFromTemplateListener.php
@@ -17,7 +17,6 @@ use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\Files\File;
 use OCP\Files\Template\FileCreatedFromTemplateEvent;
-use OCP\IUser;
 use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
 
@@ -46,8 +45,6 @@ class FileCreatedFromTemplateListener implements IEventListener {
 		}
 		$template = $event->getTemplate();
 		if (!$template instanceof File) {
-			// Blank template (no source) — leave the file empty so the
-			// regular missing-frontmatter initialize path handles it.
 			return;
 		}
 
@@ -60,6 +57,9 @@ class FileCreatedFromTemplateListener implements IEventListener {
 				'templateFileId' => (int)$template->getId(),
 				'exception' => $e,
 			]);
+			// Wipe whatever NC byte-copied so the new file becomes a regular
+			// empty .pad and the next open initialises frontmatter normally.
+			$this->resetTargetToEmpty($target);
 		}
 	}
 
@@ -70,15 +70,19 @@ class FileCreatedFromTemplateListener implements IEventListener {
 			return;
 		}
 
-		$parsed = $this->padFileService->parsePadFile($content);
-		$frontmatter = $parsed['frontmatter'];
-		$meta = $this->padFileService->extractPadMetadata($frontmatter);
+		try {
+			$parsed = $this->padFileService->parsePadFile($content);
+			$frontmatter = $parsed['frontmatter'];
+			$meta = $this->padFileService->extractPadMetadata($frontmatter);
+		} catch (\Throwable) {
+			$this->resetTargetToEmpty($target);
+			return;
+		}
+
 		$sourcePadId = (string)($meta['pad_id'] ?? '');
 		if ($sourcePadId === '' || str_starts_with($sourcePadId, 'ext.')
 			|| $this->padFileService->isExternalFrontmatter($frontmatter, $sourcePadId)) {
-			// External / unparseable templates carry no usable body for a
-			// managed-pad clone. Skip and let the empty target initialize
-			// normally on first open.
+			$this->resetTargetToEmpty($target);
 			return;
 		}
 
@@ -92,7 +96,6 @@ class FileCreatedFromTemplateListener implements IEventListener {
 		$resolvedHtml = $this->placeholderResolver->apply($snapshot['html'], $user);
 
 		$newPadId = $this->padBootstrapService->provisionPadId($accessMode);
-		$padCreated = true;
 
 		try {
 			$this->padBootstrapService->pushInitialSnapshot($newPadId, $resolvedText, $resolvedHtml);
@@ -115,21 +118,29 @@ class FileCreatedFromTemplateListener implements IEventListener {
 			);
 			$target->putContent($withSnapshot);
 			$this->bindingService->createBinding($targetFileId, $newPadId, $accessMode);
-			$padCreated = false;
 		} catch (\Throwable $e) {
-			if ($padCreated) {
-				try {
-					$this->etherpadClient->deletePad($newPadId);
-				} catch (\Throwable $cleanupError) {
-					$this->logger->warning('Could not cleanup Etherpad pad after template materialization failed.', [
-						'app' => 'etherpad_nextcloud',
-						'padId' => $newPadId,
-						'exception' => $cleanupError,
-					]);
-				}
+			try {
+				$this->etherpadClient->deletePad($newPadId);
+			} catch (\Throwable $cleanupError) {
+				$this->logger->warning('Could not cleanup Etherpad pad after template materialization failed.', [
+					'app' => 'etherpad_nextcloud',
+					'padId' => $newPadId,
+					'exception' => $cleanupError,
+				]);
 			}
 			throw $e;
 		}
 	}
 
+	private function resetTargetToEmpty(File $target): void {
+		try {
+			$target->putContent('');
+		} catch (\Throwable $e) {
+			$this->logger->warning('Could not reset target file content after rejected template.', [
+				'app' => 'etherpad_nextcloud',
+				'fileId' => (int)$target->getId(),
+				'exception' => $e,
+			]);
+		}
+	}
 }

--- a/lib/Listeners/FileCreatedFromTemplateListener.php
+++ b/lib/Listeners/FileCreatedFromTemplateListener.php
@@ -117,7 +117,7 @@ class FileCreatedFromTemplateListener implements IEventListener {
 			$this->bindingService->createBinding($targetFileId, $newPadId, $accessMode);
 			$padCreated = false;
 
-			$this->maybeRenameByPlaceholder($target, $user);
+			$this->maybeRenameByPlaceholder($target, $template, $user);
 		} catch (\Throwable $e) {
 			if ($padCreated) {
 				try {
@@ -134,24 +134,31 @@ class FileCreatedFromTemplateListener implements IEventListener {
 		}
 	}
 
-	private function maybeRenameByPlaceholder(File $target, ?IUser $user): void {
-		$current = $target->getName();
-		if (!str_contains($current, '{{')) {
+	private function maybeRenameByPlaceholder(File $target, File $template, ?IUser $user): void {
+		// The placeholder lives in the *template's* filename. NC asks the user
+		// for a target filename before showing the template picker, so the
+		// target name is whatever the user typed and never carries `{{...}}`.
+		$templateName = $template->getName();
+		if (!str_contains($templateName, '{{')) {
 			return;
 		}
-		$rendered = $this->placeholderResolver->apply($current, $user);
-		if ($rendered === '' || $rendered === $current) {
+		$rendered = $this->placeholderResolver->apply($templateName, $user);
+		if ($rendered === '' || $rendered === $templateName) {
 			return;
 		}
 		$parent = $target->getParent();
 		$candidate = $parent->getNonExistingName($rendered);
+		$currentName = $target->getName();
+		if ($candidate === $currentName) {
+			return;
+		}
 		try {
 			$target->move($parent->getPath() . '/' . $candidate);
 		} catch (\Throwable $e) {
 			$this->logger->warning('Could not rename pad after template-placeholder substitution.', [
 				'app' => 'etherpad_nextcloud',
 				'fileId' => (int)$target->getId(),
-				'from' => $current,
+				'from' => $currentName,
 				'to' => $candidate,
 				'exception' => $e,
 			]);

--- a/lib/Listeners/FileCreatedFromTemplateListener.php
+++ b/lib/Listeners/FileCreatedFromTemplateListener.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * Copyright (c) 2026 Jacob Bühler
+ */
+
+namespace OCA\EtherpadNextcloud\Listeners;
+
+use OCA\EtherpadNextcloud\Service\BindingService;
+use OCA\EtherpadNextcloud\Service\EtherpadClient;
+use OCA\EtherpadNextcloud\Service\PadBootstrapService;
+use OCA\EtherpadNextcloud\Service\PadFileService;
+use OCA\EtherpadNextcloud\Service\PadPlaceholderResolver;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use OCP\Files\File;
+use OCP\Files\Template\FileCreatedFromTemplateEvent;
+use OCP\IUser;
+use OCP\IUserSession;
+use Psr\Log\LoggerInterface;
+
+class FileCreatedFromTemplateListener implements IEventListener {
+	public function __construct(
+		private PadFileService $padFileService,
+		private PadPlaceholderResolver $placeholderResolver,
+		private PadBootstrapService $padBootstrapService,
+		private BindingService $bindingService,
+		private EtherpadClient $etherpadClient,
+		private IUserSession $userSession,
+		private LoggerInterface $logger,
+	) {
+	}
+
+	public function handle(Event $event): void {
+		if (!($event instanceof FileCreatedFromTemplateEvent)) {
+			return;
+		}
+		$target = $event->getTarget();
+		if (!$target instanceof File) {
+			return;
+		}
+		if (!str_ends_with(strtolower($target->getName()), '.pad')) {
+			return;
+		}
+		$template = $event->getTemplate();
+		if (!$template instanceof File) {
+			// Blank template (no source) — leave the file empty so the
+			// regular missing-frontmatter initialize path handles it.
+			return;
+		}
+
+		try {
+			$this->materializeFromTemplate($target, $template);
+		} catch (\Throwable $e) {
+			$this->logger->error('Pad template materialization failed.', [
+				'app' => 'etherpad_nextcloud',
+				'targetFileId' => (int)$target->getId(),
+				'templateFileId' => (int)$template->getId(),
+				'exception' => $e,
+			]);
+		}
+	}
+
+	private function materializeFromTemplate(File $target, File $template): void {
+		$user = $this->userSession->getUser();
+		$content = (string)$template->getContent();
+		if (trim($content) === '') {
+			return;
+		}
+
+		$parsed = $this->padFileService->parsePadFile($content);
+		$frontmatter = $parsed['frontmatter'];
+		$meta = $this->padFileService->extractPadMetadata($frontmatter);
+		$sourcePadId = (string)($meta['pad_id'] ?? '');
+		if ($sourcePadId === '' || str_starts_with($sourcePadId, 'ext.')
+			|| $this->padFileService->isExternalFrontmatter($frontmatter, $sourcePadId)) {
+			// External / unparseable templates carry no usable body for a
+			// managed-pad clone. Skip and let the empty target initialize
+			// normally on first open.
+			return;
+		}
+
+		$accessMode = (string)($meta['access_mode'] ?? BindingService::ACCESS_PROTECTED);
+		if ($accessMode !== BindingService::ACCESS_PUBLIC && $accessMode !== BindingService::ACCESS_PROTECTED) {
+			$accessMode = BindingService::ACCESS_PROTECTED;
+		}
+
+		$snapshot = $this->padFileService->getSnapshotPartsFromBody((string)$parsed['body']);
+		$resolvedText = $this->placeholderResolver->apply($snapshot['text'], $user);
+		$resolvedHtml = $this->placeholderResolver->apply($snapshot['html'], $user);
+
+		$newPadId = $this->padBootstrapService->provisionPadId($accessMode);
+		$padCreated = true;
+
+		try {
+			$this->padBootstrapService->pushInitialSnapshot($newPadId, $resolvedText, $resolvedHtml);
+
+			$targetFileId = (int)$target->getId();
+			$padUrl = $this->etherpadClient->buildPadUrl($newPadId);
+			$initialDoc = $this->padFileService->buildInitialDocument(
+				$targetFileId,
+				$newPadId,
+				$accessMode,
+				$resolvedText,
+				$padUrl,
+			);
+			$withSnapshot = $this->padFileService->withExportSnapshot(
+				$initialDoc,
+				$resolvedText,
+				$resolvedHtml,
+				0,
+				true,
+			);
+			$target->putContent($withSnapshot);
+			$this->bindingService->createBinding($targetFileId, $newPadId, $accessMode);
+			$padCreated = false;
+
+			$this->maybeRenameByPlaceholder($target, $user);
+		} catch (\Throwable $e) {
+			if ($padCreated) {
+				try {
+					$this->etherpadClient->deletePad($newPadId);
+				} catch (\Throwable $cleanupError) {
+					$this->logger->warning('Could not cleanup Etherpad pad after template materialization failed.', [
+						'app' => 'etherpad_nextcloud',
+						'padId' => $newPadId,
+						'exception' => $cleanupError,
+					]);
+				}
+			}
+			throw $e;
+		}
+	}
+
+	private function maybeRenameByPlaceholder(File $target, ?IUser $user): void {
+		$current = $target->getName();
+		if (!str_contains($current, '{{')) {
+			return;
+		}
+		$rendered = $this->placeholderResolver->apply($current, $user);
+		if ($rendered === '' || $rendered === $current) {
+			return;
+		}
+		$parent = $target->getParent();
+		$candidate = $parent->getNonExistingName($rendered);
+		try {
+			$target->move($parent->getPath() . '/' . $candidate);
+		} catch (\Throwable $e) {
+			$this->logger->warning('Could not rename pad after template-placeholder substitution.', [
+				'app' => 'etherpad_nextcloud',
+				'fileId' => (int)$target->getId(),
+				'from' => $current,
+				'to' => $candidate,
+				'exception' => $e,
+			]);
+		}
+	}
+}

--- a/lib/Service/PadBootstrapService.php
+++ b/lib/Service/PadBootstrapService.php
@@ -24,20 +24,23 @@ class PadBootstrapService {
 	}
 
 	/**
-	 * Seeds a freshly provisioned pad with content. Imports the HTML snapshot
-	 * (so formatting survives) and, when that succeeded, also pushes the
-	 * resolved plain-text via setText so Etherpad's `getText` returns the same
-	 * string we recorded as the file's text snapshot — otherwise Etherpad
-	 * derives plain text from the HTML, which can drift from what the `.pad`
-	 * frontmatter claims. When HTML import fails or no HTML snapshot is
-	 * provided, setText alone seeds the pad.
+	 * Seeds a freshly provisioned pad with content. Tries setHTML first so
+	 * formatting (headings, lists, bold/italic) survives, and falls back to
+	 * plain-text setText if the HTML import fails or no HTML snapshot is
+	 * available.
+	 *
+	 * We intentionally do NOT also call setText after a successful setHTML:
+	 * Etherpad's `setText` replaces the pad content rather than appending, so
+	 * doing both would wipe the formatted HTML we just imported. The minor
+	 * downside — `getText` returns plain text Etherpad derived from the HTML
+	 * rather than the exact string we put into the frontmatter snapshot — is
+	 * acceptable in exchange for keeping the rich formatting.
 	 */
 	public function pushInitialSnapshot(string $padId, string $text, string $html): void {
-		$htmlSucceeded = false;
 		if (trim($html) !== '') {
 			try {
 				$this->etherpadClient->setHTML($padId, $html);
-				$htmlSucceeded = true;
+				return;
 			} catch (\Throwable $htmlError) {
 				$this->logger->warning('Initial HTML push failed, falling back to plain text.', [
 					'app' => 'etherpad_nextcloud',
@@ -46,26 +49,7 @@ class PadBootstrapService {
 				]);
 			}
 		}
-
-		if ($htmlSucceeded && trim($text) === '') {
-			// HTML carried the content and the text snapshot is empty — nothing
-			// to add on top.
-			return;
-		}
-
-		try {
-			$this->etherpadClient->setText($padId, $text);
-		} catch (\Throwable $textError) {
-			if (!$htmlSucceeded) {
-				throw $textError;
-			}
-			// HTML already seeded the pad — log the divergence but don't fail.
-			$this->logger->warning('Initial setText after setHTML failed; pad text may diverge from .pad snapshot.', [
-				'app' => 'etherpad_nextcloud',
-				'padId' => $padId,
-				'exception' => $textError,
-			]);
-		}
+		$this->etherpadClient->setText($padId, $text);
 	}
 
 	public function provisionPadId(string $accessMode): string {

--- a/lib/Service/PadBootstrapService.php
+++ b/lib/Service/PadBootstrapService.php
@@ -23,6 +23,27 @@ class PadBootstrapService {
 	) {
 	}
 
+	/**
+	 * Seeds a freshly provisioned pad with content. Tries setHTML first
+	 * (preserves formatting) and falls back to plain-text setText if the
+	 * HTML import fails.
+	 */
+	public function pushInitialSnapshot(string $padId, string $text, string $html): void {
+		if (trim($html) !== '') {
+			try {
+				$this->etherpadClient->setHTML($padId, $html);
+				return;
+			} catch (\Throwable $htmlError) {
+				$this->logger->warning('Initial HTML push failed, falling back to plain text.', [
+					'app' => 'etherpad_nextcloud',
+					'padId' => $padId,
+					'exception' => $htmlError,
+				]);
+			}
+		}
+		$this->etherpadClient->setText($padId, $text);
+	}
+
 	public function provisionPadId(string $accessMode): string {
 		if ($accessMode === BindingService::ACCESS_PUBLIC) {
 			$padId = 'nc-' . $this->secureRandom->generate(24, ISecureRandom::CHAR_LOWER . ISecureRandom::CHAR_DIGITS);

--- a/lib/Service/PadBootstrapService.php
+++ b/lib/Service/PadBootstrapService.php
@@ -24,15 +24,20 @@ class PadBootstrapService {
 	}
 
 	/**
-	 * Seeds a freshly provisioned pad with content. Tries setHTML first
-	 * (preserves formatting) and falls back to plain-text setText if the
-	 * HTML import fails.
+	 * Seeds a freshly provisioned pad with content. Imports the HTML snapshot
+	 * (so formatting survives) and, when that succeeded, also pushes the
+	 * resolved plain-text via setText so Etherpad's `getText` returns the same
+	 * string we recorded as the file's text snapshot — otherwise Etherpad
+	 * derives plain text from the HTML, which can drift from what the `.pad`
+	 * frontmatter claims. When HTML import fails or no HTML snapshot is
+	 * provided, setText alone seeds the pad.
 	 */
 	public function pushInitialSnapshot(string $padId, string $text, string $html): void {
+		$htmlSucceeded = false;
 		if (trim($html) !== '') {
 			try {
 				$this->etherpadClient->setHTML($padId, $html);
-				return;
+				$htmlSucceeded = true;
 			} catch (\Throwable $htmlError) {
 				$this->logger->warning('Initial HTML push failed, falling back to plain text.', [
 					'app' => 'etherpad_nextcloud',
@@ -41,7 +46,26 @@ class PadBootstrapService {
 				]);
 			}
 		}
-		$this->etherpadClient->setText($padId, $text);
+
+		if ($htmlSucceeded && trim($text) === '') {
+			// HTML carried the content and the text snapshot is empty — nothing
+			// to add on top.
+			return;
+		}
+
+		try {
+			$this->etherpadClient->setText($padId, $text);
+		} catch (\Throwable $textError) {
+			if (!$htmlSucceeded) {
+				throw $textError;
+			}
+			// HTML already seeded the pad — log the divergence but don't fail.
+			$this->logger->warning('Initial setText after setHTML failed; pad text may diverge from .pad snapshot.', [
+				'app' => 'etherpad_nextcloud',
+				'padId' => $padId,
+				'exception' => $textError,
+			]);
+		}
 	}
 
 	public function provisionPadId(string $accessMode): string {

--- a/lib/Service/PadCreationService.php
+++ b/lib/Service/PadCreationService.php
@@ -11,8 +11,10 @@ namespace OCA\EtherpadNextcloud\Service;
 
 use OCA\EtherpadNextcloud\Exception\BindingException;
 use OCA\EtherpadNextcloud\Exception\EtherpadClientException;
+use OCA\EtherpadNextcloud\Exception\NotAPadFileException;
 use OCA\EtherpadNextcloud\Exception\PadFileAlreadyExistsException;
 use OCA\EtherpadNextcloud\Exception\PadParentFolderNotWritableException;
+use OCP\IUser;
 use Psr\Log\LoggerInterface;
 
 class PadCreationService {
@@ -25,6 +27,7 @@ class PadCreationService {
 		private BindingService $bindingService,
 		private EtherpadClient $etherpadClient,
 		private PadBootstrapService $padBootstrapService,
+		private PadPlaceholderResolver $placeholderResolver,
 		private LoggerInterface $logger,
 	) {
 	}
@@ -253,6 +256,118 @@ class PadCreationService {
 					'context' => [
 						'file' => $path,
 						'padUrl' => $padUrl,
+					],
+				];
+			},
+		);
+	}
+
+	/**
+	 * Materializes a new pad from an existing `.pad` source file. Reuses the
+	 * same provisioning + binding pipeline as create(), but seeds the new
+	 * pad with the template's body (placeholders resolved). The source can
+	 * be any `.pad` in the requester's userspace — caller picks the file
+	 * by id, so a custom frontend can decide what counts as a template
+	 * (current folder, ancestor scan, a fixed picker, …).
+	 *
+	 * @return array{file:string,file_id:int,pad_id:string,access_mode:string,pad_url:string}
+	 */
+	public function createFromTemplate(string $uid, string $targetFile, int $templateFileId, ?IUser $user): array {
+		$resolvedTargetFile = $this->placeholderResolver->apply($targetFile, $user);
+		$path = $this->padPaths->normalizeCreatePath($resolvedTargetFile);
+
+		$templateNode = $this->userNodeResolver->resolveUserFileNodeById($uid, $templateFileId);
+		if (!str_ends_with(strtolower($templateNode->getName()), '.pad')) {
+			throw new NotAPadFileException('Template is not a .pad file.');
+		}
+		$templateContent = (string)$templateNode->getContent();
+		if (trim($templateContent) === '') {
+			throw new \InvalidArgumentException('Template is empty.');
+		}
+
+		$parsed = $this->padFileService->parsePadFile($templateContent);
+		$frontmatter = $parsed['frontmatter'];
+		$meta = $this->padFileService->extractPadMetadata($frontmatter);
+		$sourcePadId = (string)($meta['pad_id'] ?? '');
+		if ($sourcePadId === '' || str_starts_with($sourcePadId, 'ext.')
+			|| $this->padFileService->isExternalFrontmatter($frontmatter, $sourcePadId)) {
+			throw new \InvalidArgumentException('External pads cannot be used as a template.');
+		}
+
+		$accessMode = (string)($meta['access_mode'] ?? BindingService::ACCESS_PROTECTED);
+		if ($accessMode !== BindingService::ACCESS_PUBLIC && $accessMode !== BindingService::ACCESS_PROTECTED) {
+			$accessMode = BindingService::ACCESS_PROTECTED;
+		}
+
+		$snapshot = $this->padFileService->getSnapshotPartsFromBody((string)$parsed['body']);
+		$resolvedText = $this->placeholderResolver->apply($snapshot['text'], $user);
+		$resolvedHtml = $this->placeholderResolver->apply($snapshot['html'], $user);
+
+		$padId = '';
+		$fileCreated = false;
+
+		return $this->withCreateRollback(
+			function () use ($uid, $path, $accessMode, $resolvedText, $resolvedHtml, &$padId, &$fileCreated): array {
+				$fileNode = $this->padFileCreator->createUserFile($uid, $path);
+				$fileCreated = true;
+				$fileId = (int)$fileNode->getId();
+				if ($fileId <= 0) {
+					throw new \RuntimeException('Could not resolve new file ID.');
+				}
+
+				$padId = $this->padBootstrapService->provisionPadId($accessMode);
+				$this->padBootstrapService->pushInitialSnapshot($padId, $resolvedText, $resolvedHtml);
+				$padUrl = $this->etherpadClient->buildPadUrl($padId);
+
+				$content = $this->padFileService->buildInitialDocument(
+					$fileId,
+					$padId,
+					$accessMode,
+					$resolvedText,
+					$padUrl,
+				);
+				$content = $this->padFileService->withExportSnapshot(
+					$content,
+					$resolvedText,
+					$resolvedHtml,
+					0,
+					true,
+				);
+				$fileNode->putContent($content);
+				$this->bindingService->createBinding($fileId, $padId, $accessMode);
+
+				return [
+					'file' => $path,
+					'file_id' => $fileId,
+					'pad_id' => $padId,
+					'access_mode' => $accessMode,
+					'pad_url' => $padUrl,
+				];
+			},
+			function () use ($uid, $path, &$padId, &$fileCreated): void {
+				$this->rollbackService->rollbackFailedCreate($uid, $path, $padId, $fileCreated);
+			},
+			function (\Throwable $e) use ($path, $accessMode, &$padId): ?array {
+				if ($e instanceof BindingException) {
+					return [
+						'message' => 'Pad create-from-template hit existing binding',
+						'context' => [
+							'file' => $path,
+							'accessMode' => $accessMode,
+							'padId' => $padId,
+						],
+					];
+				}
+				return null;
+			},
+			function () use ($path, $accessMode, $templateFileId, &$padId): array {
+				return [
+					'message' => 'Pad create-from-template failed',
+					'context' => [
+						'file' => $path,
+						'templateFileId' => $templateFileId,
+						'accessMode' => $accessMode,
+						'padId' => $padId,
 					],
 				];
 			},

--- a/lib/Service/PadCreationService.php
+++ b/lib/Service/PadCreationService.php
@@ -274,7 +274,7 @@ class PadCreationService {
 	 * @return array{file:string,file_id:int,pad_id:string,access_mode:string,pad_url:string}
 	 */
 	public function createFromTemplate(string $uid, string $targetFile, int $templateFileId, ?IUser $user): array {
-		$resolvedTargetFile = $this->placeholderResolver->apply($targetFile, $user);
+		$resolvedTargetFile = $this->placeholderResolver->applyForPath($targetFile, $user);
 		$path = $this->padPaths->normalizeCreatePath($resolvedTargetFile);
 
 		$templateNode = $this->userNodeResolver->resolveUserFileNodeById($uid, $templateFileId);
@@ -363,8 +363,8 @@ class PadCreationService {
 		}
 
 		$snapshot = $this->padFileService->getSnapshotPartsFromBody((string)$parsed['body']);
-		$resolvedText = $this->placeholderResolver->apply($snapshot['text'], $user);
-		$resolvedHtml = $this->placeholderResolver->apply($snapshot['html'], $user);
+		$resolvedText = $this->placeholderResolver->applyForContent($snapshot['text'], $user);
+		$resolvedHtml = $this->placeholderResolver->applyForContent($snapshot['html'], $user);
 
 		$fileId = (int)$target->getId();
 		if ($fileId <= 0) {

--- a/lib/Service/PadCreationService.php
+++ b/lib/Service/PadCreationService.php
@@ -14,6 +14,7 @@ use OCA\EtherpadNextcloud\Exception\EtherpadClientException;
 use OCA\EtherpadNextcloud\Exception\NotAPadFileException;
 use OCA\EtherpadNextcloud\Exception\PadFileAlreadyExistsException;
 use OCA\EtherpadNextcloud\Exception\PadParentFolderNotWritableException;
+use OCP\Files\File;
 use OCP\IUser;
 use Psr\Log\LoggerInterface;
 
@@ -277,10 +278,72 @@ class PadCreationService {
 		$path = $this->padPaths->normalizeCreatePath($resolvedTargetFile);
 
 		$templateNode = $this->userNodeResolver->resolveUserFileNodeById($uid, $templateFileId);
-		if (!str_ends_with(strtolower($templateNode->getName()), '.pad')) {
+
+		$padId = '';
+		$fileCreated = false;
+
+		return $this->withCreateRollback(
+			function () use ($uid, $path, $templateNode, $user, &$padId, &$fileCreated): array {
+				$fileNode = $this->padFileCreator->createUserFile($uid, $path);
+				$fileCreated = true;
+
+				$result = $this->materializeTemplateInto($fileNode, $templateNode, $user);
+				$padId = $result['pad_id'];
+
+				return [
+					'file' => $path,
+					'file_id' => $result['file_id'],
+					'pad_id' => $result['pad_id'],
+					'access_mode' => $result['access_mode'],
+					'pad_url' => $result['pad_url'],
+				];
+			},
+			function () use ($uid, $path, &$padId, &$fileCreated): void {
+				$this->rollbackService->rollbackFailedCreate($uid, $path, $padId, $fileCreated);
+			},
+			function (\Throwable $e) use ($path, &$padId): ?array {
+				if ($e instanceof BindingException) {
+					return [
+						'message' => 'Pad create-from-template hit existing binding',
+						'context' => [
+							'file' => $path,
+							'padId' => $padId,
+						],
+					];
+				}
+				return null;
+			},
+			function () use ($path, $templateFileId, &$padId): array {
+				return [
+					'message' => 'Pad create-from-template failed',
+					'context' => [
+						'file' => $path,
+						'templateFileId' => $templateFileId,
+						'padId' => $padId,
+					],
+				];
+			},
+		);
+	}
+
+	/**
+	 * Shared core of the template materialization pipeline. Validates the
+	 * template, resolves placeholders, provisions a fresh pad, seeds its
+	 * content, writes the target file, and creates the binding. The target
+	 * file must already exist on disk (the callers either create it via
+	 * `PadFileCreator` or receive it pre-populated from NC's native template
+	 * copy flow).
+	 *
+	 * On any failure between provisioning and binding, the freshly created
+	 * Etherpad pad is best-effort deleted before rethrowing.
+	 *
+	 * @return array{file_id:int,pad_id:string,access_mode:string,pad_url:string}
+	 */
+	public function materializeTemplateInto(File $target, File $template, ?IUser $user): array {
+		if (!str_ends_with(strtolower($template->getName()), '.pad')) {
 			throw new NotAPadFileException('Template is not a .pad file.');
 		}
-		$templateContent = (string)$templateNode->getContent();
+		$templateContent = (string)$template->getContent();
 		if (trim($templateContent) === '') {
 			throw new \InvalidArgumentException('Template is empty.');
 		}
@@ -303,75 +366,51 @@ class PadCreationService {
 		$resolvedText = $this->placeholderResolver->apply($snapshot['text'], $user);
 		$resolvedHtml = $this->placeholderResolver->apply($snapshot['html'], $user);
 
-		$padId = '';
-		$fileCreated = false;
+		$fileId = (int)$target->getId();
+		if ($fileId <= 0) {
+			throw new \RuntimeException('Could not resolve target file ID.');
+		}
 
-		return $this->withCreateRollback(
-			function () use ($uid, $path, $accessMode, $resolvedText, $resolvedHtml, &$padId, &$fileCreated): array {
-				$fileNode = $this->padFileCreator->createUserFile($uid, $path);
-				$fileCreated = true;
-				$fileId = (int)$fileNode->getId();
-				if ($fileId <= 0) {
-					throw new \RuntimeException('Could not resolve new file ID.');
-				}
+		$padId = $this->padBootstrapService->provisionPadId($accessMode);
+		try {
+			$this->padBootstrapService->pushInitialSnapshot($padId, $resolvedText, $resolvedHtml);
+			$padUrl = $this->etherpadClient->buildPadUrl($padId);
 
-				$padId = $this->padBootstrapService->provisionPadId($accessMode);
-				$this->padBootstrapService->pushInitialSnapshot($padId, $resolvedText, $resolvedHtml);
-				$padUrl = $this->etherpadClient->buildPadUrl($padId);
+			$content = $this->padFileService->buildInitialDocument(
+				$fileId,
+				$padId,
+				$accessMode,
+				$resolvedText,
+				$padUrl,
+			);
+			$content = $this->padFileService->withExportSnapshot(
+				$content,
+				$resolvedText,
+				$resolvedHtml,
+				0,
+				true,
+			);
+			$target->putContent($content);
+			$this->bindingService->createBinding($fileId, $padId, $accessMode);
+		} catch (\Throwable $e) {
+			try {
+				$this->etherpadClient->deletePad($padId);
+			} catch (\Throwable $cleanupError) {
+				$this->logger->warning('Could not cleanup Etherpad pad after template materialization failure.', [
+					'app' => 'etherpad_nextcloud',
+					'padId' => $padId,
+					'exception' => $cleanupError,
+				]);
+			}
+			throw $e;
+		}
 
-				$content = $this->padFileService->buildInitialDocument(
-					$fileId,
-					$padId,
-					$accessMode,
-					$resolvedText,
-					$padUrl,
-				);
-				$content = $this->padFileService->withExportSnapshot(
-					$content,
-					$resolvedText,
-					$resolvedHtml,
-					0,
-					true,
-				);
-				$fileNode->putContent($content);
-				$this->bindingService->createBinding($fileId, $padId, $accessMode);
-
-				return [
-					'file' => $path,
-					'file_id' => $fileId,
-					'pad_id' => $padId,
-					'access_mode' => $accessMode,
-					'pad_url' => $padUrl,
-				];
-			},
-			function () use ($uid, $path, &$padId, &$fileCreated): void {
-				$this->rollbackService->rollbackFailedCreate($uid, $path, $padId, $fileCreated);
-			},
-			function (\Throwable $e) use ($path, $accessMode, &$padId): ?array {
-				if ($e instanceof BindingException) {
-					return [
-						'message' => 'Pad create-from-template hit existing binding',
-						'context' => [
-							'file' => $path,
-							'accessMode' => $accessMode,
-							'padId' => $padId,
-						],
-					];
-				}
-				return null;
-			},
-			function () use ($path, $accessMode, $templateFileId, &$padId): array {
-				return [
-					'message' => 'Pad create-from-template failed',
-					'context' => [
-						'file' => $path,
-						'templateFileId' => $templateFileId,
-						'accessMode' => $accessMode,
-						'padId' => $padId,
-					],
-				];
-			},
-		);
+		return [
+			'file_id' => $fileId,
+			'pad_id' => $padId,
+			'access_mode' => $accessMode,
+			'pad_url' => $padUrl,
+		];
 	}
 
 	/**

--- a/lib/Service/PadCreationService.php
+++ b/lib/Service/PadCreationService.php
@@ -337,6 +337,13 @@ class PadCreationService {
 	 * On any failure between provisioning and binding, the freshly created
 	 * Etherpad pad is best-effort deleted before rethrowing.
 	 *
+	 * Pad-lifecycle ownership: this method **owns the Etherpad-side lifecycle**
+	 * of any pad it provisions — callers that wrap the call in an outer
+	 * rollback (e.g. `withCreateRollback`) must NOT also try to delete the
+	 * pad in their rollback path. The outer wrapper's job is limited to the
+	 * Nextcloud file it created; the pad is already cleaned up internally if
+	 * we throw out of here.
+	 *
 	 * @return array{file_id:int,pad_id:string,access_mode:string,pad_url:string}
 	 */
 	public function materializeTemplateInto(File $target, File $template, ?IUser $user): array {
@@ -352,7 +359,10 @@ class PadCreationService {
 		$frontmatter = $parsed['frontmatter'];
 		$meta = $this->padFileService->extractPadMetadata($frontmatter);
 		$sourcePadId = (string)($meta['pad_id'] ?? '');
-		if ($sourcePadId === '' || str_starts_with($sourcePadId, 'ext.')
+		if ($sourcePadId === '') {
+			throw new \InvalidArgumentException('Template has no usable pad_id in its frontmatter.');
+		}
+		if (str_starts_with($sourcePadId, 'ext.')
 			|| $this->padFileService->isExternalFrontmatter($frontmatter, $sourcePadId)) {
 			throw new \InvalidArgumentException('External pads cannot be used as a template.');
 		}

--- a/lib/Service/PadPlaceholderResolver.php
+++ b/lib/Service/PadPlaceholderResolver.php
@@ -21,22 +21,48 @@ class PadPlaceholderResolver {
 	) {
 	}
 
-	public function apply(string $content, ?IUser $user): string {
+	/**
+	 * Resolve placeholders for use inside user-visible pad body content.
+	 * Display name and UID are preserved as-is so e.g. "AC/DC" stays "AC/DC".
+	 */
+	public function applyForContent(string $content, ?IUser $user): string {
+		return $this->applyInternal($content, $user, sanitizeUserValues: false);
+	}
+
+	/**
+	 * Resolve placeholders for use inside a target filename or path. Display
+	 * name and UID are stripped of `/`, `\`, NUL and leading dots so a
+	 * free-form display name can't smuggle path-traversal segments into the
+	 * resolved path. Use this when the resolved string is fed into a path
+	 * normaliser / file-create call.
+	 */
+	public function applyForPath(string $content, ?IUser $user): string {
+		return $this->applyInternal($content, $user, sanitizeUserValues: true);
+	}
+
+	private function applyInternal(string $content, ?IUser $user, bool $sanitizeUserValues): string {
 		return (string)preg_replace_callback(
 			self::TOKEN_REGEX,
-			fn (array $match): string => $this->resolve($match[1], $match[2] ?? '', $match[3] ?? '', $user, $match[0]),
+			fn (array $match): string => $this->resolve(
+				$match[1],
+				$match[2] ?? '',
+				$match[3] ?? '',
+				$user,
+				$match[0],
+				$sanitizeUserValues,
+			),
 			$content,
 		);
 	}
 
-	private function resolve(string $name, string $arg, string $format, ?IUser $user, string $original): string {
+	private function resolve(string $name, string $arg, string $format, ?IUser $user, string $original, bool $sanitizeUserValues): string {
 		$normalized = strtolower($name);
 		[$head, $property] = array_pad(explode('.', $normalized, 2), 2, '');
 		switch ($head) {
 			case 'date':
 				return $this->resolveDate($arg, $format, $original);
 			case 'user':
-				return $this->resolveUser($property, $user, $original);
+				return $this->resolveUser($property, $user, $original, $sanitizeUserValues);
 			default:
 				return $original;
 		}
@@ -67,18 +93,21 @@ class PadPlaceholderResolver {
 		}
 	}
 
-	private function resolveUser(string $arg, ?IUser $user, string $original): string {
+	private function resolveUser(string $arg, ?IUser $user, string $original, bool $sanitize): string {
 		if ($user === null) {
 			return $original;
 		}
 		switch (strtolower($arg)) {
 			case '':
-				return $this->sanitizePathLikeValue($user->getDisplayName());
+				$value = $user->getDisplayName();
+				break;
 			case 'uid':
-				return $this->sanitizePathLikeValue($user->getUID());
+				$value = $user->getUID();
+				break;
 			default:
 				return $original;
 		}
+		return $sanitize ? $this->sanitizePathLikeValue($value) : $value;
 	}
 
 	/**

--- a/lib/Service/PadPlaceholderResolver.php
+++ b/lib/Service/PadPlaceholderResolver.php
@@ -43,15 +43,28 @@ class PadPlaceholderResolver {
 	}
 
 	private function resolveDate(string $arg, string $format, string $original): string {
+		// Pin to UTC so resolver output is deterministic across server timezones —
+		// otherwise `strtotime`/`date` follow `date_default_timezone_get()` and
+		// "today" / "next monday" drift by ±1 day on western-tz hosts.
 		$reference = $this->timeFactory->getTime();
 		$expression = $arg === '' ? 'today' : $arg;
-		$timestamp = strtotime($expression, $reference);
-		if ($timestamp === false) {
+		try {
+			$utc = new \DateTimeZone('UTC');
+			$base = (new \DateTimeImmutable('@' . $reference))->setTimezone($utc);
+			$resolved = $base->modify($expression);
+			if ($resolved === false) {
+				return $original;
+			}
+		} catch (\Throwable) {
 			return $original;
 		}
+
 		$effectiveFormat = $format === '' ? self::DEFAULT_DATE_FORMAT : $format;
-		$rendered = @date($effectiveFormat, $timestamp);
-		return is_string($rendered) ? $rendered : $original;
+		try {
+			return $resolved->format($effectiveFormat);
+		} catch (\Throwable) {
+			return $original;
+		}
 	}
 
 	private function resolveUser(string $arg, ?IUser $user, string $original): string {
@@ -60,11 +73,28 @@ class PadPlaceholderResolver {
 		}
 		switch (strtolower($arg)) {
 			case '':
-				return $user->getDisplayName();
+				return $this->sanitizePathLikeValue($user->getDisplayName());
 			case 'uid':
-				return $user->getUID();
+				return $this->sanitizePathLikeValue($user->getUID());
 			default:
 				return $original;
 		}
+	}
+
+	/**
+	 * Strip characters that could break out of a filename segment when the
+	 * resolved value is interpolated into a user-supplied path (e.g. a target
+	 * file name in `createFromTemplate`). Display names are free-form and may
+	 * contain `/`, `\`, NUL or `..` — none of which belong inside a single
+	 * filename segment. We collapse runs of separators to a single space so
+	 * the result remains human-readable.
+	 */
+	private function sanitizePathLikeValue(string $value): string {
+		$cleaned = str_replace(["\0", "\r", "\n", "\t"], '', $value);
+		$cleaned = preg_replace('#[/\\\\]+#', ' ', $cleaned) ?? $cleaned;
+		// Disallow leading dots so a display name "..foo" can't become "../foo"
+		// after concatenation with separators.
+		$cleaned = preg_replace('/^\.+/', '', $cleaned) ?? $cleaned;
+		return trim($cleaned);
 	}
 }

--- a/lib/Service/PadPlaceholderResolver.php
+++ b/lib/Service/PadPlaceholderResolver.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Copyright (c) 2026 Jacob Bühler
+ */
+
+namespace OCA\EtherpadNextcloud\Service;
+
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\IUser;
+
+class PadPlaceholderResolver {
+	private const TOKEN_REGEX = '/\{\{\s*([a-z][a-z0-9_.]*)\s*(?::\s*([^|}]+?)\s*)?(?:\|\s*([^}]+?)\s*)?\}\}/i';
+	private const DEFAULT_DATE_FORMAT = 'Y-m-d';
+
+	public function __construct(
+		private ITimeFactory $timeFactory,
+	) {
+	}
+
+	public function apply(string $content, ?IUser $user): string {
+		return (string)preg_replace_callback(
+			self::TOKEN_REGEX,
+			fn (array $match): string => $this->resolve($match[1], $match[2] ?? '', $match[3] ?? '', $user, $match[0]),
+			$content,
+		);
+	}
+
+	private function resolve(string $name, string $arg, string $format, ?IUser $user, string $original): string {
+		$normalized = strtolower($name);
+		[$head, $property] = array_pad(explode('.', $normalized, 2), 2, '');
+		switch ($head) {
+			case 'date':
+				return $this->resolveDate($arg, $format, $original);
+			case 'user':
+				return $this->resolveUser($property, $user, $original);
+			default:
+				return $original;
+		}
+	}
+
+	private function resolveDate(string $arg, string $format, string $original): string {
+		$reference = $this->timeFactory->getTime();
+		$expression = $arg === '' ? 'today' : $arg;
+		$timestamp = strtotime($expression, $reference);
+		if ($timestamp === false) {
+			return $original;
+		}
+		$effectiveFormat = $format === '' ? self::DEFAULT_DATE_FORMAT : $format;
+		$rendered = @date($effectiveFormat, $timestamp);
+		return is_string($rendered) ? $rendered : $original;
+	}
+
+	private function resolveUser(string $arg, ?IUser $user, string $original): string {
+		if ($user === null) {
+			return $original;
+		}
+		switch (strtolower($arg)) {
+			case '':
+				return $user->getDisplayName();
+			case 'uid':
+				return $user->getUID();
+			default:
+				return $original;
+		}
+	}
+}

--- a/lib/Service/PadPlaceholderResolver.php
+++ b/lib/Service/PadPlaceholderResolver.php
@@ -60,6 +60,13 @@ class PadPlaceholderResolver {
 		[$head, $property] = array_pad(explode('.', $normalized, 2), 2, '');
 		switch ($head) {
 			case 'date':
+				// `date` directive uses `:` for its argument and `|` for the
+				// format — a dotted property is never meaningful. Leave such
+				// inputs as literal so the user can spot the typo rather than
+				// silently rendering today's date.
+				if ($property !== '') {
+					return $original;
+				}
 				return $this->resolveDate($arg, $format, $original);
 			case 'user':
 				return $this->resolveUser($property, $user, $original, $sanitizeUserValues);

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -27,6 +27,7 @@ $stubFiles = [
 	__DIR__ . '/stubs/OCP/Files/Folder.php',
 	__DIR__ . '/stubs/OCP/Files/IRootFolder.php',
 	__DIR__ . '/stubs/OCP/Files/NotFoundException.php',
+	__DIR__ . '/stubs/OCP/Files/Template/FileCreatedFromTemplateEvent.php',
 	__DIR__ . '/stubs/OCP/IRequest.php',
 	__DIR__ . '/stubs/OCP/Security/ISecureRandom.php',
 	__DIR__ . '/stubs/OCP/IConfig.php',

--- a/tests/phpunit/stubs/OCP/Files/File.php
+++ b/tests/phpunit/stubs/OCP/Files/File.php
@@ -17,9 +17,5 @@ if (!interface_exists(File::class)) {
 		public function getContent();
 
 		public function putContent($data): void;
-
-		public function getParent(): Folder;
-
-		public function move(string $targetPath): void;
 	}
 }

--- a/tests/phpunit/stubs/OCP/Files/File.php
+++ b/tests/phpunit/stubs/OCP/Files/File.php
@@ -17,5 +17,9 @@ if (!interface_exists(File::class)) {
 		public function getContent();
 
 		public function putContent($data): void;
+
+		public function getParent(): Folder;
+
+		public function move(string $targetPath): void;
 	}
 }

--- a/tests/phpunit/stubs/OCP/Files/Folder.php
+++ b/tests/phpunit/stubs/OCP/Files/Folder.php
@@ -15,7 +15,5 @@ if (!interface_exists(Folder::class)) {
 		public function isCreatable(): bool;
 
 		public function getPath(): string;
-
-		public function getNonExistingName(string $name): string;
 	}
 }

--- a/tests/phpunit/stubs/OCP/Files/Folder.php
+++ b/tests/phpunit/stubs/OCP/Files/Folder.php
@@ -13,5 +13,9 @@ if (!interface_exists(Folder::class)) {
 		public function newFile(string $name): mixed;
 
 		public function isCreatable(): bool;
+
+		public function getPath(): string;
+
+		public function getNonExistingName(string $name): string;
 	}
 }

--- a/tests/phpunit/stubs/OCP/Files/Template/FileCreatedFromTemplateEvent.php
+++ b/tests/phpunit/stubs/OCP/Files/Template/FileCreatedFromTemplateEvent.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCP\Files\Template;
+
+if (!class_exists(FileCreatedFromTemplateEvent::class)) {
+	class FileCreatedFromTemplateEvent extends \OCP\EventDispatcher\Event {
+		/**
+		 * @param array<string,mixed> $templateFields
+		 */
+		public function __construct(
+			private ?\OCP\Files\File $template,
+			private \OCP\Files\File $target,
+			private array $templateFields = [],
+		) {
+		}
+
+		public function getTemplate(): ?\OCP\Files\File {
+			return $this->template;
+		}
+
+		public function getTarget(): \OCP\Files\File {
+			return $this->target;
+		}
+
+		/** @return array<string,mixed> */
+		public function getTemplateFields(): array {
+			return $this->templateFields;
+		}
+	}
+}

--- a/tests/phpunit/unit/FileCreatedFromTemplateListenerTest.php
+++ b/tests/phpunit/unit/FileCreatedFromTemplateListenerTest.php
@@ -103,35 +103,14 @@ class FileCreatedFromTemplateListenerTest extends TestCase {
 			->handle(new FileCreatedFromTemplateEvent($template, $target));
 	}
 
-	public function testRenamesTargetWhenTemplateFilenameContainsPlaceholder(): void {
-		// NC asks the user for a target filename *before* showing the
-		// template picker, so the target ends up with whatever they typed
-		// ("Untitled.pad"). The placeholder lives in the template's filename
-		// and must be applied to the target after the copy.
+	public function testNeverRenamesTargetEvenWhenTemplateNameHasPlaceholder(): void {
+		// NC's TemplateManager re-fetches the new file by its original path
+		// *after* this event fires (TemplateManager.php:171). A rename here
+		// would break that lookup with NotFoundException → 403 to the
+		// client. Filename templating must come from elsewhere; this
+		// listener stays read-only on the file path.
 		$template = $this->file(7, 'Protokoll {{date:next monday|d.m.Y}}.pad', 'tpl');
-		$targetParent = $this->createMock(Folder::class);
-		$targetParent->method('getPath')->willReturn('/alice/files/Meetings');
-		$targetParent->expects($this->once())
-			->method('getNonExistingName')
-			->with('Protokoll 18.05.2026.pad')
-			->willReturn('Protokoll 18.05.2026.pad');
-		$target = $this->file(99, 'Untitled.pad', '', $targetParent);
-		$target->expects($this->once())
-			->method('move')
-			->with('/alice/files/Meetings/Protokoll 18.05.2026.pad');
-
-		$padFileService = $this->minimalPadFileService();
-		$bootstrap = $this->minimalBootstrap();
-		$bindingService = $this->createMock(BindingService::class);
-		$bindingService->method('createBinding');
-
-		$this->buildListener($bindingService, $padFileService, $bootstrap)
-			->handle(new FileCreatedFromTemplateEvent($template, $target));
-	}
-
-	public function testLeavesTargetNameAloneWhenTemplateHasNoPlaceholder(): void {
-		$template = $this->file(7, 'Plain-Template.pad', 'tpl');
-		$target = $this->file(99, 'My Notes.pad', '');
+		$target = $this->file(99, 'Untitled.pad', '');
 		$target->expects($this->never())->method('move');
 
 		$padFileService = $this->minimalPadFileService();

--- a/tests/phpunit/unit/FileCreatedFromTemplateListenerTest.php
+++ b/tests/phpunit/unit/FileCreatedFromTemplateListenerTest.php
@@ -5,262 +5,112 @@ declare(strict_types=1);
 namespace OCA\EtherpadNextcloud\Tests\Unit;
 
 use OCA\EtherpadNextcloud\Listeners\FileCreatedFromTemplateListener;
-use OCA\EtherpadNextcloud\Service\BindingService;
-use OCA\EtherpadNextcloud\Service\EtherpadClient;
-use OCA\EtherpadNextcloud\Service\PadBootstrapService;
-use OCA\EtherpadNextcloud\Service\PadFileService;
-use OCA\EtherpadNextcloud\Service\PadPlaceholderResolver;
-use OCP\AppFramework\Utility\ITimeFactory;
+use OCA\EtherpadNextcloud\Service\PadCreationService;
 use OCP\EventDispatcher\Event;
 use OCP\Files\File;
-use OCP\Files\Folder;
 use OCP\Files\Template\FileCreatedFromTemplateEvent;
 use OCP\IUser;
 use OCP\IUserSession;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
+/**
+ * The listener is now a thin wrapper that delegates the template
+ * materialization pipeline to `PadCreationService::materializeTemplateInto`.
+ * Detailed behavior of that pipeline (external template handling, binding
+ * cleanup, etc.) is exercised in `PadCreationServiceTest`. The cases here
+ * focus on the listener-specific responsibilities: filtering irrelevant
+ * events and resetting the NC byte-copy to empty when materialization fails.
+ */
 class FileCreatedFromTemplateListenerTest extends TestCase {
-	private const FIXED_NOW = 1778976000; // 2026-05-17 (Sunday)
-
 	public function testIgnoresUnrelatedEvent(): void {
-		$bindingService = $this->createMock(BindingService::class);
-		$bindingService->expects($this->never())->method('createBinding');
+		$service = $this->createMock(PadCreationService::class);
+		$service->expects($this->never())->method('materializeTemplateInto');
 
-		$this->buildListener($bindingService)->handle(new class extends Event {});
+		$this->buildListener($service)->handle(new class extends Event {});
 	}
 
 	public function testIgnoresNonPadTarget(): void {
-		$target = $this->file(101, 'Notes.txt', '');
-		$bindingService = $this->createMock(BindingService::class);
-		$bindingService->expects($this->never())->method('createBinding');
+		$service = $this->createMock(PadCreationService::class);
+		$service->expects($this->never())->method('materializeTemplateInto');
 
-		$this->buildListener($bindingService)->handle(new FileCreatedFromTemplateEvent(
-			$this->file(7, 'Template.pad', ''),
-			$target,
+		$this->buildListener($service)->handle(new FileCreatedFromTemplateEvent(
+			$this->file('Template.pad'),
+			$this->file('Notes.txt'),
 		));
 	}
 
-	public function testIgnoresBlankTemplate(): void {
-		$bindingService = $this->createMock(BindingService::class);
-		$bindingService->expects($this->never())->method('createBinding');
+	public function testIgnoresMissingTemplate(): void {
+		$service = $this->createMock(PadCreationService::class);
+		$service->expects($this->never())->method('materializeTemplateInto');
 
-		$this->buildListener($bindingService)->handle(new FileCreatedFromTemplateEvent(
+		$this->buildListener($service)->handle(new FileCreatedFromTemplateEvent(
 			null,
-			$this->file(102, 'New.pad', ''),
+			$this->file('New.pad'),
 		));
 	}
 
-	public function testMaterializesFromTemplate(): void {
-		$template = $this->file(7, 'Protokoll-Template.pad', 'tpl-content');
-		$targetParent = $this->createMock(Folder::class);
-		$targetParent->method('getPath')->willReturn('/alice/files/Meetings');
-		$target = $this->file(99, 'Protokoll.pad', '', $targetParent);
-		$target->expects($this->once())
-			->method('putContent')
-			->with($this->stringContains('snapshot+placeholders'));
+	public function testDelegatesToService(): void {
+		$template = $this->file('Tpl.pad');
+		$target = $this->file('New.pad');
+		$target->expects($this->never())->method('putContent');
 
-		$padFileService = $this->createMock(PadFileService::class);
-		$padFileService->method('parsePadFile')->with('tpl-content')->willReturn([
-			'frontmatter' => ['pad_id' => 'g.tpl$pad', 'access_mode' => 'protected'],
-			'body' => 'body',
-		]);
-		$padFileService->method('extractPadMetadata')->willReturn([
-			'pad_id' => 'g.tpl$pad',
-			'access_mode' => 'protected',
-			'pad_url' => '',
-		]);
-		$padFileService->method('isExternalFrontmatter')->willReturn(false);
-		$padFileService->method('getSnapshotPartsFromBody')->willReturn([
-			'text' => 'Sitzung am {{date:next monday|d.m.Y}}',
-			'html' => '<p>{{date:next monday|d.m.Y}}</p>',
-		]);
-		$padFileService->method('buildInitialDocument')->willReturn('initial-doc');
-		$padFileService->method('withExportSnapshot')->willReturn('snapshot+placeholders-applied');
+		$service = $this->createMock(PadCreationService::class);
+		$service->expects($this->once())
+			->method('materializeTemplateInto')
+			->with($target, $template, $this->isInstanceOf(IUser::class));
 
-		$bootstrap = $this->createMock(PadBootstrapService::class);
-		$bootstrap->expects($this->once())
-			->method('provisionPadId')
-			->with('protected')
-			->willReturn('p-newpad123');
-		$bootstrap->expects($this->once())
-			->method('pushInitialSnapshot')
-			->with(
-				'p-newpad123',
-				'Sitzung am 18.05.2026',
-				'<p>18.05.2026</p>',
-			);
-
-		$bindingService = $this->createMock(BindingService::class);
-		$bindingService->expects($this->once())
-			->method('createBinding')
-			->with(99, 'p-newpad123', 'protected');
-
-		$etherpadClient = $this->createMock(EtherpadClient::class);
-		$etherpadClient->method('buildPadUrl')->willReturn('https://pad.example.test/p/p-newpad123');
-
-		$this->buildListener($bindingService, $padFileService, $bootstrap, $etherpadClient)
-			->handle(new FileCreatedFromTemplateEvent($template, $target));
+		$this->buildListener($service)->handle(new FileCreatedFromTemplateEvent($template, $target));
 	}
 
-	public function testNeverRenamesTargetEvenWhenTemplateNameHasPlaceholder(): void {
-		// NC's TemplateManager re-fetches the new file by its original path
-		// *after* this event fires (TemplateManager.php:171). A rename here
-		// would break that lookup with NotFoundException → 403 to the
-		// client. Filename templating must come from elsewhere; this
-		// listener stays read-only on the file path.
-		$template = $this->file(7, 'Protokoll {{date:next monday|d.m.Y}}.pad', 'tpl');
-		$target = $this->file(99, 'Untitled.pad', '');
-		$target->expects($this->never())->method('move');
-
-		$padFileService = $this->minimalPadFileService();
-		$bootstrap = $this->minimalBootstrap();
-		$bindingService = $this->createMock(BindingService::class);
-		$bindingService->method('createBinding');
-
-		$this->buildListener($bindingService, $padFileService, $bootstrap)
-			->handle(new FileCreatedFromTemplateEvent($template, $target));
-	}
-
-	public function testWipesTargetWhenTemplateIsExternal(): void {
-		// NC has already byte-copied the external template's frontmatter
-		// (with ext.* pad_id) into the new file. Leaving it there would
-		// confuse the open flow and leak the source's external pad URL.
-		// Reset the target to empty so the regular missing-frontmatter
-		// init creates a clean managed pad on first open.
-		$template = $this->file(7, 'External.pad', 'tpl');
-		$target = $this->file(99, 'New.pad', '');
+	public function testResetsTargetWhenServiceThrows(): void {
+		$template = $this->file('Tpl.pad');
+		$target = $this->file('New.pad');
 		$target->expects($this->once())->method('putContent')->with('');
 
-		$padFileService = $this->createMock(PadFileService::class);
-		$padFileService->method('parsePadFile')->willReturn([
-			'frontmatter' => ['pad_id' => 'ext.remote', 'access_mode' => 'public'],
-			'body' => '',
-		]);
-		$padFileService->method('extractPadMetadata')->willReturn(['pad_id' => 'ext.remote']);
+		$service = $this->createMock(PadCreationService::class);
+		$service->method('materializeTemplateInto')
+			->willThrowException(new \RuntimeException('boom'));
 
-		$bootstrap = $this->createMock(PadBootstrapService::class);
-		$bootstrap->expects($this->never())->method('provisionPadId');
-
-		$bindingService = $this->createMock(BindingService::class);
-		$bindingService->expects($this->never())->method('createBinding');
-
-		$this->buildListener($bindingService, $padFileService, $bootstrap)
-			->handle(new FileCreatedFromTemplateEvent($template, $target));
+		$this->buildListener($service)->handle(new FileCreatedFromTemplateEvent($template, $target));
 	}
 
-	public function testWipesTargetWhenTemplateFrontmatterIsUnparseable(): void {
-		$template = $this->file(7, 'Broken.pad', 'tpl');
-		$target = $this->file(99, 'New.pad', '');
+	public function testResetsTargetWhenNoUserInSession(): void {
+		$template = $this->file('Tpl.pad');
+		$target = $this->file('New.pad');
 		$target->expects($this->once())->method('putContent')->with('');
 
-		$padFileService = $this->createMock(PadFileService::class);
-		$padFileService->method('parsePadFile')->willThrowException(new \RuntimeException('not yaml'));
+		$service = $this->createMock(PadCreationService::class);
+		$service->expects($this->never())->method('materializeTemplateInto');
 
-		$bootstrap = $this->createMock(PadBootstrapService::class);
-		$bootstrap->expects($this->never())->method('provisionPadId');
-
-		$bindingService = $this->createMock(BindingService::class);
-		$bindingService->expects($this->never())->method('createBinding');
-
-		$this->buildListener($bindingService, $padFileService, $bootstrap)
-			->handle(new FileCreatedFromTemplateEvent($template, $target));
-	}
-
-	public function testWipesTargetAndDeletesPadWhenBindingFails(): void {
-		// createBinding can fail (unique-constraint race, DB error). The
-		// freshly provisioned Etherpad pad must be deleted and the target
-		// file wiped so the user gets a clean state instead of a .pad
-		// pointing at a deleted pad_id.
-		$template = $this->file(7, 'Tpl.pad', 'tpl');
-		$target = $this->file(99, 'New.pad', '');
-		$putCalls = [];
-		$target->method('putContent')->willReturnCallback(
-			static function (string $content) use (&$putCalls): void {
-				$putCalls[] = $content;
-			}
-		);
-
-		$padFileService = $this->minimalPadFileService();
-		$bootstrap = $this->createMock(PadBootstrapService::class);
-		$bootstrap->method('provisionPadId')->willReturn('p-doomed');
-		$bootstrap->method('pushInitialSnapshot');
-
-		$bindingService = $this->createMock(BindingService::class);
-		$bindingService->method('createBinding')->willThrowException(new \RuntimeException('binding race'));
-
-		$etherpadClient = $this->createMock(EtherpadClient::class);
-		$etherpadClient->method('buildPadUrl')->willReturn('https://pad.example.test/p/p-doomed');
-		// Cleanup: the freshly provisioned pad has to be deleted.
-		$etherpadClient->expects($this->once())->method('deletePad')->with('p-doomed');
-
-		$this->buildListener($bindingService, $padFileService, $bootstrap, $etherpadClient)
-			->handle(new FileCreatedFromTemplateEvent($template, $target));
-
-		// First putContent wrote the template payload; second wiped it back
-		// to empty after the binding race surfaced via the handle() catch.
-		$this->assertCount(2, $putCalls);
-		$this->assertSame('', end($putCalls));
+		$listener = $this->buildListener($service, withUser: false);
+		$listener->handle(new FileCreatedFromTemplateEvent($template, $target));
 	}
 
 	private function buildListener(
-		?BindingService $bindingService = null,
-		?PadFileService $padFileService = null,
-		?PadBootstrapService $bootstrap = null,
-		?EtherpadClient $etherpadClient = null,
+		PadCreationService $service,
+		bool $withUser = true,
 	): FileCreatedFromTemplateListener {
-		$user = $this->createMock(IUser::class);
-		$user->method('getDisplayName')->willReturn('Jacob');
-		$user->method('getUID')->willReturn('jaggob');
 		$userSession = $this->createMock(IUserSession::class);
-		$userSession->method('getUser')->willReturn($user);
-
-		$time = $this->createMock(ITimeFactory::class);
-		$time->method('getTime')->willReturn(self::FIXED_NOW);
-
+		if ($withUser) {
+			$user = $this->createMock(IUser::class);
+			$user->method('getUID')->willReturn('alice');
+			$user->method('getDisplayName')->willReturn('Alice');
+			$userSession->method('getUser')->willReturn($user);
+		} else {
+			$userSession->method('getUser')->willReturn(null);
+		}
 		return new FileCreatedFromTemplateListener(
-			$padFileService ?? $this->minimalPadFileService(),
-			new PadPlaceholderResolver($time),
-			$bootstrap ?? $this->minimalBootstrap(),
-			$bindingService ?? $this->createMock(BindingService::class),
-			$etherpadClient ?? $this->createMock(EtherpadClient::class),
+			$service,
 			$userSession,
 			$this->createMock(LoggerInterface::class),
 		);
 	}
 
-	private function minimalPadFileService(): PadFileService {
-		$padFileService = $this->createMock(PadFileService::class);
-		$padFileService->method('parsePadFile')->willReturn([
-			'frontmatter' => ['pad_id' => 'g.tpl$pad', 'access_mode' => 'protected'],
-			'body' => '',
-		]);
-		$padFileService->method('extractPadMetadata')->willReturn([
-			'pad_id' => 'g.tpl$pad',
-			'access_mode' => 'protected',
-			'pad_url' => '',
-		]);
-		$padFileService->method('isExternalFrontmatter')->willReturn(false);
-		$padFileService->method('getSnapshotPartsFromBody')->willReturn(['text' => '', 'html' => '']);
-		$padFileService->method('buildInitialDocument')->willReturn('initial-doc');
-		$padFileService->method('withExportSnapshot')->willReturn('updated-doc');
-		return $padFileService;
-	}
-
-	private function minimalBootstrap(): PadBootstrapService {
-		$bootstrap = $this->createMock(PadBootstrapService::class);
-		$bootstrap->method('provisionPadId')->willReturn('p-new');
-		return $bootstrap;
-	}
-
-	private function file(int $id, string $name, string $content, ?Folder $parent = null): File {
+	private function file(string $name): File {
 		$file = $this->createMock(File::class);
-		$file->method('getId')->willReturn($id);
 		$file->method('getName')->willReturn($name);
-		$file->method('getContent')->willReturn($content);
-		if ($parent !== null) {
-			$file->method('getParent')->willReturn($parent);
-		}
+		$file->method('getId')->willReturn(42);
 		return $file;
 	}
 }

--- a/tests/phpunit/unit/FileCreatedFromTemplateListenerTest.php
+++ b/tests/phpunit/unit/FileCreatedFromTemplateListenerTest.php
@@ -103,7 +103,11 @@ class FileCreatedFromTemplateListenerTest extends TestCase {
 			->handle(new FileCreatedFromTemplateEvent($template, $target));
 	}
 
-	public function testRenamesTargetWhenFilenameContainsPlaceholder(): void {
+	public function testRenamesTargetWhenTemplateFilenameContainsPlaceholder(): void {
+		// NC asks the user for a target filename *before* showing the
+		// template picker, so the target ends up with whatever they typed
+		// ("Untitled.pad"). The placeholder lives in the template's filename
+		// and must be applied to the target after the copy.
 		$template = $this->file(7, 'Protokoll {{date:next monday|d.m.Y}}.pad', 'tpl');
 		$targetParent = $this->createMock(Folder::class);
 		$targetParent->method('getPath')->willReturn('/alice/files/Meetings');
@@ -111,10 +115,24 @@ class FileCreatedFromTemplateListenerTest extends TestCase {
 			->method('getNonExistingName')
 			->with('Protokoll 18.05.2026.pad')
 			->willReturn('Protokoll 18.05.2026.pad');
-		$target = $this->file(99, 'Protokoll {{date:next monday|d.m.Y}}.pad', '', $targetParent);
+		$target = $this->file(99, 'Untitled.pad', '', $targetParent);
 		$target->expects($this->once())
 			->method('move')
 			->with('/alice/files/Meetings/Protokoll 18.05.2026.pad');
+
+		$padFileService = $this->minimalPadFileService();
+		$bootstrap = $this->minimalBootstrap();
+		$bindingService = $this->createMock(BindingService::class);
+		$bindingService->method('createBinding');
+
+		$this->buildListener($bindingService, $padFileService, $bootstrap)
+			->handle(new FileCreatedFromTemplateEvent($template, $target));
+	}
+
+	public function testLeavesTargetNameAloneWhenTemplateHasNoPlaceholder(): void {
+		$template = $this->file(7, 'Plain-Template.pad', 'tpl');
+		$target = $this->file(99, 'My Notes.pad', '');
+		$target->expects($this->never())->method('move');
 
 		$padFileService = $this->minimalPadFileService();
 		$bootstrap = $this->minimalBootstrap();

--- a/tests/phpunit/unit/FileCreatedFromTemplateListenerTest.php
+++ b/tests/phpunit/unit/FileCreatedFromTemplateListenerTest.php
@@ -122,10 +122,15 @@ class FileCreatedFromTemplateListenerTest extends TestCase {
 			->handle(new FileCreatedFromTemplateEvent($template, $target));
 	}
 
-	public function testSkipsExternalTemplateGracefully(): void {
+	public function testWipesTargetWhenTemplateIsExternal(): void {
+		// NC has already byte-copied the external template's frontmatter
+		// (with ext.* pad_id) into the new file. Leaving it there would
+		// confuse the open flow and leak the source's external pad URL.
+		// Reset the target to empty so the regular missing-frontmatter
+		// init creates a clean managed pad on first open.
 		$template = $this->file(7, 'External.pad', 'tpl');
 		$target = $this->file(99, 'New.pad', '');
-		$target->expects($this->never())->method('putContent');
+		$target->expects($this->once())->method('putContent')->with('');
 
 		$padFileService = $this->createMock(PadFileService::class);
 		$padFileService->method('parsePadFile')->willReturn([
@@ -142,6 +147,60 @@ class FileCreatedFromTemplateListenerTest extends TestCase {
 
 		$this->buildListener($bindingService, $padFileService, $bootstrap)
 			->handle(new FileCreatedFromTemplateEvent($template, $target));
+	}
+
+	public function testWipesTargetWhenTemplateFrontmatterIsUnparseable(): void {
+		$template = $this->file(7, 'Broken.pad', 'tpl');
+		$target = $this->file(99, 'New.pad', '');
+		$target->expects($this->once())->method('putContent')->with('');
+
+		$padFileService = $this->createMock(PadFileService::class);
+		$padFileService->method('parsePadFile')->willThrowException(new \RuntimeException('not yaml'));
+
+		$bootstrap = $this->createMock(PadBootstrapService::class);
+		$bootstrap->expects($this->never())->method('provisionPadId');
+
+		$bindingService = $this->createMock(BindingService::class);
+		$bindingService->expects($this->never())->method('createBinding');
+
+		$this->buildListener($bindingService, $padFileService, $bootstrap)
+			->handle(new FileCreatedFromTemplateEvent($template, $target));
+	}
+
+	public function testWipesTargetAndDeletesPadWhenBindingFails(): void {
+		// createBinding can fail (unique-constraint race, DB error). The
+		// freshly provisioned Etherpad pad must be deleted and the target
+		// file wiped so the user gets a clean state instead of a .pad
+		// pointing at a deleted pad_id.
+		$template = $this->file(7, 'Tpl.pad', 'tpl');
+		$target = $this->file(99, 'New.pad', '');
+		$putCalls = [];
+		$target->method('putContent')->willReturnCallback(
+			static function (string $content) use (&$putCalls): void {
+				$putCalls[] = $content;
+			}
+		);
+
+		$padFileService = $this->minimalPadFileService();
+		$bootstrap = $this->createMock(PadBootstrapService::class);
+		$bootstrap->method('provisionPadId')->willReturn('p-doomed');
+		$bootstrap->method('pushInitialSnapshot');
+
+		$bindingService = $this->createMock(BindingService::class);
+		$bindingService->method('createBinding')->willThrowException(new \RuntimeException('binding race'));
+
+		$etherpadClient = $this->createMock(EtherpadClient::class);
+		$etherpadClient->method('buildPadUrl')->willReturn('https://pad.example.test/p/p-doomed');
+		// Cleanup: the freshly provisioned pad has to be deleted.
+		$etherpadClient->expects($this->once())->method('deletePad')->with('p-doomed');
+
+		$this->buildListener($bindingService, $padFileService, $bootstrap, $etherpadClient)
+			->handle(new FileCreatedFromTemplateEvent($template, $target));
+
+		// First putContent wrote the template payload; second wiped it back
+		// to empty after the binding race surfaced via the handle() catch.
+		$this->assertCount(2, $putCalls);
+		$this->assertSame('', end($putCalls));
 	}
 
 	private function buildListener(

--- a/tests/phpunit/unit/FileCreatedFromTemplateListenerTest.php
+++ b/tests/phpunit/unit/FileCreatedFromTemplateListenerTest.php
@@ -1,0 +1,210 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\EtherpadNextcloud\Tests\Unit;
+
+use OCA\EtherpadNextcloud\Listeners\FileCreatedFromTemplateListener;
+use OCA\EtherpadNextcloud\Service\BindingService;
+use OCA\EtherpadNextcloud\Service\EtherpadClient;
+use OCA\EtherpadNextcloud\Service\PadBootstrapService;
+use OCA\EtherpadNextcloud\Service\PadFileService;
+use OCA\EtherpadNextcloud\Service\PadPlaceholderResolver;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\EventDispatcher\Event;
+use OCP\Files\File;
+use OCP\Files\Folder;
+use OCP\Files\Template\FileCreatedFromTemplateEvent;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+class FileCreatedFromTemplateListenerTest extends TestCase {
+	private const FIXED_NOW = 1778976000; // 2026-05-17 (Sunday)
+
+	public function testIgnoresUnrelatedEvent(): void {
+		$bindingService = $this->createMock(BindingService::class);
+		$bindingService->expects($this->never())->method('createBinding');
+
+		$this->buildListener($bindingService)->handle(new class extends Event {});
+	}
+
+	public function testIgnoresNonPadTarget(): void {
+		$target = $this->file(101, 'Notes.txt', '');
+		$bindingService = $this->createMock(BindingService::class);
+		$bindingService->expects($this->never())->method('createBinding');
+
+		$this->buildListener($bindingService)->handle(new FileCreatedFromTemplateEvent(
+			$this->file(7, 'Template.pad', ''),
+			$target,
+		));
+	}
+
+	public function testIgnoresBlankTemplate(): void {
+		$bindingService = $this->createMock(BindingService::class);
+		$bindingService->expects($this->never())->method('createBinding');
+
+		$this->buildListener($bindingService)->handle(new FileCreatedFromTemplateEvent(
+			null,
+			$this->file(102, 'New.pad', ''),
+		));
+	}
+
+	public function testMaterializesFromTemplate(): void {
+		$template = $this->file(7, 'Protokoll-Template.pad', 'tpl-content');
+		$targetParent = $this->createMock(Folder::class);
+		$targetParent->method('getPath')->willReturn('/alice/files/Meetings');
+		$target = $this->file(99, 'Protokoll.pad', '', $targetParent);
+		$target->expects($this->once())
+			->method('putContent')
+			->with($this->stringContains('snapshot+placeholders'));
+
+		$padFileService = $this->createMock(PadFileService::class);
+		$padFileService->method('parsePadFile')->with('tpl-content')->willReturn([
+			'frontmatter' => ['pad_id' => 'g.tpl$pad', 'access_mode' => 'protected'],
+			'body' => 'body',
+		]);
+		$padFileService->method('extractPadMetadata')->willReturn([
+			'pad_id' => 'g.tpl$pad',
+			'access_mode' => 'protected',
+			'pad_url' => '',
+		]);
+		$padFileService->method('isExternalFrontmatter')->willReturn(false);
+		$padFileService->method('getSnapshotPartsFromBody')->willReturn([
+			'text' => 'Sitzung am {{date:next monday|d.m.Y}}',
+			'html' => '<p>{{date:next monday|d.m.Y}}</p>',
+		]);
+		$padFileService->method('buildInitialDocument')->willReturn('initial-doc');
+		$padFileService->method('withExportSnapshot')->willReturn('snapshot+placeholders-applied');
+
+		$bootstrap = $this->createMock(PadBootstrapService::class);
+		$bootstrap->expects($this->once())
+			->method('provisionPadId')
+			->with('protected')
+			->willReturn('p-newpad123');
+		$bootstrap->expects($this->once())
+			->method('pushInitialSnapshot')
+			->with(
+				'p-newpad123',
+				'Sitzung am 18.05.2026',
+				'<p>18.05.2026</p>',
+			);
+
+		$bindingService = $this->createMock(BindingService::class);
+		$bindingService->expects($this->once())
+			->method('createBinding')
+			->with(99, 'p-newpad123', 'protected');
+
+		$etherpadClient = $this->createMock(EtherpadClient::class);
+		$etherpadClient->method('buildPadUrl')->willReturn('https://pad.example.test/p/p-newpad123');
+
+		$this->buildListener($bindingService, $padFileService, $bootstrap, $etherpadClient)
+			->handle(new FileCreatedFromTemplateEvent($template, $target));
+	}
+
+	public function testRenamesTargetWhenFilenameContainsPlaceholder(): void {
+		$template = $this->file(7, 'Protokoll {{date:next monday|d.m.Y}}.pad', 'tpl');
+		$targetParent = $this->createMock(Folder::class);
+		$targetParent->method('getPath')->willReturn('/alice/files/Meetings');
+		$targetParent->expects($this->once())
+			->method('getNonExistingName')
+			->with('Protokoll 18.05.2026.pad')
+			->willReturn('Protokoll 18.05.2026.pad');
+		$target = $this->file(99, 'Protokoll {{date:next monday|d.m.Y}}.pad', '', $targetParent);
+		$target->expects($this->once())
+			->method('move')
+			->with('/alice/files/Meetings/Protokoll 18.05.2026.pad');
+
+		$padFileService = $this->minimalPadFileService();
+		$bootstrap = $this->minimalBootstrap();
+		$bindingService = $this->createMock(BindingService::class);
+		$bindingService->method('createBinding');
+
+		$this->buildListener($bindingService, $padFileService, $bootstrap)
+			->handle(new FileCreatedFromTemplateEvent($template, $target));
+	}
+
+	public function testSkipsExternalTemplateGracefully(): void {
+		$template = $this->file(7, 'External.pad', 'tpl');
+		$target = $this->file(99, 'New.pad', '');
+		$target->expects($this->never())->method('putContent');
+
+		$padFileService = $this->createMock(PadFileService::class);
+		$padFileService->method('parsePadFile')->willReturn([
+			'frontmatter' => ['pad_id' => 'ext.remote', 'access_mode' => 'public'],
+			'body' => '',
+		]);
+		$padFileService->method('extractPadMetadata')->willReturn(['pad_id' => 'ext.remote']);
+
+		$bootstrap = $this->createMock(PadBootstrapService::class);
+		$bootstrap->expects($this->never())->method('provisionPadId');
+
+		$bindingService = $this->createMock(BindingService::class);
+		$bindingService->expects($this->never())->method('createBinding');
+
+		$this->buildListener($bindingService, $padFileService, $bootstrap)
+			->handle(new FileCreatedFromTemplateEvent($template, $target));
+	}
+
+	private function buildListener(
+		?BindingService $bindingService = null,
+		?PadFileService $padFileService = null,
+		?PadBootstrapService $bootstrap = null,
+		?EtherpadClient $etherpadClient = null,
+	): FileCreatedFromTemplateListener {
+		$user = $this->createMock(IUser::class);
+		$user->method('getDisplayName')->willReturn('Jacob');
+		$user->method('getUID')->willReturn('jaggob');
+		$userSession = $this->createMock(IUserSession::class);
+		$userSession->method('getUser')->willReturn($user);
+
+		$time = $this->createMock(ITimeFactory::class);
+		$time->method('getTime')->willReturn(self::FIXED_NOW);
+
+		return new FileCreatedFromTemplateListener(
+			$padFileService ?? $this->minimalPadFileService(),
+			new PadPlaceholderResolver($time),
+			$bootstrap ?? $this->minimalBootstrap(),
+			$bindingService ?? $this->createMock(BindingService::class),
+			$etherpadClient ?? $this->createMock(EtherpadClient::class),
+			$userSession,
+			$this->createMock(LoggerInterface::class),
+		);
+	}
+
+	private function minimalPadFileService(): PadFileService {
+		$padFileService = $this->createMock(PadFileService::class);
+		$padFileService->method('parsePadFile')->willReturn([
+			'frontmatter' => ['pad_id' => 'g.tpl$pad', 'access_mode' => 'protected'],
+			'body' => '',
+		]);
+		$padFileService->method('extractPadMetadata')->willReturn([
+			'pad_id' => 'g.tpl$pad',
+			'access_mode' => 'protected',
+			'pad_url' => '',
+		]);
+		$padFileService->method('isExternalFrontmatter')->willReturn(false);
+		$padFileService->method('getSnapshotPartsFromBody')->willReturn(['text' => '', 'html' => '']);
+		$padFileService->method('buildInitialDocument')->willReturn('initial-doc');
+		$padFileService->method('withExportSnapshot')->willReturn('updated-doc');
+		return $padFileService;
+	}
+
+	private function minimalBootstrap(): PadBootstrapService {
+		$bootstrap = $this->createMock(PadBootstrapService::class);
+		$bootstrap->method('provisionPadId')->willReturn('p-new');
+		return $bootstrap;
+	}
+
+	private function file(int $id, string $name, string $content, ?Folder $parent = null): File {
+		$file = $this->createMock(File::class);
+		$file->method('getId')->willReturn($id);
+		$file->method('getName')->willReturn($name);
+		$file->method('getContent')->willReturn($content);
+		if ($parent !== null) {
+			$file->method('getParent')->willReturn($parent);
+		}
+		return $file;
+	}
+}

--- a/tests/phpunit/unit/PadCreationServiceTest.php
+++ b/tests/phpunit/unit/PadCreationServiceTest.php
@@ -274,6 +274,114 @@ class PadCreationServiceTest extends TestCase {
 			->createFromUrl('alice', '/External', 'https://pad.remote.test/p/RemotePad');
 	}
 
+	public function testCreateFromTemplateProvisionsFreshPadWithResolvedBody(): void {
+		$templateNode = $this->createMock(\OCP\Files\File::class);
+		$templateNode->method('getName')->willReturn('Protokoll-Tpl.pad');
+		$templateNode->method('getContent')->willReturn('tpl-content');
+
+		$userNodeResolver = $this->createMock(UserNodeResolver::class);
+		$userNodeResolver->method('resolveUserFileNodeById')
+			->with('alice', 7)
+			->willReturn($templateNode);
+
+		$padPaths = $this->createMock(PadPathService::class);
+		$padPaths->method('normalizeCreatePath')->with('/Meetings/Protokoll 18.05.2026.pad')->willReturn('/Meetings/Protokoll 18.05.2026.pad');
+
+		$newFile = $this->createMock(\OCP\Files\File::class);
+		$newFile->method('getId')->willReturn(99);
+		$newFile->expects($this->once())->method('putContent');
+		$fileCreator = $this->createMock(PadFileCreator::class);
+		$fileCreator->method('createUserFile')->with('alice', '/Meetings/Protokoll 18.05.2026.pad')->willReturn($newFile);
+
+		$padFileService = $this->createMock(PadFileService::class);
+		$padFileService->method('parsePadFile')->with('tpl-content')->willReturn([
+			'frontmatter' => ['pad_id' => 'g.tpl$pad', 'access_mode' => BindingService::ACCESS_PROTECTED],
+			'body' => 'body',
+		]);
+		$padFileService->method('extractPadMetadata')->willReturn([
+			'pad_id' => 'g.tpl$pad',
+			'access_mode' => BindingService::ACCESS_PROTECTED,
+			'pad_url' => '',
+		]);
+		$padFileService->method('isExternalFrontmatter')->willReturn(false);
+		$padFileService->method('getSnapshotPartsFromBody')->willReturn([
+			'text' => 'Datum: {{date:next monday|d.m.Y}}',
+			'html' => '',
+		]);
+		$padFileService->expects($this->once())
+			->method('buildInitialDocument')
+			->with(99, 'p-fresh', BindingService::ACCESS_PROTECTED, 'Datum: 18.05.2026', $this->isType('string'))
+			->willReturn('doc');
+		$padFileService->method('withExportSnapshot')->willReturn('doc-with-snapshot');
+
+		$bootstrap = $this->createMock(PadBootstrapService::class);
+		$bootstrap->expects($this->once())
+			->method('provisionPadId')
+			->with(BindingService::ACCESS_PROTECTED)
+			->willReturn('p-fresh');
+		$bootstrap->expects($this->once())
+			->method('pushInitialSnapshot')
+			->with('p-fresh', 'Datum: 18.05.2026', '');
+
+		$bindingService = $this->createMock(BindingService::class);
+		$bindingService->expects($this->once())
+			->method('createBinding')
+			->with(99, 'p-fresh', BindingService::ACCESS_PROTECTED);
+
+		$etherpadClient = $this->createMock(EtherpadClient::class);
+		$etherpadClient->method('buildPadUrl')->willReturn('https://pad.example.test/p/p-fresh');
+
+		$user = $this->createMock(\OCP\IUser::class);
+		$user->method('getDisplayName')->willReturn('Alice');
+		$user->method('getUID')->willReturn('alice');
+
+		$result = $this->buildService($padFileService, $padPaths, $fileCreator, $userNodeResolver, null, $bindingService, $etherpadClient, $bootstrap)
+			->createFromTemplate('alice', '/Meetings/Protokoll {{date:next monday|d.m.Y}}.pad', 7, $user);
+
+		$this->assertSame('/Meetings/Protokoll 18.05.2026.pad', $result['file']);
+		$this->assertSame(99, $result['file_id']);
+		$this->assertSame('p-fresh', $result['pad_id']);
+		$this->assertSame(BindingService::ACCESS_PROTECTED, $result['access_mode']);
+	}
+
+	public function testCreateFromTemplateRefusesNonPadTemplate(): void {
+		$templateNode = $this->createMock(\OCP\Files\File::class);
+		$templateNode->method('getName')->willReturn('Notes.txt');
+
+		$userNodeResolver = $this->createMock(UserNodeResolver::class);
+		$userNodeResolver->method('resolveUserFileNodeById')->willReturn($templateNode);
+
+		$this->expectException(\OCA\EtherpadNextcloud\Exception\NotAPadFileException::class);
+
+		$this->buildService(userNodeResolver: $userNodeResolver)
+			->createFromTemplate('alice', '/Out.pad', 7, null);
+	}
+
+	public function testCreateFromTemplateRefusesExternalTemplate(): void {
+		$templateNode = $this->createMock(\OCP\Files\File::class);
+		$templateNode->method('getName')->willReturn('Remote.pad');
+		$templateNode->method('getContent')->willReturn('tpl');
+
+		$userNodeResolver = $this->createMock(UserNodeResolver::class);
+		$userNodeResolver->method('resolveUserFileNodeById')->willReturn($templateNode);
+
+		$padFileService = $this->createMock(PadFileService::class);
+		$padFileService->method('parsePadFile')->willReturn([
+			'frontmatter' => ['pad_id' => 'ext.remote'],
+			'body' => '',
+		]);
+		$padFileService->method('extractPadMetadata')->willReturn(['pad_id' => 'ext.remote']);
+
+		$padPaths = $this->createMock(PadPathService::class);
+		$padPaths->method('normalizeCreatePath')->willReturn('/Out.pad');
+
+		$this->expectException(\InvalidArgumentException::class);
+		$this->expectExceptionMessage('External pads cannot be used as a template.');
+
+		$this->buildService($padFileService, $padPaths, null, $userNodeResolver)
+			->createFromTemplate('alice', '/Out.pad', 7, null);
+	}
+
 	private function buildService(
 		?PadFileService $padFileService = null,
 		?PadPathService $padPaths = null,
@@ -283,7 +391,13 @@ class PadCreationServiceTest extends TestCase {
 		?BindingService $bindingService = null,
 		?EtherpadClient $etherpadClient = null,
 		?PadBootstrapService $bootstrap = null,
+		?\OCA\EtherpadNextcloud\Service\PadPlaceholderResolver $placeholderResolver = null,
 	): PadCreationService {
+		if ($placeholderResolver === null) {
+			$timeFactory = $this->createMock(\OCP\AppFramework\Utility\ITimeFactory::class);
+			$timeFactory->method('getTime')->willReturn(1778976000);
+			$placeholderResolver = new \OCA\EtherpadNextcloud\Service\PadPlaceholderResolver($timeFactory);
+		}
 		return new PadCreationService(
 			$padFileService ?? $this->createMock(PadFileService::class),
 			$padPaths ?? $this->createMock(PadPathService::class),
@@ -293,6 +407,7 @@ class PadCreationServiceTest extends TestCase {
 			$bindingService ?? $this->createMock(BindingService::class),
 			$etherpadClient ?? $this->createMock(EtherpadClient::class),
 			$bootstrap ?? $this->createMock(PadBootstrapService::class),
+			$placeholderResolver,
 			$this->createMock(LoggerInterface::class),
 		);
 	}

--- a/tests/phpunit/unit/PadCreationServiceTest.php
+++ b/tests/phpunit/unit/PadCreationServiceTest.php
@@ -382,6 +382,35 @@ class PadCreationServiceTest extends TestCase {
 			->createFromTemplate('alice', '/Out.pad', 7, null);
 	}
 
+	public function testCreateFromTemplateReportsMissingPadIdSeparately(): void {
+		// A template with malformed / empty frontmatter (no pad_id) is not the
+		// same failure mode as an `ext.*` template — the user should see a
+		// targeted message so they can fix the template instead of being told
+		// the file is "external".
+		$templateNode = $this->createMock(\OCP\Files\File::class);
+		$templateNode->method('getName')->willReturn('Broken.pad');
+		$templateNode->method('getContent')->willReturn('tpl');
+
+		$userNodeResolver = $this->createMock(UserNodeResolver::class);
+		$userNodeResolver->method('resolveUserFileNodeById')->willReturn($templateNode);
+
+		$padFileService = $this->createMock(PadFileService::class);
+		$padFileService->method('parsePadFile')->willReturn([
+			'frontmatter' => [],
+			'body' => '',
+		]);
+		$padFileService->method('extractPadMetadata')->willReturn([]);
+
+		$padPaths = $this->createMock(PadPathService::class);
+		$padPaths->method('normalizeCreatePath')->willReturn('/Out.pad');
+
+		$this->expectException(\InvalidArgumentException::class);
+		$this->expectExceptionMessage('Template has no usable pad_id in its frontmatter.');
+
+		$this->buildService($padFileService, $padPaths, null, $userNodeResolver)
+			->createFromTemplate('alice', '/Out.pad', 7, null);
+	}
+
 	private function buildService(
 		?PadFileService $padFileService = null,
 		?PadPathService $padPaths = null,

--- a/tests/phpunit/unit/PadPlaceholderResolverTest.php
+++ b/tests/phpunit/unit/PadPlaceholderResolverTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\EtherpadNextcloud\Tests\Unit;
+
+use OCA\EtherpadNextcloud\Service\PadPlaceholderResolver;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\IUser;
+use PHPUnit\Framework\TestCase;
+
+class PadPlaceholderResolverTest extends TestCase {
+	private const FIXED_NOW = 1778976000; // 2026-05-17 (Sunday) 00:00 UTC
+
+	public function testReplacesDateWithDefaultFormat(): void {
+		$result = $this->resolver()->apply('Heute ist {{date}}.', $this->user('Jacob Bühler'));
+		$this->assertSame('Heute ist 2026-05-17.', $result);
+	}
+
+	public function testReplacesDateWithCustomFormat(): void {
+		$result = $this->resolver()->apply('Stempel: {{date|d.m.Y}}', $this->user('Jacob Bühler'));
+		$this->assertSame('Stempel: 17.05.2026', $result);
+	}
+
+	public function testReplacesDateRelativeNextMonday(): void {
+		$result = $this->resolver()->apply('Sitzung {{date:next monday|d.m.Y}}', $this->user('Jacob Bühler'));
+		// 2026-05-17 is Sunday → next monday is 2026-05-18
+		$this->assertSame('Sitzung 18.05.2026', $result);
+	}
+
+	public function testReplacesDateOffset(): void {
+		$result = $this->resolver()->apply('In sieben Tagen: {{date:+7 days}}', $this->user('Jacob Bühler'));
+		$this->assertSame('In sieben Tagen: 2026-05-24', $result);
+	}
+
+	public function testReplacesUserDisplayName(): void {
+		$result = $this->resolver()->apply('Autor: {{user}}', $this->user('Jacob Bühler'));
+		$this->assertSame('Autor: Jacob Bühler', $result);
+	}
+
+	public function testReplacesUserUid(): void {
+		$result = $this->resolver()->apply('UID: {{user.uid}}', $this->user('Jacob Bühler', 'jaggob'));
+		$this->assertSame('UID: jaggob', $result);
+	}
+
+	public function testLeavesUnknownDirectivesAsLiteral(): void {
+		$result = $this->resolver()->apply('Weather: {{forecast}}', $this->user('x'));
+		$this->assertSame('Weather: {{forecast}}', $result);
+	}
+
+	public function testLeavesUnknownUserPropertyAsLiteral(): void {
+		$result = $this->resolver()->apply('Whoami: {{user.phone}}', $this->user('x'));
+		$this->assertSame('Whoami: {{user.phone}}', $result);
+	}
+
+	public function testLeavesUnparseableDateExpressionAsLiteral(): void {
+		$result = $this->resolver()->apply('Datum: {{date:complete-nonsense-xyz}}', $this->user('x'));
+		$this->assertSame('Datum: {{date:complete-nonsense-xyz}}', $result);
+	}
+
+	public function testReplacesMultiplePlaceholdersInOneLine(): void {
+		$result = $this->resolver()->apply(
+			'# Protokoll {{date:next monday|d.m.Y}} ({{user}})',
+			$this->user('Jacob Bühler'),
+		);
+		$this->assertSame('# Protokoll 18.05.2026 (Jacob Bühler)', $result);
+	}
+
+	public function testTolerantToWhitespaceInsideBraces(): void {
+		$result = $this->resolver()->apply('{{ date | Y }}', $this->user('x'));
+		$this->assertSame('2026', $result);
+	}
+
+	public function testNoUserSilentlySkipsUserDirectives(): void {
+		// Public-share / anonymous context: user is null. Leave the directive
+		// alone rather than render the empty string.
+		$result = $this->resolver()->apply('Autor: {{user}}, Datum: {{date}}', null);
+		$this->assertSame('Autor: {{user}}, Datum: 2026-05-17', $result);
+	}
+
+	private function resolver(): PadPlaceholderResolver {
+		$time = $this->createMock(ITimeFactory::class);
+		$time->method('getTime')->willReturn(self::FIXED_NOW);
+		return new PadPlaceholderResolver($time);
+	}
+
+	private function user(string $displayName, string $uid = 'user1'): IUser {
+		$user = $this->createMock(IUser::class);
+		$user->method('getDisplayName')->willReturn($displayName);
+		$user->method('getUID')->willReturn($uid);
+		return $user;
+	}
+}

--- a/tests/phpunit/unit/PadPlaceholderResolverTest.php
+++ b/tests/phpunit/unit/PadPlaceholderResolverTest.php
@@ -71,6 +71,31 @@ class PadPlaceholderResolverTest extends TestCase {
 		$this->assertSame('2026', $result);
 	}
 
+	public function testRelativeDatesAreDeterministicUnderWesternTimezone(): void {
+		// Regression: strtotime/date previously depended on
+		// date_default_timezone_get(), so "today" and "next monday" drifted on
+		// hosts west of UTC. Resolver now pins to UTC internally.
+		$previous = date_default_timezone_get();
+		date_default_timezone_set('America/Los_Angeles');
+		try {
+			$result = $this->resolver()->apply(
+				'{{date}} | {{date:next monday|d.m.Y}} | {{date:+7 days}}',
+				$this->user('x'),
+			);
+			$this->assertSame('2026-05-17 | 18.05.2026 | 2026-05-24', $result);
+		} finally {
+			date_default_timezone_set($previous);
+		}
+	}
+
+	public function testStripsPathSeparatorsFromDisplayName(): void {
+		// Defense-in-depth: a display name containing "/" or ".." must not
+		// expand into a path-traversal payload when interpolated into a
+		// user-supplied target file path.
+		$result = $this->resolver()->apply('{{user}}', $this->user('../etc/passwd'));
+		$this->assertSame('etc passwd', $result);
+	}
+
 	public function testNoUserSilentlySkipsUserDirectives(): void {
 		// Public-share / anonymous context: user is null. Leave the directive
 		// alone rather than render the empty string.

--- a/tests/phpunit/unit/PadPlaceholderResolverTest.php
+++ b/tests/phpunit/unit/PadPlaceholderResolverTest.php
@@ -13,53 +13,53 @@ class PadPlaceholderResolverTest extends TestCase {
 	private const FIXED_NOW = 1778976000; // 2026-05-17 (Sunday) 00:00 UTC
 
 	public function testReplacesDateWithDefaultFormat(): void {
-		$result = $this->resolver()->apply('Heute ist {{date}}.', $this->user('Jacob Bühler'));
+		$result = $this->resolver()->applyForContent('Heute ist {{date}}.', $this->user('Jacob Bühler'));
 		$this->assertSame('Heute ist 2026-05-17.', $result);
 	}
 
 	public function testReplacesDateWithCustomFormat(): void {
-		$result = $this->resolver()->apply('Stempel: {{date|d.m.Y}}', $this->user('Jacob Bühler'));
+		$result = $this->resolver()->applyForContent('Stempel: {{date|d.m.Y}}', $this->user('Jacob Bühler'));
 		$this->assertSame('Stempel: 17.05.2026', $result);
 	}
 
 	public function testReplacesDateRelativeNextMonday(): void {
-		$result = $this->resolver()->apply('Sitzung {{date:next monday|d.m.Y}}', $this->user('Jacob Bühler'));
+		$result = $this->resolver()->applyForContent('Sitzung {{date:next monday|d.m.Y}}', $this->user('Jacob Bühler'));
 		// 2026-05-17 is Sunday → next monday is 2026-05-18
 		$this->assertSame('Sitzung 18.05.2026', $result);
 	}
 
 	public function testReplacesDateOffset(): void {
-		$result = $this->resolver()->apply('In sieben Tagen: {{date:+7 days}}', $this->user('Jacob Bühler'));
+		$result = $this->resolver()->applyForContent('In sieben Tagen: {{date:+7 days}}', $this->user('Jacob Bühler'));
 		$this->assertSame('In sieben Tagen: 2026-05-24', $result);
 	}
 
 	public function testReplacesUserDisplayName(): void {
-		$result = $this->resolver()->apply('Autor: {{user}}', $this->user('Jacob Bühler'));
+		$result = $this->resolver()->applyForContent('Autor: {{user}}', $this->user('Jacob Bühler'));
 		$this->assertSame('Autor: Jacob Bühler', $result);
 	}
 
 	public function testReplacesUserUid(): void {
-		$result = $this->resolver()->apply('UID: {{user.uid}}', $this->user('Jacob Bühler', 'jaggob'));
+		$result = $this->resolver()->applyForContent('UID: {{user.uid}}', $this->user('Jacob Bühler', 'jaggob'));
 		$this->assertSame('UID: jaggob', $result);
 	}
 
 	public function testLeavesUnknownDirectivesAsLiteral(): void {
-		$result = $this->resolver()->apply('Weather: {{forecast}}', $this->user('x'));
+		$result = $this->resolver()->applyForContent('Weather: {{forecast}}', $this->user('x'));
 		$this->assertSame('Weather: {{forecast}}', $result);
 	}
 
 	public function testLeavesUnknownUserPropertyAsLiteral(): void {
-		$result = $this->resolver()->apply('Whoami: {{user.phone}}', $this->user('x'));
+		$result = $this->resolver()->applyForContent('Whoami: {{user.phone}}', $this->user('x'));
 		$this->assertSame('Whoami: {{user.phone}}', $result);
 	}
 
 	public function testLeavesUnparseableDateExpressionAsLiteral(): void {
-		$result = $this->resolver()->apply('Datum: {{date:complete-nonsense-xyz}}', $this->user('x'));
+		$result = $this->resolver()->applyForContent('Datum: {{date:complete-nonsense-xyz}}', $this->user('x'));
 		$this->assertSame('Datum: {{date:complete-nonsense-xyz}}', $result);
 	}
 
 	public function testReplacesMultiplePlaceholdersInOneLine(): void {
-		$result = $this->resolver()->apply(
+		$result = $this->resolver()->applyForContent(
 			'# Protokoll {{date:next monday|d.m.Y}} ({{user}})',
 			$this->user('Jacob Bühler'),
 		);
@@ -67,7 +67,7 @@ class PadPlaceholderResolverTest extends TestCase {
 	}
 
 	public function testTolerantToWhitespaceInsideBraces(): void {
-		$result = $this->resolver()->apply('{{ date | Y }}', $this->user('x'));
+		$result = $this->resolver()->applyForContent('{{ date | Y }}', $this->user('x'));
 		$this->assertSame('2026', $result);
 	}
 
@@ -78,7 +78,7 @@ class PadPlaceholderResolverTest extends TestCase {
 		$previous = date_default_timezone_get();
 		date_default_timezone_set('America/Los_Angeles');
 		try {
-			$result = $this->resolver()->apply(
+			$result = $this->resolver()->applyForContent(
 				'{{date}} | {{date:next monday|d.m.Y}} | {{date:+7 days}}',
 				$this->user('x'),
 			);
@@ -88,18 +88,26 @@ class PadPlaceholderResolverTest extends TestCase {
 		}
 	}
 
-	public function testStripsPathSeparatorsFromDisplayName(): void {
+	public function testApplyForPathStripsSeparatorsFromDisplayName(): void {
 		// Defense-in-depth: a display name containing "/" or ".." must not
 		// expand into a path-traversal payload when interpolated into a
 		// user-supplied target file path.
-		$result = $this->resolver()->apply('{{user}}', $this->user('../etc/passwd'));
+		$result = $this->resolver()->applyForPath('{{user}}', $this->user('../etc/passwd'));
 		$this->assertSame('etc passwd', $result);
+	}
+
+	public function testApplyForContentPreservesSlashesInDisplayName(): void {
+		// In body / snapshot context the display name must reach the user
+		// verbatim — stripping `/` from "AC/DC" would silently mangle visible
+		// document content. Only `applyForPath` sanitizes.
+		$result = $this->resolver()->applyForContent('Band: {{user}}', $this->user('AC/DC'));
+		$this->assertSame('Band: AC/DC', $result);
 	}
 
 	public function testNoUserSilentlySkipsUserDirectives(): void {
 		// Public-share / anonymous context: user is null. Leave the directive
 		// alone rather than render the empty string.
-		$result = $this->resolver()->apply('Autor: {{user}}, Datum: {{date}}', null);
+		$result = $this->resolver()->applyForContent('Autor: {{user}}, Datum: {{date}}', null);
 		$this->assertSame('Autor: {{user}}, Datum: 2026-05-17', $result);
 	}
 

--- a/tests/phpunit/unit/PadPlaceholderResolverTest.php
+++ b/tests/phpunit/unit/PadPlaceholderResolverTest.php
@@ -96,6 +96,14 @@ class PadPlaceholderResolverTest extends TestCase {
 		$this->assertSame('etc passwd', $result);
 	}
 
+	public function testLeavesDotedDateDirectiveAsLiteral(): void {
+		// `date.something` is not a real property — the date directive only
+		// supports `:arg` and `|format`. Silently rendering today's date
+		// would mask the typo, so we keep the original literal.
+		$result = $this->resolver()->applyForContent('Stempel: {{date.foo}}', $this->user('x'));
+		$this->assertSame('Stempel: {{date.foo}}', $result);
+	}
+
 	public function testApplyForContentPreservesSlashesInDisplayName(): void {
 		// In body / snapshot context the display name must reach the user
 		// verbatim — stripping `/` from "AC/DC" would silently mangle visible


### PR DESCRIPTION
Closes #26.

Lets users pre-fill new `.pad` files with content from a template they prepared once. Templates live in Nextcloud's standard `/Templates` folder — no new menu, no custom file picker, no `is_template` flag. Hooks into NC's existing template flow and additionally exposes an API for custom frontends.

## What ships

### `PadPlaceholderResolver`
Mustache-style `{{date}}` / `{{user}}` tokens, optional argument and format suffix:

| Token | Output |
|---|---|
| `{{date}}` | today, ISO `Y-m-d` |
| `{{date\|d.m.Y}}` | today, custom PHP format |
| `{{date:next monday}}` | relative date, ISO |
| `{{date:next monday\|d.m.Y}}` | relative + custom format |
| `{{date:+7 days}}` | offset |
| `{{user}}` | display name |
| `{{user.uid}}` | UID |

- Dates resolve via `DateTimeImmutable` pinned to **UTC** so output is deterministic regardless of the server's default timezone.
- Display-name and UID outputs are stripped of `/`, `\`, NUL and leading `.` runs so a free-form display name can't smuggle path-traversal into a target file path.
- Unknown directives and unparseable date expressions stay as literal text — a broken template never crashes the create flow.

### Shared materialization core
`PadCreationService::materializeTemplateInto(File $target, File $template, ?IUser $user)` owns the entire template pipeline (parse → validate → reject `ext.*` → resolve placeholders → provision pad → push snapshot → write file → create binding → cleanup on failure). Both entry points share it.

### Two entry points

**NC-native picker** via `FileCreatedFromTemplateListener`. NC copies the template byte-for-byte; the listener then delegates to `materializeTemplateInto` against the byte-copied target. On any skip/failure the target is reset to empty so NC's normal missing-frontmatter init takes over on first open.

**Custom frontend API** via `POST /api/v1/pads/from-template`:

- Body: `file=<path-with-optional-placeholders>&templateFileId=<id>`
- Filename placeholders are applied server-side (NC's native picker can't do this because `TemplateManager` re-fetches the new file by the user-typed path *after* our event fires — renaming would break that lookup).
- Any `.pad` the user has read access to works as a template — no `/Templates` restriction.

### `PadBootstrapService::pushInitialSnapshot`
setHTML-first, with setText as fallback when no HTML snapshot is present or the HTML import fails. We intentionally do NOT also call setText after a successful setHTML — Etherpad's `setText` replaces rather than appends, so it would wipe the formatting we just imported. Trade-off: server-side `getText` returns plain text Etherpad derived from the HTML, which can differ slightly from the exact frontmatter snapshot string; formatting (headings, lists, bold) survives, which is what users actually expect from a template.

## Why this design

- **No new menu entry.** Existing `RegisterTemplateCreatorListener` registers `.pad` as a template type; NC's `+` menu picks it up.
- **Filename placeholders only in the API path.** Documented limitation of the native flow.
- **Single shared pipeline.** Listener and controller call into the same method — review-driven consolidation prevents drift.

## Tests

- PHP 350 → 373 (+23). New `PadPlaceholderResolverTest` (14 cases) covers UTC determinism + path sanitization; new `FileCreatedFromTemplateListenerTest` (6 cases) focuses on event filtering and the wipe-target fallback; `PadCreationServiceTest` gains coverage for `createFromTemplate` (template validation, external rejection, full materialization).
- JS 98 unchanged.

## Manual verification

1. Put a `.pad` template in `/Templates`. Body: `# Protokoll {{date:next monday|d.m.Y}}\n\n- {{user}}`. Sync.
2. Files → `+ New pad` → pick template → confirm filename → file appears with resolved body. Filename stays as typed.
3. From a custom frontend: `POST /api/v1/pads/from-template` with `file=/Meetings/Protokoll {{date:next monday|d.m.Y}}.pad&templateFileId=<id>` — filename placeholders resolve, returns `file_id` + `pad_id` + `viewer_url`.
4. Negative paths: Blank → empty pad. `{{notADirective}}` → literal. `ext.*` template via native flow → empty target.
