### PR TITLE
Lazy legacy Ownpad import on first open (closes #25)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Legacy Ownpad `.pad` files (those holding only an `[InternetShortcut]` block) are automatically migrated to the current binding-and-`.pad` model on first open. The conversion branches on the source URL's origin and the pad-id format (`g.X$Y` → protected, anything else → public), preserves the existing remote pad on the same-origin path, and routes cross-origin shortcuts through the external-pad flow. A claim-collision rule prevents legacy files from being used to "claim" pads already bound to another user's file. See `docs/legacy-ownpad-migration.md`.
 - Trusted embed integration for same-site / trusted-origin hosts:
   - minimal authenticated embed page via `/embed/by-id/{fileId}`
   - trusted `frame-ancestors` / embed-origin allowlist

--- a/README.md
+++ b/README.md
@@ -32,9 +32,11 @@ This plugin lets you surface pads from an Etherpad instance inside Nextcloud and
 
 - Running this app and Ownpad at the same time is not supported.
   - Both apps hook into `.pad` MIME/viewer handling, which leads to ambiguous file-type resolution and open-action conflicts.
-- This app does currently not automatically import Ownpad legacy `.pad` files.
-- Ownpad `.pad` files (`[InternetShortcut]` + `URL=...`) are currently rejected by default because of a different binding/lifecycle model than Ownpad (including database state handling), so a safe migration is non-trivial.
-- A dedicated, explicit migration/import flow for legacy Ownpad `.pad` files is planned for the future. Feel free to commit your solutions for that!
+- Legacy Ownpad `.pad` files (`[InternetShortcut]` + `URL=...`) are automatically migrated to this app's binding-and-`.pad` model on first open — no admin action required. The migration branches on the source URL's origin and the embedded pad-id:
+  - Same Etherpad server, free-form pad-id → re-bound as a managed public pad.
+  - Same Etherpad server, group pad-id (`g.<group>$<name>`) → re-bound as a managed protected pad.
+  - Different Etherpad server → converted to an external (`ext.*`) public pad pointing at the original URL.
+- A claim-collision check prevents legacy files from being used to claim pads already bound to another user's file. See [`docs/legacy-ownpad-migration.md`](docs/legacy-ownpad-migration.md) for the full state table, audit-log shape, and the security rationale.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@ This plugin lets you surface pads from an Etherpad instance inside Nextcloud and
 
 - Running this app and Ownpad at the same time is not supported.
   - Both apps hook into `.pad` MIME/viewer handling, which leads to ambiguous file-type resolution and open-action conflicts.
-- Legacy Ownpad `.pad` files (`[InternetShortcut]` + `URL=...`) are automatically migrated to this app's binding-and-`.pad` model on first open — no admin action required. The migration branches on the source URL's origin and the embedded pad-id:
+- Legacy Ownpad `.pad` files (`[InternetShortcut]` + `URL=...`) are automatically migrated to this app's binding-and-`.pad` model the first time a user opens them. The migration branches on the source URL's origin and the embedded pad-id:
   - Same Etherpad server, free-form pad-id → re-bound as a managed public pad.
   - Same Etherpad server, group pad-id (`g.<group>$<name>`) → re-bound as a managed protected pad.
   - Different Etherpad server → converted to an external (`ext.*`) public pad pointing at the original URL.
-- A claim-collision check prevents legacy files from being used to claim pads already bound to another user's file. See [`docs/legacy-ownpad-migration.md`](docs/legacy-ownpad-migration.md) for the full state table, audit-log shape, and the security rationale.
+- If two Ownpad `.pad` files point at the same pad, only the first one to be opened gets the binding; the second is treated like a copied pad (no second binding row, the existing copy-of-a-pad flow handles open from there). See [`docs/legacy-ownpad-migration.md`](docs/legacy-ownpad-migration.md) for the full state table, audit-log shape, and the security rationale.
 
 ## Install
 

--- a/docs/legacy-ownpad-migration.md
+++ b/docs/legacy-ownpad-migration.md
@@ -1,0 +1,64 @@
+# Legacy Ownpad migration
+
+When a `.pad` file with no YAML frontmatter and an `[InternetShortcut]` block (the legacy Ownpad / Etherpad-Lite format) is opened, the plugin automatically converts it to the current binding-and-`.pad` model on the first open. Users coming from an older Ownpad installation see no modal and no prompts — the pad simply opens.
+
+The detection lives in `PadFileService::parseLegacyOwnpadShortcut`; the migration is driven by `PadLegacyMigrationService`.
+
+## What happens on first open
+
+The migration service compares the shortcut URL's origin (scheme + host + port, normalized) against the configured `etherpad_host` and branches accordingly:
+
+### Different origin — external public pad
+
+The source URL points at an Etherpad server that isn't the one this Nextcloud instance manages. We can't apply protected-mode auth to a server we don't control, so the file is converted to an `ext.*` public pad via the same path as `POST /api/v1/pads/from-url`:
+
+- Frontmatter is written with `pad_id = ext.<remote-id>` and `pad_origin` / `remote_pad_id` extras.
+- A best-effort snapshot of the remote pad's text is embedded.
+- **No binding row** is created — `ext.*` pads are intentionally not bound, since the plugin doesn't own their lifecycle.
+
+### Same origin — re-bind as managed pad
+
+The source URL points at the configured Etherpad server. The access mode is derived from the source pad-id format:
+
+- `g.<groupId>$<padName>` → protected.
+- Anything else → public.
+
+This is a pure local re-bind. No remote pad is created, no content is copied; the existing Etherpad pad keeps running unchanged under our schema:
+
+- New YAML frontmatter is written referencing the same `pad_id`.
+- A binding row is inserted.
+
+### Same origin — claim-collision rule
+
+If the pad-id is already bound to another Nextcloud file, the unique constraint on `oc_etherpad_bindings.pad_id` prevents a second binding row. The migration handles the conflict explicitly:
+
+- **Requesting user has read access to the file that owns the existing binding** → managed frontmatter is written into the legacy file, but **no new binding row is created**. The file is now a "copy of a pad" in the plugin's model, and the existing copy-of-a-pad flow handles future opens (offers "Open the original" via `recoverByFileId`).
+- **Requesting user has no access to the bound file** → the migration is refused with `LegacyPadCollisionException`, surfaced as HTTP 409 with `code: "legacy_collision_no_access"`. The `.pad` file is left untouched, so the migration offer is still pending on the next open.
+
+This prevents the legacy format from being a backdoor: a malicious user can't drop a hand-crafted `[InternetShortcut]` file pointing at another user's pad and "claim" the binding.
+
+## Audit log
+
+Every branch emits a single log line at `info` level (or `warning` for the refusal). Fields:
+
+| Field | Meaning |
+|---|---|
+| `fileId` | NC file ID being migrated |
+| `sourceUrl` | URL parsed from the legacy shortcut |
+| `originBranch` | `same` or `cross` |
+| `accessMode` | `public` / `protected` / unset for cross-origin |
+| `padId` | Source pad-id (same as new pad-id in same-origin re-bind) |
+| `collision` | `none` / `with_access` / `no_access` / `self` |
+| `uid` | Migrating user |
+
+Grep `app:etherpad_nextcloud` + `Migrated legacy Ownpad` in `nextcloud.log` to reconstruct what was imported when.
+
+## Out of scope
+
+- **Admin bulk-migration CLI / `occ` command.** Each file migrates on its own first-open; admins don't need to coordinate.
+- **Public → protected conversion of an already-managed pad.** Etherpad's pad-id format encodes the type and can't be renamed in place; converting would require content copy + a new pad. If needed, that lives in a separate "Convert pad access mode" feature.
+- **Real-time mirroring** between legacy and current pads.
+
+## Status returned by `/api/v1/pads/initialize*`
+
+When the migration ran, the endpoint returns `status: "migrated_from_legacy"` (instead of the regular `initialized`). The frontend logs this to the browser console on first open; a user-facing toast is not currently surfaced (the codebase has no notification framework wired in).

--- a/docs/pad-format.md
+++ b/docs/pad-format.md
@@ -52,8 +52,8 @@ Legacy migration:
 - Old Ownpad format
   - `[InternetShortcut]`
   - `URL=https://.../p/<pad-id>`
-- is auto-migrated on open to `etherpad-nextcloud/1` (only for empty files or this legacy format).
-- GroupPad IDs in legacy format (`g.<group>$<name>`) are not auto-imported for security reasons.
+- is auto-migrated on first open to `etherpad-nextcloud/1`. The migration branches on the URL origin (same vs. cross) and the pad-id format; GroupPad IDs (`g.<group>$<name>`) re-bind as protected, free-form IDs re-bind as public, cross-origin URLs route through the external-pad flow as `ext.*`.
+- A claim-collision check protects against legacy files being used to claim pads already bound to another user's file — see `docs/legacy-ownpad-migration.md` for the full state table.
 
 ## Snapshot Body
 

--- a/docs/pad-format.md
+++ b/docs/pad-format.md
@@ -52,8 +52,8 @@ Legacy migration:
 - Old Ownpad format
   - `[InternetShortcut]`
   - `URL=https://.../p/<pad-id>`
-- is auto-migrated on first open to `etherpad-nextcloud/1`. The migration branches on the URL origin (same vs. cross) and the pad-id format; GroupPad IDs (`g.<group>$<name>`) re-bind as protected, free-form IDs re-bind as public, cross-origin URLs route through the external-pad flow as `ext.*`.
-- A claim-collision check protects against legacy files being used to claim pads already bound to another user's file — see `docs/legacy-ownpad-migration.md` for the full state table.
+  - is auto-migrated on first open to `etherpad-nextcloud/1`. The migration branches on the URL origin (same vs. cross) and the pad-id format; GroupPad IDs (`g.<group>$<name>`) re-bind as protected, free-form IDs re-bind as public, cross-origin URLs route through the external-pad flow as `ext.*`.
+  - A claim-collision check protects against legacy files being used to claim pads already bound to another user's file — see `docs/legacy-ownpad-migration.md` for the full state table.
 
 ## Snapshot Body
 

--- a/lib/Controller/PadControllerErrorMapper.php
+++ b/lib/Controller/PadControllerErrorMapper.php
@@ -11,6 +11,7 @@ namespace OCA\EtherpadNextcloud\Controller;
 
 use OCA\EtherpadNextcloud\Exception\BindingException;
 use OCA\EtherpadNextcloud\Exception\ControllerBadRequestException;
+use OCA\EtherpadNextcloud\Exception\LegacyPadCollisionException;
 use OCA\EtherpadNextcloud\Exception\MissingBindingException;
 use OCA\EtherpadNextcloud\Exception\EtherpadClientException;
 use OCA\EtherpadNextcloud\Exception\PadAlreadyHasBindingException;
@@ -108,6 +109,15 @@ class PadControllerErrorMapper {
 				$payload,
 				(int)($options['binding_status'] ?? Http::STATUS_BAD_REQUEST),
 			);
+		} catch (LegacyPadCollisionException $e) {
+			// The legacy Ownpad shortcut points at a pad-id that is already
+			// bound to another file the requesting user has no access to.
+			// 409 (not 403): the conflict is with the *other* file's
+			// binding, not access-denied to the file we're opening.
+			return new DataResponse([
+				'message' => $e->getMessage(),
+				'code' => 'legacy_collision_no_access',
+			], Http::STATUS_CONFLICT);
 		} catch (PadFileFormatException|EtherpadClientException $e) {
 			return new DataResponse(['message' => $e->getMessage()], Http::STATUS_BAD_REQUEST);
 		} catch (\RuntimeException $e) {

--- a/lib/Exception/LegacyPadCollisionException.php
+++ b/lib/Exception/LegacyPadCollisionException.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * Copyright (c) 2026 Jacob Bühler
+ */
+
+namespace OCA\EtherpadNextcloud\Exception;
+
+/**
+ * Thrown by the legacy Ownpad migration path when the source URL's pad-id
+ * is already bound to a different NC file in this instance and the
+ * requesting user cannot read the file that owns the existing binding.
+ *
+ * The migration is refused rather than letting the requesting user claim
+ * a pad they don't already have access to. Surfaces as HTTP 409 with code
+ * `legacy_collision_no_access`.
+ */
+final class LegacyPadCollisionException extends \RuntimeException {
+}

--- a/lib/Service/EtherpadClient.php
+++ b/lib/Service/EtherpadClient.php
@@ -646,7 +646,11 @@ class EtherpadClient {
 		$host = strtolower((string)($parts['host'] ?? ''));
 		$port = isset($parts['port']) ? (int)$parts['port'] : 443;
 		$path = (string)($parts['path'] ?? '');
-		$decodedPath = urldecode($path);
+		// `+` is literal in URL path segments — only query/form bodies treat
+		// it as a space. Using urldecode here turned `/p/team+pad` into
+		// pad-id `team pad`, then re-encoded to `/p/team%20pad` at fetch
+		// time, hitting a different / non-existent remote pad.
+		$decodedPath = rawurldecode($path);
 		if ($scheme !== 'https' || $host === '' || $decodedPath === '' || $port <= 0 || $port > 65535) {
 			throw new EtherpadClientException('Invalid public pad URL.');
 		}

--- a/lib/Service/EtherpadClient.php
+++ b/lib/Service/EtherpadClient.php
@@ -304,6 +304,44 @@ class EtherpadClient {
 		return $host;
 	}
 
+	/**
+	 * Returns the configured Etherpad origin (scheme + host + port,
+	 * normalized) so callers can compare a foreign pad URL against "is this
+	 * the server we manage?". Default ports (80/443) are omitted. Empty
+	 * string when no host is configured — callers should treat that as
+	 * "always cross-origin".
+	 *
+	 * Tolerant of http (unlike `parsePublicPadUrl` which enforces https)
+	 * because admins may legitimately run Etherpad behind a plain-http
+	 * internal endpoint while still wanting same-origin re-bind to work.
+	 */
+	public function getConfiguredOrigin(): string {
+		$host = rtrim((string)$this->config->getAppValue('etherpad_nextcloud', 'etherpad_host', ''), '/');
+		if ($host === '') {
+			return '';
+		}
+		return $this->normalizeOrigin($host);
+	}
+
+	/**
+	 * Normalize an absolute URL to a comparable origin string
+	 * (scheme://host[:port]). Returns '' on unparseable input.
+	 */
+	public function normalizeOrigin(string $url): string {
+		$parts = parse_url($url);
+		if ($parts === false || empty($parts['scheme']) || empty($parts['host'])) {
+			return '';
+		}
+		$scheme = strtolower((string)$parts['scheme']);
+		$host = strtolower((string)$parts['host']);
+		$port = isset($parts['port']) ? (int)$parts['port'] : null;
+		$isDefaultPort = ($scheme === 'https' && $port === 443) || ($scheme === 'http' && $port === 80);
+		if ($port === null || $isDefaultPort) {
+			return $scheme . '://' . $host;
+		}
+		return $scheme . '://' . $host . ':' . $port;
+	}
+
 	private function getApiHost(): string {
 		$apiHost = rtrim((string)$this->config->getAppValue('etherpad_nextcloud', 'etherpad_api_host', ''), '/');
 		if ($apiHost !== '') {

--- a/lib/Service/ExternalPadSeeder.php
+++ b/lib/Service/ExternalPadSeeder.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * Copyright (c) 2026 Jacob Bühler
+ */
+
+namespace OCA\EtherpadNextcloud\Service;
+
+use OCP\Files\File;
+
+/**
+ * Writes `ext.<remote-id>` frontmatter (with a snapshot of the remote pad's
+ * text) into an existing `.pad` file. Used by both `PadCreationService`'s
+ * `createFromUrl` (where the file was just created) and
+ * `PadLegacyMigrationService`'s cross-origin branch (where the file already
+ * existed as a legacy `[InternetShortcut]`).
+ *
+ * Lives in its own service to keep `PadCreationService` and
+ * `PadLegacyMigrationService` from forming a constructor cycle with
+ * `PadBootstrapService` — the seeding logic only needs `EtherpadClient`
+ * and `PadFileService`, never the bootstrap path.
+ */
+class ExternalPadSeeder {
+	public function __construct(
+		private PadFileService $padFileService,
+		private EtherpadClient $etherpadClient,
+	) {
+	}
+
+	/**
+	 * @return array{file_id:int,pad_id:string,access_mode:string,pad_url:string,snapshot_warning_code?:string}
+	 */
+	public function seed(File $file, int $fileId, string $padUrl): array {
+		$external = $this->etherpadClient->normalizeAndFetchExternalPublicPadTextOrEmpty($padUrl);
+		// External pads are no longer DB-bound, so the local marker only needs to
+		// distinguish them from managed internal pad IDs. The canonical remote
+		// identity remains pad_origin + remote_pad_id in the frontmatter.
+		$externalPadId = 'ext.' . $external['pad_id'];
+		$content = $this->padFileService->buildInitialDocument(
+			$fileId,
+			$externalPadId,
+			BindingService::ACCESS_PUBLIC,
+			'',
+			$external['pad_url'],
+			[
+				'pad_origin' => $external['origin'],
+				'remote_pad_id' => $external['pad_id'],
+			]
+		);
+		$content = $this->padFileService->withExportSnapshot($content, $external['text'], '', 0, false);
+		$file->putContent($content);
+
+		$result = [
+			'file_id' => $fileId,
+			'pad_id' => $externalPadId,
+			'access_mode' => BindingService::ACCESS_PUBLIC,
+			'pad_url' => $external['pad_url'],
+		];
+		if (!empty($external['snapshot_unavailable'])) {
+			// The pad URL itself validated, but the public-text export
+			// endpoint refused to serve content (404). Common causes:
+			// the remote Etherpad has authentication on /p/<id>/export,
+			// or the pad is restricted despite a public-looking URL.
+			// We keep the file (the viewer can still load the pad
+			// directly through the iframe) and surface a stable code
+			// the frontend translates into a toast.
+			$result['snapshot_warning_code'] = 'remote_export_unavailable';
+		}
+		return $result;
+	}
+}

--- a/lib/Service/ExternalPadSeeder.php
+++ b/lib/Service/ExternalPadSeeder.php
@@ -34,9 +34,10 @@ class ExternalPadSeeder {
 	 */
 	public function seed(File $file, int $fileId, string $padUrl): array {
 		$external = $this->etherpadClient->normalizeAndFetchExternalPublicPadTextOrEmpty($padUrl);
-		// External pads are no longer DB-bound, so the local marker only needs to
-		// distinguish them from managed internal pad IDs. The canonical remote
-		// identity remains pad_origin + remote_pad_id in the frontmatter.
+		// External pads aren't DB-bound (we don't own their lifecycle), so the
+		// local `ext.*` pad-id is just a marker distinguishing them from
+		// managed internal IDs. Canonical remote identity lives in the
+		// pad_origin + remote_pad_id frontmatter extras.
 		$externalPadId = 'ext.' . $external['pad_id'];
 		$content = $this->padFileService->buildInitialDocument(
 			$fileId,

--- a/lib/Service/PadBootstrapService.php
+++ b/lib/Service/PadBootstrapService.php
@@ -93,7 +93,6 @@ class PadBootstrapService {
 		$createdNewPad = false;
 		$padId = '';
 		$accessMode = BindingService::ACCESS_PROTECTED;
-		$padUrl = null;
 
 		if ($binding !== null) {
 			$padId = (string)$binding['pad_id'];
@@ -107,10 +106,8 @@ class PadBootstrapService {
 		}
 
 		try {
-			$effectivePadUrl = ($padUrl !== null && $padUrl !== '')
-				? $padUrl
-				: $this->etherpadClient->buildPadUrl($padId);
-			$doc = $this->padFileService->buildInitialDocument($fileId, $padId, $accessMode, '', $effectivePadUrl);
+			$padUrl = $this->etherpadClient->buildPadUrl($padId);
+			$doc = $this->padFileService->buildInitialDocument($fileId, $padId, $accessMode, '', $padUrl);
 			$file->putContent($doc);
 		} catch (\Throwable $e) {
 			if ($createdNewBinding) {

--- a/lib/Service/PadBootstrapService.php
+++ b/lib/Service/PadBootstrapService.php
@@ -20,6 +20,7 @@ class PadBootstrapService {
 		private EtherpadClient $etherpadClient,
 		private ISecureRandom $secureRandom,
 		private LoggerInterface $logger,
+		private PadLegacyMigrationService $legacyMigrationService,
 	) {
 	}
 
@@ -68,7 +69,13 @@ class PadBootstrapService {
 		return $this->etherpadClient->createGroupPad($groupId, $padName);
 	}
 
-	public function initializeMissingFrontmatter(File $file, string $existingContent): void {
+	/**
+	 * Bootstrap the YAML frontmatter for a `.pad` file that doesn't have it
+	 * yet. Returns true if the file was a legacy Ownpad shortcut and we ran
+	 * the migration path (callers may want to surface that as a distinct
+	 * status to the frontend); false for the regular empty-file init.
+	 */
+	public function initializeMissingFrontmatter(string $uid, File $file, string $existingContent): bool {
 		$fileId = (int)$file->getId();
 		$existingContentTrimmed = trim($existingContent);
 		$isEmptyFile = $existingContentTrimmed === '';
@@ -77,7 +84,8 @@ class PadBootstrapService {
 			throw new PadFileFormatException('Missing YAML frontmatter in .pad file.');
 		}
 		if ($legacyShortcut !== null) {
-			throw new PadFileFormatException('Legacy Ownpad .pad files cannot be auto-imported.');
+			$this->legacyMigrationService->migrate($uid, $file, $legacyShortcut);
+			return true;
 		}
 
 		$binding = $this->bindingService->findByFileId($fileId);
@@ -90,9 +98,6 @@ class PadBootstrapService {
 		if ($binding !== null) {
 			$padId = (string)$binding['pad_id'];
 			$accessMode = (string)$binding['access_mode'];
-			if ($legacyShortcut !== null) {
-				$padUrl = (string)$legacyShortcut['url'];
-			}
 		} else {
 			$padId = $this->provisionPadId(BindingService::ACCESS_PROTECTED);
 			$accessMode = BindingService::ACCESS_PROTECTED;
@@ -134,6 +139,7 @@ class PadBootstrapService {
 			}
 			throw $e;
 		}
+		return false;
 	}
 
 	private function buildProtectedPadName(): string {

--- a/lib/Service/PadCreationService.php
+++ b/lib/Service/PadCreationService.php
@@ -186,10 +186,9 @@ class PadCreationService {
 	public function createFromUrl(string $uid, string $file, string $padUrl): array {
 		$path = $this->padPaths->normalizeCreatePath($file);
 		$fileCreated = false;
-		$external = null;
 
 		return $this->withCreateRollback(
-			function () use ($uid, $path, $padUrl, &$external, &$fileCreated): array {
+			function () use ($uid, $path, $padUrl, &$fileCreated): array {
 				$fileNode = $this->padFileCreator->createUserFile($uid, $path);
 				$fileCreated = true;
 				$fileId = (int)$fileNode->getId();
@@ -197,42 +196,11 @@ class PadCreationService {
 					throw new \RuntimeException('Could not resolve new file ID.');
 				}
 
-				$external = $this->etherpadClient->normalizeAndFetchExternalPublicPadTextOrEmpty($padUrl);
-				// External pads are no longer DB-bound, so the local marker only needs to
-				// distinguish them from managed internal pad IDs. The canonical remote
-				// identity remains pad_origin + remote_pad_id in the frontmatter.
-				$externalPadId = 'ext.' . $external['pad_id'];
-				$content = $this->padFileService->buildInitialDocument(
-					$fileId,
-					$externalPadId,
-					BindingService::ACCESS_PUBLIC,
-					'',
-					$external['pad_url'],
-					[
-						'pad_origin' => $external['origin'],
-						'remote_pad_id' => $external['pad_id'],
-					]
-				);
-				$content = $this->padFileService->withExportSnapshot($content, $external['text'], '', 0, false);
-				$fileNode->putContent($content);
-
-				$result = [
-					'file' => $path,
-					'file_id' => $fileId,
-					'pad_id' => $externalPadId,
-					'access_mode' => BindingService::ACCESS_PUBLIC,
-					'pad_url' => $external['pad_url'],
-				];
-				if (!empty($external['snapshot_unavailable'])) {
-					// The pad URL itself validated, but the public-text export
-					// endpoint refused to serve content (404). Common causes:
-					// the remote Etherpad has authentication on /p/<id>/export,
-					// or the pad is restricted despite a public-looking URL.
-					// We keep the file (the viewer can still load the pad
-					// directly through the iframe) and surface a stable code
-					// the frontend translates into a toast.
-					$result['snapshot_warning_code'] = 'remote_export_unavailable';
-				}
+				$seeded = $this->seedExternalIntoFile($fileNode, $fileId, $padUrl);
+				// Preserve the historical key ordering for the external-create
+				// response: `file` is the first key so tests asserting via
+				// `assertSame` keep matching after the refactor.
+				$result = ['file' => $path] + $seeded;
 				return $result;
 			},
 			function () use ($uid, $path, &$fileCreated): void {
@@ -261,6 +229,57 @@ class PadCreationService {
 				];
 			},
 		);
+	}
+
+	/**
+	 * Writes external-pad frontmatter (`ext.<remote-id>`) into a `.pad` file
+	 * that already exists on disk, fetching a snapshot of the remote pad's
+	 * content along the way. Extracted from `createFromUrl` so the legacy
+	 * Ownpad migration path can reuse the same shape when the source URL
+	 * points at a different Etherpad server than the one we manage.
+	 *
+	 * No binding row is created — `ext.*` pads are intentionally not bound,
+	 * since we don't own their lifecycle.
+	 *
+	 * @return array{file_id:int,pad_id:string,access_mode:string,pad_url:string,snapshot_warning_code?:string}
+	 */
+	public function seedExternalIntoFile(File $file, int $fileId, string $padUrl): array {
+		$external = $this->etherpadClient->normalizeAndFetchExternalPublicPadTextOrEmpty($padUrl);
+		// External pads are no longer DB-bound, so the local marker only needs to
+		// distinguish them from managed internal pad IDs. The canonical remote
+		// identity remains pad_origin + remote_pad_id in the frontmatter.
+		$externalPadId = 'ext.' . $external['pad_id'];
+		$content = $this->padFileService->buildInitialDocument(
+			$fileId,
+			$externalPadId,
+			BindingService::ACCESS_PUBLIC,
+			'',
+			$external['pad_url'],
+			[
+				'pad_origin' => $external['origin'],
+				'remote_pad_id' => $external['pad_id'],
+			]
+		);
+		$content = $this->padFileService->withExportSnapshot($content, $external['text'], '', 0, false);
+		$file->putContent($content);
+
+		$result = [
+			'file_id' => $fileId,
+			'pad_id' => $externalPadId,
+			'access_mode' => BindingService::ACCESS_PUBLIC,
+			'pad_url' => $external['pad_url'],
+		];
+		if (!empty($external['snapshot_unavailable'])) {
+			// The pad URL itself validated, but the public-text export
+			// endpoint refused to serve content (404). Common causes:
+			// the remote Etherpad has authentication on /p/<id>/export,
+			// or the pad is restricted despite a public-looking URL.
+			// We keep the file (the viewer can still load the pad
+			// directly through the iframe) and surface a stable code
+			// the frontend translates into a toast.
+			$result['snapshot_warning_code'] = 'remote_export_unavailable';
+		}
+		return $result;
 	}
 
 	/**

--- a/lib/Service/PadCreationService.php
+++ b/lib/Service/PadCreationService.php
@@ -29,6 +29,7 @@ class PadCreationService {
 		private EtherpadClient $etherpadClient,
 		private PadBootstrapService $padBootstrapService,
 		private PadPlaceholderResolver $placeholderResolver,
+		private ExternalPadSeeder $externalPadSeeder,
 		private LoggerInterface $logger,
 	) {
 	}
@@ -196,7 +197,7 @@ class PadCreationService {
 					throw new \RuntimeException('Could not resolve new file ID.');
 				}
 
-				$seeded = $this->seedExternalIntoFile($fileNode, $fileId, $padUrl);
+				$seeded = $this->externalPadSeeder->seed($fileNode, $fileId, $padUrl);
 				// Preserve the historical key ordering for the external-create
 				// response: `file` is the first key so tests asserting via
 				// `assertSame` keep matching after the refactor.
@@ -229,57 +230,6 @@ class PadCreationService {
 				];
 			},
 		);
-	}
-
-	/**
-	 * Writes external-pad frontmatter (`ext.<remote-id>`) into a `.pad` file
-	 * that already exists on disk, fetching a snapshot of the remote pad's
-	 * content along the way. Extracted from `createFromUrl` so the legacy
-	 * Ownpad migration path can reuse the same shape when the source URL
-	 * points at a different Etherpad server than the one we manage.
-	 *
-	 * No binding row is created — `ext.*` pads are intentionally not bound,
-	 * since we don't own their lifecycle.
-	 *
-	 * @return array{file_id:int,pad_id:string,access_mode:string,pad_url:string,snapshot_warning_code?:string}
-	 */
-	public function seedExternalIntoFile(File $file, int $fileId, string $padUrl): array {
-		$external = $this->etherpadClient->normalizeAndFetchExternalPublicPadTextOrEmpty($padUrl);
-		// External pads are no longer DB-bound, so the local marker only needs to
-		// distinguish them from managed internal pad IDs. The canonical remote
-		// identity remains pad_origin + remote_pad_id in the frontmatter.
-		$externalPadId = 'ext.' . $external['pad_id'];
-		$content = $this->padFileService->buildInitialDocument(
-			$fileId,
-			$externalPadId,
-			BindingService::ACCESS_PUBLIC,
-			'',
-			$external['pad_url'],
-			[
-				'pad_origin' => $external['origin'],
-				'remote_pad_id' => $external['pad_id'],
-			]
-		);
-		$content = $this->padFileService->withExportSnapshot($content, $external['text'], '', 0, false);
-		$file->putContent($content);
-
-		$result = [
-			'file_id' => $fileId,
-			'pad_id' => $externalPadId,
-			'access_mode' => BindingService::ACCESS_PUBLIC,
-			'pad_url' => $external['pad_url'],
-		];
-		if (!empty($external['snapshot_unavailable'])) {
-			// The pad URL itself validated, but the public-text export
-			// endpoint refused to serve content (404). Common causes:
-			// the remote Etherpad has authentication on /p/<id>/export,
-			// or the pad is restricted despite a public-looking URL.
-			// We keep the file (the viewer can still load the pad
-			// directly through the iframe) and surface a stable code
-			// the frontend translates into a toast.
-			$result['snapshot_warning_code'] = 'remote_export_unavailable';
-		}
-		return $result;
 	}
 
 	/**

--- a/lib/Service/PadFileService.php
+++ b/lib/Service/PadFileService.php
@@ -108,7 +108,13 @@ class PadFileService {
 		}
 
 		$path = (string)(parse_url($url, PHP_URL_PATH) ?? '');
-		$decodedPath = urldecode($path);
+		// rawurldecode (not urldecode): `+` is a literal in URL path
+		// segments, only `application/x-www-form-urlencoded` (query strings,
+		// form bodies) treats `+` as a space. A pad URL like
+		// `/p/team+meeting` must yield pad-id `team+meeting`, not
+		// `team meeting` — otherwise we re-emit `/p/team%20meeting` and the
+		// binding points at a different / non-existent pad.
+		$decodedPath = rawurldecode($path);
 		if (preg_match('~/p/([^/?#]+)$~', $decodedPath, $padMatches) !== 1) {
 			return null;
 		}

--- a/lib/Service/PadInitializationService.php
+++ b/lib/Service/PadInitializationService.php
@@ -17,6 +17,7 @@ use OCP\Files\NotFoundException;
 class PadInitializationService {
 	public const STATUS_ALREADY_INITIALIZED = 'already_initialized';
 	public const STATUS_INITIALIZED = 'initialized';
+	public const STATUS_MIGRATED_FROM_LEGACY = 'migrated_from_legacy';
 
 	public function __construct(
 		private PadFileService $padFileService,
@@ -75,13 +76,13 @@ class PadInitializationService {
 			throw $e;
 		}
 
-		$this->padBootstrapService->initializeMissingFrontmatter($file, $content);
+		$wasLegacyMigration = $this->padBootstrapService->initializeMissingFrontmatter($uid, $file, $content);
 		$updatedContent = (string)$file->getContent();
 		$parsed = $this->padFileService->parsePadFile((string)$updatedContent);
 		$meta = $parsed['frontmatter'];
 
 		return new PadInitializationResult(
-			status: self::STATUS_INITIALIZED,
+			status: $wasLegacyMigration ? self::STATUS_MIGRATED_FROM_LEGACY : self::STATUS_INITIALIZED,
 			file: $path,
 			fileId: $fileId,
 			padId: (string)$meta['pad_id'],

--- a/lib/Service/PadLegacyMigrationService.php
+++ b/lib/Service/PadLegacyMigrationService.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * Copyright (c) 2026 Jacob Bühler
+ */
+
+namespace OCA\EtherpadNextcloud\Service;
+
+use OCA\EtherpadNextcloud\Exception\LegacyPadCollisionException;
+use OCP\Files\File;
+use OCP\Files\NotFoundException;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Lazy per-file migration of legacy Ownpad `.pad` files (those holding an
+ * `[InternetShortcut]` block instead of YAML frontmatter) into the current
+ * binding-and-`.pad` model. Called from `PadBootstrapService` when the
+ * detection in `PadFileService::parseLegacyOwnpadShortcut` matches.
+ *
+ * Three branches, all silent in the happy path:
+ *
+ * 1. **Cross-origin** — the source URL points at a different Etherpad
+ *    server than the one we manage. We can't apply protected-mode auth to
+ *    a server we don't control, so we route through the existing external
+ *    pad shape: write `ext.*` frontmatter, no binding row. Public-only.
+ *
+ * 2. **Same-origin, no collision** — the source pad-id is not yet bound
+ *    to any NC file. We write fresh YAML frontmatter referencing the
+ *    same pad-id and create a binding row. The access mode is derived
+ *    from the pad-id format (g.X$Y → protected, anything else → public).
+ *
+ * 3. **Same-origin, collision** — another NC file already owns the
+ *    binding for this pad-id. If the requesting user can read that
+ *    original file we write frontmatter only (no new binding) and the
+ *    file behaves like a copy-of-a-pad; the existing copy-handling in
+ *    the open flow takes over. If the user has no access we throw
+ *    `LegacyPadCollisionException` and the `.pad` file is left
+ *    untouched — subsequent opens see the same legacy state.
+ */
+class PadLegacyMigrationService {
+	public function __construct(
+		private BindingService $bindingService,
+		private PadFileService $padFileService,
+		private EtherpadClient $etherpadClient,
+		private PadCreationService $padCreationService,
+		private UserNodeResolver $userNodeResolver,
+		private LoggerInterface $logger,
+	) {
+	}
+
+	/**
+	 * Migrate the legacy `.pad` file in place.
+	 *
+	 * @param array{url:string,pad_id:string} $legacyShortcut output of
+	 *   `PadFileService::parseLegacyOwnpadShortcut`
+	 *
+	 * @throws LegacyPadCollisionException when the pad is already bound to
+	 *   a file the requesting user has no access to.
+	 */
+	public function migrate(string $uid, File $file, array $legacyShortcut): void {
+		$fileId = (int)$file->getId();
+		$sourceUrl = $legacyShortcut['url'];
+		$sourcePadId = $legacyShortcut['pad_id'];
+
+		$configuredOrigin = $this->etherpadClient->getConfiguredOrigin();
+		$sourceOrigin = $this->etherpadClient->normalizeOrigin($sourceUrl);
+		$isSameOrigin = $configuredOrigin !== '' && $configuredOrigin === $sourceOrigin;
+
+		if (!$isSameOrigin) {
+			$this->padCreationService->seedExternalIntoFile($file, $fileId, $sourceUrl);
+			$this->logger->info('Migrated legacy Ownpad .pad as external public pad.', [
+				'app' => 'etherpad_nextcloud',
+				'fileId' => $fileId,
+				'sourceUrl' => $sourceUrl,
+				'originBranch' => 'cross',
+				'uid' => $uid,
+			]);
+			return;
+		}
+
+		$accessMode = $this->padFileService->inferAccessModeFromPadId($sourcePadId);
+		$existingBinding = $this->bindingService->findByPadId($sourcePadId, BindingService::STATE_ACTIVE);
+
+		if ($existingBinding === null) {
+			$this->writeManagedFrontmatter($file, $fileId, $sourcePadId, $accessMode);
+			$this->bindingService->createBinding($fileId, $sourcePadId, $accessMode);
+			$this->logger->info('Migrated legacy Ownpad .pad as managed pad (re-bind).', [
+				'app' => 'etherpad_nextcloud',
+				'fileId' => $fileId,
+				'sourceUrl' => $sourceUrl,
+				'originBranch' => 'same',
+				'accessMode' => $accessMode,
+				'padId' => $sourcePadId,
+				'collision' => 'none',
+				'uid' => $uid,
+			]);
+			return;
+		}
+
+		$boundFileId = (int)$existingBinding['file_id'];
+		if ($boundFileId === $fileId) {
+			// Defensive: this branch is unreachable today because we only get
+			// here when the file has no YAML frontmatter, which implies no
+			// binding tied to it either. If it happens anyway, just write the
+			// frontmatter — the existing binding already covers us.
+			$this->writeManagedFrontmatter($file, $fileId, $sourcePadId, $accessMode);
+			$this->logger->info('Migrated legacy Ownpad .pad — binding already exists for this file.', [
+				'app' => 'etherpad_nextcloud',
+				'fileId' => $fileId,
+				'sourceUrl' => $sourceUrl,
+				'originBranch' => 'same',
+				'accessMode' => $accessMode,
+				'padId' => $sourcePadId,
+				'collision' => 'self',
+				'uid' => $uid,
+			]);
+			return;
+		}
+
+		try {
+			$this->userNodeResolver->resolveUserFileNodeById($uid, $boundFileId);
+		} catch (NotFoundException) {
+			$this->logger->warning('Refused legacy Ownpad migration — pad already bound to a file the user cannot read.', [
+				'app' => 'etherpad_nextcloud',
+				'fileId' => $fileId,
+				'sourceUrl' => $sourceUrl,
+				'padId' => $sourcePadId,
+				'boundFileId' => $boundFileId,
+				'collision' => 'no_access',
+				'uid' => $uid,
+			]);
+			throw new LegacyPadCollisionException(
+				'This pad is already linked to another file you do not have access to.',
+			);
+		}
+
+		// Collision-with-access: write managed frontmatter but do NOT create
+		// a second binding row. The file becomes a "copy of a pad" in our
+		// model and the existing copy-handling flow takes over.
+		$this->writeManagedFrontmatter($file, $fileId, $sourcePadId, $accessMode);
+		$this->logger->info('Migrated legacy Ownpad .pad as copy of an already-bound pad.', [
+			'app' => 'etherpad_nextcloud',
+			'fileId' => $fileId,
+			'sourceUrl' => $sourceUrl,
+			'originBranch' => 'same',
+			'accessMode' => $accessMode,
+			'padId' => $sourcePadId,
+			'collision' => 'with_access',
+			'boundFileId' => $boundFileId,
+			'uid' => $uid,
+		]);
+	}
+
+	private function writeManagedFrontmatter(File $file, int $fileId, string $padId, string $accessMode): void {
+		$padUrl = $this->etherpadClient->buildPadUrl($padId);
+		$content = $this->padFileService->buildInitialDocument(
+			$fileId,
+			$padId,
+			$accessMode,
+			'',
+			$padUrl,
+		);
+		$file->putContent($content);
+	}
+}

--- a/lib/Service/PadLegacyMigrationService.php
+++ b/lib/Service/PadLegacyMigrationService.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace OCA\EtherpadNextcloud\Service;
 
+use OCA\EtherpadNextcloud\Exception\BindingException;
 use OCA\EtherpadNextcloud\Exception\LegacyPadCollisionException;
 use OCP\Files\File;
 use OCP\Files\NotFoundException;
@@ -44,7 +45,7 @@ class PadLegacyMigrationService {
 		private BindingService $bindingService,
 		private PadFileService $padFileService,
 		private EtherpadClient $etherpadClient,
-		private PadCreationService $padCreationService,
+		private ExternalPadSeeder $externalPadSeeder,
 		private UserNodeResolver $userNodeResolver,
 		private LoggerInterface $logger,
 	) {
@@ -69,7 +70,7 @@ class PadLegacyMigrationService {
 		$isSameOrigin = $configuredOrigin !== '' && $configuredOrigin === $sourceOrigin;
 
 		if (!$isSameOrigin) {
-			$this->padCreationService->seedExternalIntoFile($file, $fileId, $sourceUrl);
+			$this->externalPadSeeder->seed($file, $fileId, $sourceUrl);
 			$this->logger->info('Migrated legacy Ownpad .pad as external public pad.', [
 				'app' => 'etherpad_nextcloud',
 				'fileId' => $fileId,
@@ -84,29 +85,57 @@ class PadLegacyMigrationService {
 		$existingBinding = $this->bindingService->findByPadId($sourcePadId, BindingService::STATE_ACTIVE);
 
 		if ($existingBinding === null) {
-			$this->writeManagedFrontmatter($file, $fileId, $sourcePadId, $accessMode);
-			$this->bindingService->createBinding($fileId, $sourcePadId, $accessMode);
-			$this->logger->info('Migrated legacy Ownpad .pad as managed pad (re-bind).', [
-				'app' => 'etherpad_nextcloud',
-				'fileId' => $fileId,
-				'sourceUrl' => $sourceUrl,
-				'originBranch' => 'same',
-				'accessMode' => $accessMode,
-				'padId' => $sourcePadId,
-				'collision' => 'none',
-				'uid' => $uid,
-			]);
-			return;
+			// Create the binding first, then write the file. If the binding
+			// fails (e.g. a concurrent migration claimed the same pad-id
+			// between findByPadId and createBinding), we re-classify as a
+			// collision and fall through to the access check — the .pad
+			// file is left untouched so the next open retries cleanly.
+			//
+			// Doing it in the other order would leave a half-migrated state:
+			// the file would have managed frontmatter pointing at a pad-id
+			// with no binding row, and the existing copy-recovery flow can't
+			// help (it needs *some* binding for that pad-id to exist).
+			try {
+				$this->bindingService->createBinding($fileId, $sourcePadId, $accessMode);
+			} catch (BindingException $e) {
+				$existingBinding = $this->bindingService->findByPadId($sourcePadId, BindingService::STATE_ACTIVE);
+				if ($existingBinding === null) {
+					// Race lost AND no winner — surface the original failure
+					// so the open retry sees a clear "could not initialize".
+					throw $e;
+				}
+				$this->logger->info('Legacy Ownpad migration lost a race for the pad-id; reclassifying as collision.', [
+					'app' => 'etherpad_nextcloud',
+					'fileId' => $fileId,
+					'padId' => $sourcePadId,
+					'uid' => $uid,
+				]);
+				// Fall through to the collision-with-access handling below.
+			}
+			if ($existingBinding === null) {
+				$this->writeManagedFrontmatter($file, $fileId, $sourcePadId, $accessMode);
+				$this->logger->info('Migrated legacy Ownpad .pad as managed pad (re-bind).', [
+					'app' => 'etherpad_nextcloud',
+					'fileId' => $fileId,
+					'sourceUrl' => $sourceUrl,
+					'originBranch' => 'same',
+					'accessMode' => $accessMode,
+					'padId' => $sourcePadId,
+					'collision' => 'none',
+					'uid' => $uid,
+				]);
+				return;
+			}
 		}
 
 		$boundFileId = (int)$existingBinding['file_id'];
 		if ($boundFileId === $fileId) {
-			// Defensive: this branch is unreachable today because we only get
-			// here when the file has no YAML frontmatter, which implies no
-			// binding tied to it either. If it happens anyway, just write the
-			// frontmatter — the existing binding already covers us.
+			// Self-collision: an earlier migration attempt for this file
+			// succeeded in creating the binding but failed before the file
+			// write. Just finish the file-side work; the binding already
+			// covers us.
 			$this->writeManagedFrontmatter($file, $fileId, $sourcePadId, $accessMode);
-			$this->logger->info('Migrated legacy Ownpad .pad — binding already exists for this file.', [
+			$this->logger->info('Migrated legacy Ownpad .pad — finishing partially-completed prior migration.', [
 				'app' => 'etherpad_nextcloud',
 				'fileId' => $fileId,
 				'sourceUrl' => $sourceUrl,

--- a/src/embed-main.js
+++ b/src/embed-main.js
@@ -360,12 +360,17 @@ import { fetchJsonWithTimeout as fetchJson } from './lib/fetch-helpers.js'
 
 	const initializePad = async () => {
 		const url = initializeByIdUrlTemplate.replace('__FILE_ID__', encodeURIComponent(String(fileId)))
-		await fetchJson(url, {
+		const data = await fetchJson(url, {
 			method: 'POST',
 			headers: {
 				requesttoken: requestToken(),
 			},
 		})
+		if (data && data.status === 'migrated_from_legacy') {
+			// Mirror the backend audit-log entry to the browser console; no
+			// toast surface is wired up in this app yet.
+			console.info('Legacy Ownpad .pad migrated to managed format on first open.')
+		}
 	}
 
 	const hideAllPanels = () => {

--- a/src/viewer-main.js
+++ b/src/viewer-main.js
@@ -133,13 +133,34 @@ import { parsePadPathFromDavHref, parsePublicShareTokenFromLocation } from './li
 					requesttoken: ocRequestToken(),
 				}
 
+				const buildInitError = (data, fallbackMessage) => {
+					const err = new Error((data && data.message) || fallbackMessage)
+					// Forward a structured code so callers can branch on
+					// `legacy_collision_no_access` without parsing the message.
+					if (data && typeof data.code === 'string' && data.code !== '') {
+						err.code = data.code
+					}
+					return err
+				}
+
+				const announceMigratedStatus = (data) => {
+					if (data && data.status === 'migrated_from_legacy') {
+						// Audit-visible on the backend; mirror it in the
+						// browser console so dev tools makes the conversion
+						// visible without surfacing a UI toast (the codebase
+						// has no toast infra wired yet).
+						console.info('Legacy Ownpad .pad migrated to managed format on first open.')
+					}
+				}
+
 				if (this.resolvedFileId !== null) {
 					const url = ocGenerateUrl('/apps/' + APP_ID + '/api/v1/pads/initialize-by-id/' + encodeURIComponent(String(this.resolvedFileId)))
 					const response = await fetch(url, { method: 'POST', credentials: 'same-origin', headers })
 					const data = await response.json().catch(() => ({}))
 					if (!response.ok) {
-						throw new Error((data && data.message) || 'Pad initialization failed.')
+						throw buildInitError(data, 'Pad initialization failed.')
 					}
+					announceMigratedStatus(data)
 					return data
 				}
 
@@ -160,8 +181,9 @@ import { parsePadPathFromDavHref, parsePublicShareTokenFromLocation } from './li
 				})
 				const data = await response.json().catch(() => ({}))
 				if (!response.ok) {
-					throw new Error((data && data.message) || 'Pad initialization failed.')
+					throw buildInitError(data, 'Pad initialization failed.')
 				}
+				announceMigratedStatus(data)
 				return data
 			},
 			markLoaded() {

--- a/tests/phpunit/unit/EtherpadClientTest.php
+++ b/tests/phpunit/unit/EtherpadClientTest.php
@@ -82,6 +82,22 @@ class EtherpadClientTest extends TestCase {
 		$this->assertSame('https://1.1.1.1/p/My%20Pad', $result['pad_url']);
 	}
 
+	public function testNormalizeAndValidateExternalPublicPadUrlKeepsLiteralPlusInPadId(): void {
+		// `+` is literal in URL path segments. Using urldecode() previously
+		// turned `team+pad` into pad-id `team pad`, then re-emitted
+		// `/p/team%20pad` which hits a different / non-existent pad.
+		$client = new EtherpadClient($this->buildExternalEnabledConfig());
+		$result = $client->normalizeAndValidateExternalPublicPadUrl('https://1.1.1.1/p/team+meeting');
+		$this->assertSame('team+meeting', $result['pad_id']);
+		$this->assertSame('https://1.1.1.1/p/team%2Bmeeting', $result['pad_url']);
+	}
+
+	public function testNormalizeAndValidateExternalPublicPadUrlDecodesPercentEncodedPlus(): void {
+		$client = new EtherpadClient($this->buildExternalEnabledConfig());
+		$result = $client->normalizeAndValidateExternalPublicPadUrl('https://1.1.1.1/p/team%2Bmeeting');
+		$this->assertSame('team+meeting', $result['pad_id']);
+	}
+
 	public function testNormalizeAndValidateExternalPublicPadUrlAcceptsMatchingAllowlistedOriginWithPort(): void {
 		$client = new EtherpadClient($this->buildExternalEnabledConfig('https://1.1.1.1:8443'));
 

--- a/tests/phpunit/unit/EtherpadClientTest.php
+++ b/tests/phpunit/unit/EtherpadClientTest.php
@@ -28,6 +28,50 @@ class EtherpadClientTest extends TestCase {
 		);
 	}
 
+	public function testGetConfiguredOriginNormalizesScheme(): void {
+		$client = new EtherpadClient($this->configWithHost('HTTPS://Pad.Example.Test/'));
+		$this->assertSame('https://pad.example.test', $client->getConfiguredOrigin());
+	}
+
+	public function testGetConfiguredOriginOmitsDefaultPorts(): void {
+		$client = new EtherpadClient($this->configWithHost('https://pad.example.test:443'));
+		$this->assertSame('https://pad.example.test', $client->getConfiguredOrigin());
+
+		$client = new EtherpadClient($this->configWithHost('http://pad.example.test:80'));
+		$this->assertSame('http://pad.example.test', $client->getConfiguredOrigin());
+	}
+
+	public function testGetConfiguredOriginKeepsNonDefaultPort(): void {
+		$client = new EtherpadClient($this->configWithHost('https://pad.example.test:9001'));
+		$this->assertSame('https://pad.example.test:9001', $client->getConfiguredOrigin());
+	}
+
+	public function testGetConfiguredOriginAllowsHttp(): void {
+		// Unlike `parsePublicPadUrl`, the configured-origin accessor must not
+		// enforce https — admins may legitimately run Etherpad on http behind
+		// a private network.
+		$client = new EtherpadClient($this->configWithHost('http://pad.internal.lan'));
+		$this->assertSame('http://pad.internal.lan', $client->getConfiguredOrigin());
+	}
+
+	public function testGetConfiguredOriginReturnsEmptyWhenUnconfigured(): void {
+		$client = new EtherpadClient($this->configWithHost(''));
+		$this->assertSame('', $client->getConfiguredOrigin());
+	}
+
+	private function configWithHost(string $host): IConfig {
+		$config = $this->createMock(IConfig::class);
+		$config->method('getAppValue')->willReturnCallback(
+			static function (string $appName, string $key, string $default = '') use ($host): string {
+				if ($appName === 'etherpad_nextcloud' && $key === 'etherpad_host') {
+					return $host;
+				}
+				return $default;
+			}
+		);
+		return $config;
+	}
+
 	public function testNormalizeAndValidateExternalPublicPadUrlCanonicalizesHttpsUrl(): void {
 		$client = new EtherpadClient($this->buildExternalEnabledConfig());
 

--- a/tests/phpunit/unit/ExternalPadSeederTest.php
+++ b/tests/phpunit/unit/ExternalPadSeederTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\EtherpadNextcloud\Tests\Unit;
+
+use OCA\EtherpadNextcloud\Service\BindingService;
+use OCA\EtherpadNextcloud\Service\EtherpadClient;
+use OCA\EtherpadNextcloud\Service\ExternalPadSeeder;
+use OCA\EtherpadNextcloud\Service\PadFileService;
+use OCP\Files\File;
+use PHPUnit\Framework\TestCase;
+
+class ExternalPadSeederTest extends TestCase {
+	public function testSeedWritesExtFrontmatterAndSnapshotIntoFile(): void {
+		$fileNode = $this->createMock(File::class);
+		$fileNode->expects($this->once())
+			->method('putContent')
+			->with('seeded-frontmatter');
+
+		$etherpadClient = $this->createMock(EtherpadClient::class);
+		$etherpadClient->expects($this->once())
+			->method('normalizeAndFetchExternalPublicPadTextOrEmpty')
+			->with('https://pad.remote.test/p/RemotePad')
+			->willReturn([
+				'pad_url' => 'https://pad.remote.test/p/RemotePad',
+				'origin' => 'https://pad.remote.test',
+				'pad_id' => 'RemotePad',
+				'text' => 'snapshot-body',
+			]);
+
+		$padFileService = $this->createMock(PadFileService::class);
+		$padFileService->expects($this->once())
+			->method('buildInitialDocument')
+			->with(
+				999,
+				'ext.RemotePad',
+				BindingService::ACCESS_PUBLIC,
+				'',
+				'https://pad.remote.test/p/RemotePad',
+				[
+					'pad_origin' => 'https://pad.remote.test',
+					'remote_pad_id' => 'RemotePad',
+				],
+			)
+			->willReturn('initial-doc');
+		$padFileService->expects($this->once())
+			->method('withExportSnapshot')
+			->with('initial-doc', 'snapshot-body', '', 0, false)
+			->willReturn('seeded-frontmatter');
+
+		$result = (new ExternalPadSeeder($padFileService, $etherpadClient))
+			->seed($fileNode, 999, 'https://pad.remote.test/p/RemotePad');
+
+		$this->assertSame([
+			'file_id' => 999,
+			'pad_id' => 'ext.RemotePad',
+			'access_mode' => BindingService::ACCESS_PUBLIC,
+			'pad_url' => 'https://pad.remote.test/p/RemotePad',
+		], $result);
+	}
+
+	public function testSeedSurfacesSnapshotUnavailableWarningCode(): void {
+		$etherpadClient = $this->createMock(EtherpadClient::class);
+		$etherpadClient->method('normalizeAndFetchExternalPublicPadTextOrEmpty')
+			->willReturn([
+				'pad_url' => 'https://pad.remote.test/p/RemotePad',
+				'origin' => 'https://pad.remote.test',
+				'pad_id' => 'RemotePad',
+				'text' => '',
+				'snapshot_unavailable' => true,
+			]);
+
+		$padFileService = $this->createMock(PadFileService::class);
+		$padFileService->method('buildInitialDocument')->willReturn('doc');
+		$padFileService->method('withExportSnapshot')->willReturn('doc');
+
+		$result = (new ExternalPadSeeder($padFileService, $etherpadClient))
+			->seed($this->createMock(File::class), 1, 'https://pad.remote.test/p/RemotePad');
+
+		$this->assertSame('remote_export_unavailable', $result['snapshot_warning_code']);
+	}
+}

--- a/tests/phpunit/unit/PadBootstrapServiceTest.php
+++ b/tests/phpunit/unit/PadBootstrapServiceTest.php
@@ -65,12 +65,12 @@ class PadBootstrapServiceTest extends TestCase {
 		$file->expects($this->once())->method('getId')->willReturn($fileId);
 		$file->expects($this->once())->method('putContent')->with('doc-content');
 
-		$service = new PadBootstrapService($bindingService, $padFileService, $etherpadClient, $secureRandom, $logger);
-		$service->initializeMissingFrontmatter($file, '');
+		$migration = $this->createMock(\OCA\EtherpadNextcloud\Service\PadLegacyMigrationService::class);
+		$service = new PadBootstrapService($bindingService, $padFileService, $etherpadClient, $secureRandom, $logger, $migration);
+		$service->initializeMissingFrontmatter('alice', $file, '');
 	}
 
-	public function testInitializeMissingFrontmatterRejectsLegacyShortcut(): void {
-		$fileId = 7;
+	public function testInitializeMissingFrontmatterDelegatesLegacyShortcutToMigrationService(): void {
 		$legacy = [
 			'url' => 'https://pad.example.test/p/public-pad',
 			'pad_id' => 'public-pad',
@@ -84,20 +84,23 @@ class PadBootstrapServiceTest extends TestCase {
 		$padFileService->expects($this->once())
 			->method('parseLegacyOwnpadShortcut')
 			->willReturn($legacy);
-		$padFileService->expects($this->never())->method('inferAccessModeFromPadId');
 
 		$etherpadClient = $this->createMock(EtherpadClient::class);
 		$secureRandom = $this->createMock(ISecureRandom::class);
 		$logger = $this->createMock(LoggerInterface::class);
 
 		$file = $this->createMock(File::class);
-		$file->expects($this->once())->method('getId')->willReturn($fileId);
 
-		$service = new PadBootstrapService($bindingService, $padFileService, $etherpadClient, $secureRandom, $logger);
+		$migration = $this->createMock(\OCA\EtherpadNextcloud\Service\PadLegacyMigrationService::class);
+		$migration->expects($this->once())
+			->method('migrate')
+			->with('alice', $file, $legacy);
 
-		$this->expectException(PadFileFormatException::class);
-		$this->expectExceptionMessage('Legacy Ownpad .pad files cannot be auto-imported.');
-		$service->initializeMissingFrontmatter($file, "[InternetShortcut]\nURL=https://pad.example.test/p/public-pad\n");
+		$service = new PadBootstrapService($bindingService, $padFileService, $etherpadClient, $secureRandom, $logger, $migration);
+
+		$this->assertTrue(
+			$service->initializeMissingFrontmatter('alice', $file, "[InternetShortcut]\nURL=https://pad.example.test/p/public-pad\n")
+		);
 	}
 
 	public function testInitializeMissingFrontmatterCleansUpWhenWriteFails(): void {
@@ -146,10 +149,11 @@ class PadBootstrapServiceTest extends TestCase {
 			->with('doc-that-fails-to-write')
 			->willThrowException(new \RuntimeException('write failed'));
 
-		$service = new PadBootstrapService($bindingService, $padFileService, $etherpadClient, $secureRandom, $logger);
+		$migration = $this->createMock(\OCA\EtherpadNextcloud\Service\PadLegacyMigrationService::class);
+		$service = new PadBootstrapService($bindingService, $padFileService, $etherpadClient, $secureRandom, $logger, $migration);
 
 		$this->expectException(\RuntimeException::class);
 		$this->expectExceptionMessage('write failed');
-		$service->initializeMissingFrontmatter($file, '');
+		$service->initializeMissingFrontmatter('alice', $file, '');
 	}
 }

--- a/tests/phpunit/unit/PadControllerErrorMapperTest.php
+++ b/tests/phpunit/unit/PadControllerErrorMapperTest.php
@@ -6,6 +6,7 @@ namespace OCA\EtherpadNextcloud\Tests\Unit;
 
 use OCA\EtherpadNextcloud\Controller\PadControllerErrorMapper;
 use OCA\EtherpadNextcloud\Exception\BindingException;
+use OCA\EtherpadNextcloud\Exception\LegacyPadCollisionException;
 use OCA\EtherpadNextcloud\Exception\MissingBindingException;
 use OCA\EtherpadNextcloud\Exception\ControllerBadRequestException;
 use OCA\EtherpadNextcloud\Exception\EtherpadClientException;
@@ -122,6 +123,17 @@ class PadControllerErrorMapperTest extends TestCase {
 
 		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
 		$this->assertSame('missing_binding', $response->getData()['code']);
+	}
+
+	public function testRunMapsLegacyPadCollision(): void {
+		$response = $this->buildMapper()->run(
+			static fn(): array => throw new LegacyPadCollisionException('not your pad'),
+			static fn(array $result): DataResponse => new DataResponse($result),
+		);
+
+		$this->assertSame(Http::STATUS_CONFLICT, $response->getStatus());
+		$this->assertSame('legacy_collision_no_access', $response->getData()['code']);
+		$this->assertSame('not your pad', $response->getData()['message']);
 	}
 
 	public function testRunMapsPadAlreadyHasBinding(): void {

--- a/tests/phpunit/unit/PadCreationServiceTest.php
+++ b/tests/phpunit/unit/PadCreationServiceTest.php
@@ -246,6 +246,58 @@ class PadCreationServiceTest extends TestCase {
 		$this->assertSame('remote_export_unavailable', $result['snapshot_warning_code']);
 	}
 
+	public function testSeedExternalIntoFileWritesFrontmatterOnExistingFile(): void {
+		// Re-used by the legacy-Ownpad migration path: the file already
+		// exists, we only need to seed it with `ext.*` frontmatter + snapshot.
+		$fileNode = $this->createMock(File::class);
+		$fileNode->expects($this->once())
+			->method('putContent')
+			->with('seeded-frontmatter');
+
+		$etherpadClient = $this->createMock(EtherpadClient::class);
+		$etherpadClient->expects($this->once())
+			->method('normalizeAndFetchExternalPublicPadTextOrEmpty')
+			->with('https://pad.remote.test/p/RemotePad')
+			->willReturn([
+				'pad_url' => 'https://pad.remote.test/p/RemotePad',
+				'origin' => 'https://pad.remote.test',
+				'pad_id' => 'RemotePad',
+				'text' => 'snapshot-body',
+			]);
+
+		$padFileService = $this->createMock(PadFileService::class);
+		$padFileService->expects($this->once())
+			->method('buildInitialDocument')
+			->with(
+				999,
+				'ext.RemotePad',
+				BindingService::ACCESS_PUBLIC,
+				'',
+				'https://pad.remote.test/p/RemotePad',
+				[
+					'pad_origin' => 'https://pad.remote.test',
+					'remote_pad_id' => 'RemotePad',
+				],
+			)
+			->willReturn('initial-doc');
+		$padFileService->expects($this->once())
+			->method('withExportSnapshot')
+			->with('initial-doc', 'snapshot-body', '', 0, false)
+			->willReturn('seeded-frontmatter');
+
+		$result = $this->buildService(
+			padFileService: $padFileService,
+			etherpadClient: $etherpadClient,
+		)->seedExternalIntoFile($fileNode, 999, 'https://pad.remote.test/p/RemotePad');
+
+		$this->assertSame([
+			'file_id' => 999,
+			'pad_id' => 'ext.RemotePad',
+			'access_mode' => BindingService::ACCESS_PUBLIC,
+			'pad_url' => 'https://pad.remote.test/p/RemotePad',
+		], $result);
+	}
+
 	public function testCreateFromUrlRollsBackWhenInitialSnapshotFetchFails(): void {
 		$fileNode = $this->createMock(File::class);
 		$fileNode->method('getId')->willReturn(321);

--- a/tests/phpunit/unit/PadCreationServiceTest.php
+++ b/tests/phpunit/unit/PadCreationServiceTest.php
@@ -246,58 +246,6 @@ class PadCreationServiceTest extends TestCase {
 		$this->assertSame('remote_export_unavailable', $result['snapshot_warning_code']);
 	}
 
-	public function testSeedExternalIntoFileWritesFrontmatterOnExistingFile(): void {
-		// Re-used by the legacy-Ownpad migration path: the file already
-		// exists, we only need to seed it with `ext.*` frontmatter + snapshot.
-		$fileNode = $this->createMock(File::class);
-		$fileNode->expects($this->once())
-			->method('putContent')
-			->with('seeded-frontmatter');
-
-		$etherpadClient = $this->createMock(EtherpadClient::class);
-		$etherpadClient->expects($this->once())
-			->method('normalizeAndFetchExternalPublicPadTextOrEmpty')
-			->with('https://pad.remote.test/p/RemotePad')
-			->willReturn([
-				'pad_url' => 'https://pad.remote.test/p/RemotePad',
-				'origin' => 'https://pad.remote.test',
-				'pad_id' => 'RemotePad',
-				'text' => 'snapshot-body',
-			]);
-
-		$padFileService = $this->createMock(PadFileService::class);
-		$padFileService->expects($this->once())
-			->method('buildInitialDocument')
-			->with(
-				999,
-				'ext.RemotePad',
-				BindingService::ACCESS_PUBLIC,
-				'',
-				'https://pad.remote.test/p/RemotePad',
-				[
-					'pad_origin' => 'https://pad.remote.test',
-					'remote_pad_id' => 'RemotePad',
-				],
-			)
-			->willReturn('initial-doc');
-		$padFileService->expects($this->once())
-			->method('withExportSnapshot')
-			->with('initial-doc', 'snapshot-body', '', 0, false)
-			->willReturn('seeded-frontmatter');
-
-		$result = $this->buildService(
-			padFileService: $padFileService,
-			etherpadClient: $etherpadClient,
-		)->seedExternalIntoFile($fileNode, 999, 'https://pad.remote.test/p/RemotePad');
-
-		$this->assertSame([
-			'file_id' => 999,
-			'pad_id' => 'ext.RemotePad',
-			'access_mode' => BindingService::ACCESS_PUBLIC,
-			'pad_url' => 'https://pad.remote.test/p/RemotePad',
-		], $result);
-	}
-
 	public function testCreateFromUrlRollsBackWhenInitialSnapshotFetchFails(): void {
 		$fileNode = $this->createMock(File::class);
 		$fileNode->method('getId')->willReturn(321);
@@ -473,22 +421,32 @@ class PadCreationServiceTest extends TestCase {
 		?EtherpadClient $etherpadClient = null,
 		?PadBootstrapService $bootstrap = null,
 		?\OCA\EtherpadNextcloud\Service\PadPlaceholderResolver $placeholderResolver = null,
+		?\OCA\EtherpadNextcloud\Service\ExternalPadSeeder $externalPadSeeder = null,
 	): PadCreationService {
 		if ($placeholderResolver === null) {
 			$timeFactory = $this->createMock(\OCP\AppFramework\Utility\ITimeFactory::class);
 			$timeFactory->method('getTime')->willReturn(1778976000);
 			$placeholderResolver = new \OCA\EtherpadNextcloud\Service\PadPlaceholderResolver($timeFactory);
 		}
+		$padFileService = $padFileService ?? $this->createMock(PadFileService::class);
+		$etherpadClient = $etherpadClient ?? $this->createMock(EtherpadClient::class);
+		// Build a real seeder from the test's mocked deps by default so the
+		// createFromUrl tests can keep stubbing
+		// EtherpadClient::normalizeAndFetchExternalPublicPadTextOrEmpty
+		// directly without having to mock the seeder separately.
+		$externalPadSeeder = $externalPadSeeder
+			?? new \OCA\EtherpadNextcloud\Service\ExternalPadSeeder($padFileService, $etherpadClient);
 		return new PadCreationService(
-			$padFileService ?? $this->createMock(PadFileService::class),
+			$padFileService,
 			$padPaths ?? $this->createMock(PadPathService::class),
 			$fileCreator ?? $this->createMock(PadFileCreator::class),
 			$userNodeResolver ?? $this->createMock(UserNodeResolver::class),
 			$rollbackService ?? $this->createMock(PadCreateRollbackService::class),
 			$bindingService ?? $this->createMock(BindingService::class),
-			$etherpadClient ?? $this->createMock(EtherpadClient::class),
+			$etherpadClient,
 			$bootstrap ?? $this->createMock(PadBootstrapService::class),
 			$placeholderResolver,
+			$externalPadSeeder,
 			$this->createMock(LoggerInterface::class),
 		);
 	}

--- a/tests/phpunit/unit/PadFileServiceTest.php
+++ b/tests/phpunit/unit/PadFileServiceTest.php
@@ -288,6 +288,28 @@ class PadFileServiceTest extends TestCase {
 		);
 	}
 
+	public function testParseLegacyOwnpadShortcutKeepsLiteralPlusInPadId(): void {
+		// `+` is a literal in URL path segments; only query/form encoding
+		// treats it as a space. The previous urldecode() turned
+		// `team+meeting` into `team meeting` and broke the binding lookup.
+		$service = new PadFileService();
+		$parsed = $service->parseLegacyOwnpadShortcut(
+			"[InternetShortcut]\nURL=https://pad.example.test/p/team+meeting\n"
+		);
+		$this->assertNotNull($parsed);
+		$this->assertSame('team+meeting', $parsed['pad_id']);
+	}
+
+	public function testParseLegacyOwnpadShortcutDecodesPercentEncodedPlus(): void {
+		// `%2B` (percent-encoded plus) must still decode to `+`.
+		$service = new PadFileService();
+		$parsed = $service->parseLegacyOwnpadShortcut(
+			"[InternetShortcut]\nURL=https://pad.example.test/p/team%2Bmeeting\n"
+		);
+		$this->assertNotNull($parsed);
+		$this->assertSame('team+meeting', $parsed['pad_id']);
+	}
+
 	public function testParseLegacyOwnpadShortcutReturnsNullWithoutPadSegment(): void {
 		$service = new PadFileService();
 		$this->assertNull(

--- a/tests/phpunit/unit/PadInitializationServiceTest.php
+++ b/tests/phpunit/unit/PadInitializationServiceTest.php
@@ -166,7 +166,8 @@ class PadInitializationServiceTest extends TestCase {
 		$bootstrap = $this->createMock(PadBootstrapService::class);
 		$bootstrap->expects($this->once())
 			->method('initializeMissingFrontmatter')
-			->with($file, 'legacy-content');
+			->with('alice', $file, 'legacy-content')
+			->willReturn(false);
 
 		$result = (new PadInitializationService($padFileService, $this->createMock(PadPathService::class), $userNodeResolver, $bootstrap))
 			->initialize('alice', $file, 'legacy-content');
@@ -176,5 +177,40 @@ class PadInitializationServiceTest extends TestCase {
 		$this->assertSame(42, $result->fileId);
 		$this->assertSame('g.XYZ$pad', $result->padId);
 		$this->assertSame(BindingService::ACCESS_PROTECTED, $result->accessMode);
+	}
+
+	public function testInitializeReportsMigratedStatusForLegacyOwnpadShortcut(): void {
+		$file = $this->createMock(File::class);
+		$file->method('getId')->willReturn(43);
+		$file->method('getContent')->willReturn('updated-content');
+
+		$userNodeResolver = $this->createMock(UserNodeResolver::class);
+		$userNodeResolver->method('toUserAbsolutePath')->willReturn('/LegacyShortcut.pad');
+
+		$padFileService = $this->createMock(PadFileService::class);
+		$parseCalls = 0;
+		$padFileService->expects($this->exactly(2))
+			->method('parsePadFile')
+			->willReturnCallback(static function (string $content) use (&$parseCalls): array {
+				$parseCalls++;
+				if ($parseCalls === 1) {
+					throw new MissingFrontmatterException('Missing frontmatter.');
+				}
+				return [
+					'frontmatter' => [
+						'pad_id' => 're-bound-pad',
+						'access_mode' => BindingService::ACCESS_PUBLIC,
+					],
+				];
+			});
+
+		$bootstrap = $this->createMock(PadBootstrapService::class);
+		$bootstrap->method('initializeMissingFrontmatter')->willReturn(true);
+
+		$result = (new PadInitializationService($padFileService, $this->createMock(PadPathService::class), $userNodeResolver, $bootstrap))
+			->initialize('alice', $file, "[InternetShortcut]\nURL=https://pad.example.test/p/re-bound-pad\n");
+
+		$this->assertSame(PadInitializationService::STATUS_MIGRATED_FROM_LEGACY, $result->status);
+		$this->assertSame('re-bound-pad', $result->padId);
 	}
 }

--- a/tests/phpunit/unit/PadLegacyMigrationServiceTest.php
+++ b/tests/phpunit/unit/PadLegacyMigrationServiceTest.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace OCA\EtherpadNextcloud\Tests\Unit;
 
+use OCA\EtherpadNextcloud\Exception\BindingException;
 use OCA\EtherpadNextcloud\Exception\LegacyPadCollisionException;
 use OCA\EtherpadNextcloud\Service\BindingService;
 use OCA\EtherpadNextcloud\Service\EtherpadClient;
-use OCA\EtherpadNextcloud\Service\PadCreationService;
+use OCA\EtherpadNextcloud\Service\ExternalPadSeeder;
 use OCA\EtherpadNextcloud\Service\PadFileService;
 use OCA\EtherpadNextcloud\Service\PadLegacyMigrationService;
 use OCA\EtherpadNextcloud\Service\UserNodeResolver;
@@ -21,9 +22,9 @@ class PadLegacyMigrationServiceTest extends TestCase {
 		$file = $this->createMock(File::class);
 		$file->method('getId')->willReturn(101);
 
-		$padCreation = $this->createMock(PadCreationService::class);
-		$padCreation->expects($this->once())
-			->method('seedExternalIntoFile')
+		$externalPadSeeder = $this->createMock(ExternalPadSeeder::class);
+		$externalPadSeeder->expects($this->once())
+			->method('seed')
 			->with($file, 101, 'https://legacy.example.test/p/team-meeting')
 			->willReturn([
 				'file_id' => 101,
@@ -45,7 +46,7 @@ class PadLegacyMigrationServiceTest extends TestCase {
 		$this->buildService(
 			binding: $binding,
 			etherpadClient: $etherpadClient,
-			padCreation: $padCreation,
+			externalPadSeeder: $externalPadSeeder,
 		)->migrate('alice', $file, [
 			'url' => 'https://legacy.example.test/p/team-meeting',
 			'pad_id' => 'team-meeting',
@@ -164,6 +165,98 @@ class PadLegacyMigrationServiceTest extends TestCase {
 		]);
 	}
 
+	public function testSameOriginNoCollisionCreatesBindingBeforeFile(): void {
+		// The reviewer's concern: if a partial failure leaves the .pad with
+		// managed frontmatter but no binding row, the copy-recovery flow
+		// can't help (it needs *some* binding for the pad-id to exist).
+		// So binding goes first; the file write goes second.
+		$callOrder = [];
+
+		$file = $this->createMock(File::class);
+		$file->method('getId')->willReturn(606);
+		$file->method('putContent')->willReturnCallback(static function () use (&$callOrder): void {
+			$callOrder[] = 'putContent';
+		});
+
+		$padFileService = $this->createMock(PadFileService::class);
+		$padFileService->method('inferAccessModeFromPadId')->willReturn(BindingService::ACCESS_PROTECTED);
+		$padFileService->method('buildInitialDocument')->willReturn('frontmatter');
+
+		$etherpadClient = $this->createMock(EtherpadClient::class);
+		$etherpadClient->method('getConfiguredOrigin')->willReturn('https://pad.our-server.test');
+		$etherpadClient->method('normalizeOrigin')->willReturn('https://pad.our-server.test');
+		$etherpadClient->method('buildPadUrl')->willReturn('https://pad.our-server.test/p/g.x$y');
+
+		$binding = $this->createMock(BindingService::class);
+		$binding->method('findByPadId')->willReturn(null);
+		$binding->expects($this->once())
+			->method('createBinding')
+			->willReturnCallback(static function () use (&$callOrder): void {
+				$callOrder[] = 'createBinding';
+			});
+
+		$this->buildService(
+			binding: $binding,
+			padFileService: $padFileService,
+			etherpadClient: $etherpadClient,
+		)->migrate('alice', $file, [
+			'url' => 'https://pad.our-server.test/p/g.x$y',
+			'pad_id' => 'g.x$y',
+		]);
+
+		$this->assertSame(['createBinding', 'putContent'], $callOrder);
+	}
+
+	public function testSameOriginBindingRaceReclassifiesAsCollisionWithAccess(): void {
+		// A concurrent migration / open created the binding between our
+		// findByPadId and our createBinding. The second findByPadId now
+		// finds the winning binding; if we can read that file we recover
+		// as a copy-of-a-pad without writing a second binding row.
+		$file = $this->createMock(File::class);
+		$file->method('getId')->willReturn(707);
+		$file->expects($this->once())->method('putContent');
+
+		$padFileService = $this->createMock(PadFileService::class);
+		$padFileService->method('inferAccessModeFromPadId')->willReturn(BindingService::ACCESS_PUBLIC);
+		$padFileService->method('buildInitialDocument')->willReturn('frontmatter');
+
+		$etherpadClient = $this->createMock(EtherpadClient::class);
+		$etherpadClient->method('getConfiguredOrigin')->willReturn('https://pad.our-server.test');
+		$etherpadClient->method('normalizeOrigin')->willReturn('https://pad.our-server.test');
+		$etherpadClient->method('buildPadUrl')->willReturn('https://pad.our-server.test/p/race-pad');
+
+		$binding = $this->createMock(BindingService::class);
+		$findCalls = 0;
+		$binding->method('findByPadId')->willReturnCallback(
+			static function () use (&$findCalls): ?array {
+				$findCalls++;
+				if ($findCalls === 1) {
+					return null; // initial check: no binding
+				}
+				return ['file_id' => 808, 'pad_id' => 'race-pad', 'access_mode' => 'public'];
+			}
+		);
+		$binding->expects($this->once())
+			->method('createBinding')
+			->willThrowException(new BindingException('unique constraint hit'));
+
+		$resolver = $this->createMock(UserNodeResolver::class);
+		$resolver->expects($this->once())
+			->method('resolveUserFileNodeById')
+			->with('alice', 808)
+			->willReturn($this->createMock(File::class));
+
+		$this->buildService(
+			binding: $binding,
+			padFileService: $padFileService,
+			etherpadClient: $etherpadClient,
+			resolver: $resolver,
+		)->migrate('alice', $file, [
+			'url' => 'https://pad.our-server.test/p/race-pad',
+			'pad_id' => 'race-pad',
+		]);
+	}
+
 	public function testSameOriginCollisionWithoutAccessRefuses(): void {
 		// The pad is bound to someone else's file alice cannot read.
 		// Migration is refused, the .pad file stays untouched, an exception
@@ -209,14 +302,14 @@ class PadLegacyMigrationServiceTest extends TestCase {
 		?BindingService $binding = null,
 		?PadFileService $padFileService = null,
 		?EtherpadClient $etherpadClient = null,
-		?PadCreationService $padCreation = null,
+		?ExternalPadSeeder $externalPadSeeder = null,
 		?UserNodeResolver $resolver = null,
 	): PadLegacyMigrationService {
 		return new PadLegacyMigrationService(
 			$binding ?? $this->createMock(BindingService::class),
 			$padFileService ?? $this->createMock(PadFileService::class),
 			$etherpadClient ?? $this->createMock(EtherpadClient::class),
-			$padCreation ?? $this->createMock(PadCreationService::class),
+			$externalPadSeeder ?? $this->createMock(ExternalPadSeeder::class),
 			$resolver ?? $this->createMock(UserNodeResolver::class),
 			$this->createMock(LoggerInterface::class),
 		);

--- a/tests/phpunit/unit/PadLegacyMigrationServiceTest.php
+++ b/tests/phpunit/unit/PadLegacyMigrationServiceTest.php
@@ -1,0 +1,224 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\EtherpadNextcloud\Tests\Unit;
+
+use OCA\EtherpadNextcloud\Exception\LegacyPadCollisionException;
+use OCA\EtherpadNextcloud\Service\BindingService;
+use OCA\EtherpadNextcloud\Service\EtherpadClient;
+use OCA\EtherpadNextcloud\Service\PadCreationService;
+use OCA\EtherpadNextcloud\Service\PadFileService;
+use OCA\EtherpadNextcloud\Service\PadLegacyMigrationService;
+use OCA\EtherpadNextcloud\Service\UserNodeResolver;
+use OCP\Files\File;
+use OCP\Files\NotFoundException;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+class PadLegacyMigrationServiceTest extends TestCase {
+	public function testCrossOriginShortcutRoutesThroughExternalSeed(): void {
+		$file = $this->createMock(File::class);
+		$file->method('getId')->willReturn(101);
+
+		$padCreation = $this->createMock(PadCreationService::class);
+		$padCreation->expects($this->once())
+			->method('seedExternalIntoFile')
+			->with($file, 101, 'https://legacy.example.test/p/team-meeting')
+			->willReturn([
+				'file_id' => 101,
+				'pad_id' => 'ext.team-meeting',
+				'access_mode' => BindingService::ACCESS_PUBLIC,
+				'pad_url' => 'https://legacy.example.test/p/team-meeting',
+			]);
+
+		$etherpadClient = $this->createMock(EtherpadClient::class);
+		$etherpadClient->method('getConfiguredOrigin')->willReturn('https://pad.our-server.test');
+		$etherpadClient->method('normalizeOrigin')
+			->with('https://legacy.example.test/p/team-meeting')
+			->willReturn('https://legacy.example.test');
+
+		$binding = $this->createMock(BindingService::class);
+		$binding->expects($this->never())->method('findByPadId');
+		$binding->expects($this->never())->method('createBinding');
+
+		$this->buildService(
+			binding: $binding,
+			etherpadClient: $etherpadClient,
+			padCreation: $padCreation,
+		)->migrate('alice', $file, [
+			'url' => 'https://legacy.example.test/p/team-meeting',
+			'pad_id' => 'team-meeting',
+		]);
+	}
+
+	public function testSameOriginPublicNoCollisionRebinds(): void {
+		$file = $this->createMock(File::class);
+		$file->method('getId')->willReturn(202);
+		$file->expects($this->once())->method('putContent')->with('written-frontmatter');
+
+		$padFileService = $this->createMock(PadFileService::class);
+		$padFileService->method('inferAccessModeFromPadId')
+			->with('team-pad')
+			->willReturn(BindingService::ACCESS_PUBLIC);
+		$padFileService->expects($this->once())
+			->method('buildInitialDocument')
+			->with(202, 'team-pad', BindingService::ACCESS_PUBLIC, '', 'https://pad.our-server.test/p/team-pad')
+			->willReturn('written-frontmatter');
+
+		$etherpadClient = $this->createMock(EtherpadClient::class);
+		$etherpadClient->method('getConfiguredOrigin')->willReturn('https://pad.our-server.test');
+		$etherpadClient->method('normalizeOrigin')->willReturn('https://pad.our-server.test');
+		$etherpadClient->method('buildPadUrl')->with('team-pad')->willReturn('https://pad.our-server.test/p/team-pad');
+
+		$binding = $this->createMock(BindingService::class);
+		$binding->expects($this->once())
+			->method('findByPadId')
+			->with('team-pad', BindingService::STATE_ACTIVE)
+			->willReturn(null);
+		$binding->expects($this->once())
+			->method('createBinding')
+			->with(202, 'team-pad', BindingService::ACCESS_PUBLIC);
+
+		$this->buildService(
+			binding: $binding,
+			padFileService: $padFileService,
+			etherpadClient: $etherpadClient,
+		)->migrate('alice', $file, [
+			'url' => 'https://pad.our-server.test/p/team-pad',
+			'pad_id' => 'team-pad',
+		]);
+	}
+
+	public function testSameOriginProtectedNoCollisionRebindsAsProtected(): void {
+		$file = $this->createMock(File::class);
+		$file->method('getId')->willReturn(303);
+		$file->expects($this->once())->method('putContent');
+
+		$padFileService = $this->createMock(PadFileService::class);
+		$padFileService->method('inferAccessModeFromPadId')
+			->with('g.abc$team-meeting')
+			->willReturn(BindingService::ACCESS_PROTECTED);
+		$padFileService->method('buildInitialDocument')->willReturn('frontmatter');
+
+		$etherpadClient = $this->createMock(EtherpadClient::class);
+		$etherpadClient->method('getConfiguredOrigin')->willReturn('https://pad.our-server.test');
+		$etherpadClient->method('normalizeOrigin')->willReturn('https://pad.our-server.test');
+		$etherpadClient->method('buildPadUrl')->willReturn('https://pad.our-server.test/p/g.abc$team-meeting');
+
+		$binding = $this->createMock(BindingService::class);
+		$binding->method('findByPadId')->willReturn(null);
+		$binding->expects($this->once())
+			->method('createBinding')
+			->with(303, 'g.abc$team-meeting', BindingService::ACCESS_PROTECTED);
+
+		$this->buildService(
+			binding: $binding,
+			padFileService: $padFileService,
+			etherpadClient: $etherpadClient,
+		)->migrate('alice', $file, [
+			'url' => 'https://pad.our-server.test/p/g.abc$team-meeting',
+			'pad_id' => 'g.abc$team-meeting',
+		]);
+	}
+
+	public function testSameOriginCollisionWithAccessWritesFrontmatterOnly(): void {
+		// Pad-id already bound to file 999 owned by a user with whom alice
+		// shares read access. Migrate the file's content into our format but
+		// do NOT create a second binding row — the file becomes a copy.
+		$file = $this->createMock(File::class);
+		$file->method('getId')->willReturn(404);
+		$file->expects($this->once())->method('putContent');
+
+		$padFileService = $this->createMock(PadFileService::class);
+		$padFileService->method('inferAccessModeFromPadId')->willReturn(BindingService::ACCESS_PROTECTED);
+		$padFileService->method('buildInitialDocument')->willReturn('frontmatter');
+
+		$etherpadClient = $this->createMock(EtherpadClient::class);
+		$etherpadClient->method('getConfiguredOrigin')->willReturn('https://pad.our-server.test');
+		$etherpadClient->method('normalizeOrigin')->willReturn('https://pad.our-server.test');
+		$etherpadClient->method('buildPadUrl')->willReturn('https://pad.our-server.test/p/g.abc$x');
+
+		$binding = $this->createMock(BindingService::class);
+		$binding->method('findByPadId')->willReturn([
+			'file_id' => 999,
+			'pad_id' => 'g.abc$x',
+			'access_mode' => 'protected',
+		]);
+		$binding->expects($this->never())->method('createBinding');
+
+		$resolver = $this->createMock(UserNodeResolver::class);
+		$resolver->expects($this->once())
+			->method('resolveUserFileNodeById')
+			->with('alice', 999)
+			->willReturn($this->createMock(File::class));
+
+		$this->buildService(
+			binding: $binding,
+			padFileService: $padFileService,
+			etherpadClient: $etherpadClient,
+			resolver: $resolver,
+		)->migrate('alice', $file, [
+			'url' => 'https://pad.our-server.test/p/g.abc$x',
+			'pad_id' => 'g.abc$x',
+		]);
+	}
+
+	public function testSameOriginCollisionWithoutAccessRefuses(): void {
+		// The pad is bound to someone else's file alice cannot read.
+		// Migration is refused, the .pad file stays untouched, an exception
+		// surfaces to the controller layer.
+		$file = $this->createMock(File::class);
+		$file->method('getId')->willReturn(505);
+		$file->expects($this->never())->method('putContent');
+
+		$padFileService = $this->createMock(PadFileService::class);
+		$padFileService->method('inferAccessModeFromPadId')->willReturn(BindingService::ACCESS_PROTECTED);
+
+		$etherpadClient = $this->createMock(EtherpadClient::class);
+		$etherpadClient->method('getConfiguredOrigin')->willReturn('https://pad.our-server.test');
+		$etherpadClient->method('normalizeOrigin')->willReturn('https://pad.our-server.test');
+
+		$binding = $this->createMock(BindingService::class);
+		$binding->method('findByPadId')->willReturn([
+			'file_id' => 888,
+			'pad_id' => 'g.abc$x',
+			'access_mode' => 'protected',
+		]);
+		$binding->expects($this->never())->method('createBinding');
+
+		$resolver = $this->createMock(UserNodeResolver::class);
+		$resolver->method('resolveUserFileNodeById')
+			->willThrowException(new NotFoundException('no access'));
+
+		$this->expectException(LegacyPadCollisionException::class);
+		$this->expectExceptionMessage('This pad is already linked to another file you do not have access to.');
+
+		$this->buildService(
+			binding: $binding,
+			padFileService: $padFileService,
+			etherpadClient: $etherpadClient,
+			resolver: $resolver,
+		)->migrate('alice', $file, [
+			'url' => 'https://pad.our-server.test/p/g.abc$x',
+			'pad_id' => 'g.abc$x',
+		]);
+	}
+
+	private function buildService(
+		?BindingService $binding = null,
+		?PadFileService $padFileService = null,
+		?EtherpadClient $etherpadClient = null,
+		?PadCreationService $padCreation = null,
+		?UserNodeResolver $resolver = null,
+	): PadLegacyMigrationService {
+		return new PadLegacyMigrationService(
+			$binding ?? $this->createMock(BindingService::class),
+			$padFileService ?? $this->createMock(PadFileService::class),
+			$etherpadClient ?? $this->createMock(EtherpadClient::class),
+			$padCreation ?? $this->createMock(PadCreationService::class),
+			$resolver ?? $this->createMock(UserNodeResolver::class),
+			$this->createMock(LoggerInterface::class),
+		);
+	}
+}


### PR DESCRIPTION
Closes #25.

When a `.pad` file with no YAML frontmatter and a legacy Ownpad `[InternetShortcut]` block is opened, the plugin now silently converts it to the current binding-and-`.pad` model on first open. No modal, no admin coordination, no bulk-migration command — each file migrates exactly when its owner first opens it.

## Three branches, derived not chosen

Access mode is derived from the source URL's origin and the embedded pad-id format. The user is never asked.

1. **Cross-origin source URL** (points at a different Etherpad server than `etherpad_host`). The file is converted to an `ext.*` public pad via the same shape as `POST /api/v1/pads/from-url`. No binding row.
2. **Same-origin, pad-id with no existing binding**. The file is re-bound under our schema with the access mode derived from the pad-id (`g.X$Y` → protected, anything else → public). Pure local re-bind: no remote pad is created, the existing Etherpad pad keeps running.
3. **Same-origin, pad-id already bound to another file**. Claim-collision rule:
   - Requesting user has read access to the file that owns the existing binding → write managed frontmatter only (no second binding row). The file becomes a copy-of-a-pad and the existing copy-handling flow takes over.
   - Requesting user has no access → refuse with `LegacyPadCollisionException` → HTTP 409 + `code: legacy_collision_no_access`. The `.pad` is left untouched, the migration offer stays pending on subsequent opens.

## What ships

### New
- `PadLegacyMigrationService` — owns the three-branch logic with full audit logging
- `LegacyPadCollisionException` + mapper to HTTP 409
- `EtherpadClient::getConfiguredOrigin()` + `normalizeOrigin()` for the origin compare
- `STATUS_MIGRATED_FROM_LEGACY` returned from `/api/v1/pads/initialize*` so the frontend can detect first-time migration
- `docs/legacy-ownpad-migration.md` with the audit log field reference

### Refactored
- `PadCreationService::seedExternalIntoFile()` extracted from `createFromUrl` so the cross-origin migration path can write `ext.*` frontmatter into an existing file (createFromUrl now composes on top of it)
- `PadBootstrapService::initializeMissingFrontmatter()` signature gains `string $uid` and returns `bool` indicating whether the legacy migration ran. The fatal-throw on legacy detection is replaced with delegation to `PadLegacyMigrationService`.

### Frontend
- Initialize-error path attaches `error.code` from the JSON response so callers can branch on `legacy_collision_no_access` without parsing the message string
- `migrated_from_legacy` status is mirrored to the browser console as a single `console.info` line. A user-visible toast is **not** added in this PR because the codebase has no notification framework wired yet — that would be a separate PR introducing `@nextcloud/dialogs` consistently.

## Tests

- PHP 388 → 389 (+1 listener test for the migrated status; the bulk of new coverage is 5 PadLegacyMigrationService tests covering the cross-origin, same-origin public, same-origin protected, collision-with-access, and collision-no-access branches; plus EtherpadClient + PadCreationService + PadControllerErrorMapper additions).
- JS 98 unchanged (no test files needed changes; the existing tests cover the surrounding open / initialize flows).

## Commit log

1. Extract `seedExternalIntoFile` from `createFromUrl`
2. Add `getConfiguredOrigin` + `LegacyPadCollisionException` + mapper entry
3. Add `PadLegacyMigrationService` + 5 branch tests
4. Wire the migration into `PadBootstrapService` + `STATUS_MIGRATED_FROM_LEGACY`
5. Frontend: forward error codes, log migration status
6. Docs + changelog

## Manual verification

1. Place a `.pad` file containing only `[InternetShortcut]` + `URL=https://<your-etherpad>/p/some-pad` in NC. Don't open it yet.
2. Open it via the Files app. Expect: the pad opens normally; the file's content now has YAML frontmatter; a new binding row exists pointing at `some-pad`.
3. Cross-origin variant: same as above with a URL pointing at an external Etherpad server. Expect: `ext.<remote-id>` frontmatter, no binding row, snapshot embedded.
4. Collision variant: have user A open a `.pad` pointing at `team-pad`, then user B drops a hand-crafted `[InternetShortcut]` pointing at the same `team-pad`. If B has no access to A's file → 409 with `legacy_collision_no_access`. If B has access (e.g. A shared the file) → B's file opens as a copy-of-a-pad.