### PR TITLE
Consolidate pad-meta read into single readPad helper (closes #61)

### DIFF
--- a/lib/Service/LifecycleService.php
+++ b/lib/Service/LifecycleService.php
@@ -340,15 +340,13 @@ class LifecycleService {
 				throw new LockedException('Injected test fault: restore_read_lock');
 			}
 			$currentContent = (string)$file->getContent();
-			$parsed = $this->padFileService->parsePadFile($currentContent);
-			$frontmatter = $parsed['frontmatter'];
-			$meta = $this->padFileService->extractPadMetadata($frontmatter);
-			$oldPadId = $meta['pad_id'];
-			$accessMode = $meta['access_mode'];
-			if (str_starts_with($oldPadId, 'ext.') || $this->padFileService->isExternalFrontmatter($frontmatter, $oldPadId)) {
+			$pad = $this->padFileService->readPad($currentContent);
+			$oldPadId = $pad->padId;
+			$accessMode = $pad->accessMode;
+			if (str_starts_with($oldPadId, 'ext.') || $pad->isExternal) {
 				return $this->buildSkippedResult('external_pad', $fileId, $oldPadId);
 			}
-			$snapshotParts = $this->padFileService->getSnapshotPartsFromBody((string)$parsed['body']);
+			$snapshotParts = $this->padFileService->getSnapshotPartsFromBody($pad->body);
 			$snapshot = $snapshotParts['text'];
 			$htmlSnapshot = $snapshotParts['html'];
 			$newPadId = $this->provisionRestorePadId($accessMode, $oldPadId);
@@ -447,11 +445,8 @@ class LifecycleService {
 			if ($content === null) {
 				$content = (string)$file->getContent();
 			}
-			$parsed = $this->padFileService->parsePadFile($content);
-			$frontmatter = $parsed['frontmatter'];
-			$meta = $this->padFileService->extractPadMetadata($frontmatter);
-			return str_starts_with($meta['pad_id'], 'ext.')
-				|| $this->padFileService->isExternalFrontmatter($frontmatter, $meta['pad_id']);
+			$pad = $this->padFileService->readPad($content);
+			return str_starts_with($pad->padId, 'ext.') || $pad->isExternal;
 		} catch (\Throwable) {
 			return false;
 		}

--- a/lib/Service/PadCreationService.php
+++ b/lib/Service/PadCreationService.php
@@ -324,24 +324,20 @@ class PadCreationService {
 			throw new \InvalidArgumentException('Template is empty.');
 		}
 
-		$parsed = $this->padFileService->parsePadFile($templateContent);
-		$frontmatter = $parsed['frontmatter'];
-		$meta = $this->padFileService->extractPadMetadata($frontmatter);
-		$sourcePadId = (string)($meta['pad_id'] ?? '');
-		if ($sourcePadId === '') {
+		$pad = $this->padFileService->readPad($templateContent);
+		if ($pad->padId === '') {
 			throw new \InvalidArgumentException('Template has no usable pad_id in its frontmatter.');
 		}
-		if (str_starts_with($sourcePadId, 'ext.')
-			|| $this->padFileService->isExternalFrontmatter($frontmatter, $sourcePadId)) {
+		if (str_starts_with($pad->padId, 'ext.') || $pad->isExternal) {
 			throw new \InvalidArgumentException('External pads cannot be used as a template.');
 		}
 
-		$accessMode = (string)($meta['access_mode'] ?? BindingService::ACCESS_PROTECTED);
+		$accessMode = $pad->accessMode !== '' ? $pad->accessMode : BindingService::ACCESS_PROTECTED;
 		if ($accessMode !== BindingService::ACCESS_PUBLIC && $accessMode !== BindingService::ACCESS_PROTECTED) {
 			$accessMode = BindingService::ACCESS_PROTECTED;
 		}
 
-		$snapshot = $this->padFileService->getSnapshotPartsFromBody((string)$parsed['body']);
+		$snapshot = $this->padFileService->getSnapshotPartsFromBody($pad->body);
 		$resolvedText = $this->placeholderResolver->applyForContent($snapshot['text'], $user);
 		$resolvedHtml = $this->placeholderResolver->applyForContent($snapshot['html'], $user);
 

--- a/lib/Service/PadFileService.php
+++ b/lib/Service/PadFileService.php
@@ -137,6 +137,30 @@ class PadFileService {
 	}
 
 	/**
+	 * One-shot read of the pad-file frontmatter into a typed value object.
+	 * Composes `parsePadFile`, `extractPadMetadata`, and
+	 * `isExternalFrontmatter` so callers don't open-code the same 4-line
+	 * sequence at every site that opens a `.pad`.
+	 *
+	 * @throws \OCA\EtherpadNextcloud\Exception\MissingFrontmatterException
+	 * @throws \OCA\EtherpadNextcloud\Exception\PadFileFormatException
+	 */
+	public function readPad(string $content): ParsedPadFile {
+		$parsed = $this->parsePadFile($content);
+		$frontmatter = $parsed['frontmatter'];
+		$meta = $this->extractPadMetadata($frontmatter);
+		$padId = $meta['pad_id'];
+		return new ParsedPadFile(
+			frontmatter: $frontmatter,
+			body: (string)($parsed['body'] ?? ''),
+			padId: $padId,
+			accessMode: $meta['access_mode'],
+			padUrl: $meta['pad_url'],
+			isExternal: $this->isExternalFrontmatter($frontmatter, $padId),
+		);
+	}
+
+	/**
 	 * @param array<string,mixed> $frontmatter
 	 * @return array{pad_id:string,access_mode:string,pad_url:string}
 	 */

--- a/lib/Service/PadInitializationService.php
+++ b/lib/Service/PadInitializationService.php
@@ -61,14 +61,13 @@ class PadInitializationService {
 		$fileId = (int)$file->getId();
 		$path = $this->userNodeResolver->toUserAbsolutePath($uid, $file);
 		try {
-			$parsed = $this->padFileService->parsePadFile($content);
-			$meta = $parsed['frontmatter'];
+			$pad = $this->padFileService->readPad($content);
 			return new PadInitializationResult(
 				status: self::STATUS_ALREADY_INITIALIZED,
 				file: $path,
 				fileId: $fileId,
-				padId: (string)$meta['pad_id'],
-				accessMode: (string)$meta['access_mode'],
+				padId: $pad->padId,
+				accessMode: $pad->accessMode,
 			);
 		} catch (MissingFrontmatterException) {
 			// Explicitly continue with bootstrap flow for legacy or empty .pad files.
@@ -77,16 +76,14 @@ class PadInitializationService {
 		}
 
 		$wasLegacyMigration = $this->padBootstrapService->initializeMissingFrontmatter($uid, $file, $content);
-		$updatedContent = (string)$file->getContent();
-		$parsed = $this->padFileService->parsePadFile((string)$updatedContent);
-		$meta = $parsed['frontmatter'];
+		$pad = $this->padFileService->readPad((string)$file->getContent());
 
 		return new PadInitializationResult(
 			status: $wasLegacyMigration ? self::STATUS_MIGRATED_FROM_LEGACY : self::STATUS_INITIALIZED,
 			file: $path,
 			fileId: $fileId,
-			padId: (string)$meta['pad_id'],
-			accessMode: (string)$meta['access_mode'],
+			padId: $pad->padId,
+			accessMode: $pad->accessMode,
 		);
 	}
 }

--- a/lib/Service/PadMetadataService.php
+++ b/lib/Service/PadMetadataService.php
@@ -51,10 +51,7 @@ class PadMetadataService {
 
 		$padId = '';
 		try {
-			$content = (string)$node->getContent();
-			$parsed = $this->padFileService->parsePadFile($content);
-			$meta = $this->padFileService->extractPadMetadata($parsed['frontmatter']);
-			$padId = (string)($meta['pad_id'] ?? '');
+			$padId = $this->padFileService->readPad((string)$node->getContent())->padId;
 		} catch (\Throwable) {
 			return new PadOriginalLookup(found: false);
 		}
@@ -190,13 +187,11 @@ class PadMetadataService {
 			$content = $retryLockedRead
 				? $this->lockRetryService->readContentWithOpenLockRetry($node)
 				: (string)$node->getContent();
-			$parsed = $this->padFileService->parsePadFile((string)$content);
-			$frontmatter = $parsed['frontmatter'];
-			$meta = $this->padFileService->extractPadMetadata($frontmatter);
-			$padId = $meta['pad_id'];
-			$accessMode = $meta['access_mode'];
-			$padUrl = $meta['pad_url'];
-			$isExternal = $this->padFileService->isExternalFrontmatter($frontmatter, $padId);
+			$pad = $this->padFileService->readPad((string)$content);
+			$padId = $pad->padId;
+			$accessMode = $pad->accessMode;
+			$padUrl = $pad->padUrl;
+			$isExternal = $pad->isExternal;
 
 			if ($accessMode === BindingService::ACCESS_PUBLIC) {
 				$publicOpenUrl = $this->resolvePublicOpenUrl($padId, $padUrl, $isExternal);

--- a/lib/Service/PadOpenService.php
+++ b/lib/Service/PadOpenService.php
@@ -67,13 +67,11 @@ class PadOpenService {
 				throw new \RuntimeException('Could not resolve file ID.');
 			}
 
-			$parsed = $this->padFileService->parsePadFile((string)$content);
-			$frontmatter = $parsed['frontmatter'];
-			$meta = $this->padFileService->extractPadMetadata($frontmatter);
-			$padId = $meta['pad_id'];
-			$accessMode = $meta['access_mode'];
-			$padUrl = $meta['pad_url'];
-			$isExternal = $this->padFileService->isExternalFrontmatter($frontmatter, $padId);
+			$pad = $this->padFileService->readPad((string)$content);
+			$padId = $pad->padId;
+			$accessMode = $pad->accessMode;
+			$padUrl = $pad->padUrl;
+			$isExternal = $pad->isExternal;
 			$snapshot = $isExternal
 				? $this->snapshotExtractor->extract((string)$content)
 				: new SnapshotPayload('', '');

--- a/lib/Service/PadSyncService.php
+++ b/lib/Service/PadSyncService.php
@@ -53,13 +53,11 @@ class PadSyncService {
 
 		try {
 			$currentContent = (string)$node->getContent();
-			$parsed = $this->padFileService->parsePadFile((string)$currentContent);
-			$frontmatter = $parsed['frontmatter'];
-			$meta = $this->padFileService->extractPadMetadata($frontmatter);
-			$padId = $meta['pad_id'];
-			$accessMode = $meta['access_mode'];
-			$padUrl = $meta['pad_url'];
-			$isExternal = $this->padFileService->isExternalFrontmatter($frontmatter, $padId);
+			$pad = $this->padFileService->readPad((string)$currentContent);
+			$padId = $pad->padId;
+			$accessMode = $pad->accessMode;
+			$padUrl = $pad->padUrl;
+			$isExternal = $pad->isExternal;
 			if (!$isExternal) {
 				$this->bindingService->assertConsistentMapping($fileId, $padId, $accessMode);
 			}
@@ -96,12 +94,10 @@ class PadSyncService {
 
 		try {
 			$content = (string)$node->getContent();
-			$parsed = $this->padFileService->parsePadFile((string)$content);
-			$frontmatter = $parsed['frontmatter'];
-			$meta = $this->padFileService->extractPadMetadata($frontmatter);
-			$padId = $meta['pad_id'];
-			$accessMode = $meta['access_mode'];
-			$isExternal = $this->padFileService->isExternalFrontmatter($frontmatter, $padId);
+			$pad = $this->padFileService->readPad((string)$content);
+			$padId = $pad->padId;
+			$accessMode = $pad->accessMode;
+			$isExternal = $pad->isExternal;
 			if (!$isExternal) {
 				$this->bindingService->assertConsistentMapping($fileId, $padId, $accessMode);
 			}

--- a/lib/Service/ParsedPadFile.php
+++ b/lib/Service/ParsedPadFile.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * Copyright (c) 2026 Jacob Bühler
+ */
+
+namespace OCA\EtherpadNextcloud\Service;
+
+/**
+ * Result of `PadFileService::readPad()`. Wraps the 3-step
+ * `parsePadFile + extractPadMetadata + isExternalFrontmatter` read that
+ * used to be open-coded at every caller. Most call sites only need the
+ * derived flat fields (`padId`, `accessMode`, `padUrl`, `isExternal`);
+ * `$frontmatter` + `$body` are exposed for the few sites that touch other
+ * frontmatter keys or need to inspect the body block.
+ */
+class ParsedPadFile {
+	public function __construct(
+		/** @var array<string,mixed> */
+		public readonly array $frontmatter,
+		public readonly string $body,
+		public readonly string $padId,
+		public readonly string $accessMode,
+		public readonly string $padUrl,
+		public readonly bool $isExternal,
+	) {
+	}
+}

--- a/lib/Service/PublicPadContextService.php
+++ b/lib/Service/PublicPadContextService.php
@@ -34,13 +34,11 @@ class PublicPadContextService {
 		$content = (string)$node->getContent();
 		$fileId = (int)$node->getId();
 
-		$parsed = $this->padFileService->parsePadFile($content);
-		$frontmatter = $parsed['frontmatter'];
-		$meta = $this->padFileService->extractPadMetadata($frontmatter);
-		$padId = $meta['pad_id'];
-		$accessMode = $meta['access_mode'];
-		$padUrl = $meta['pad_url'];
-		$isExternal = $this->padFileService->isExternalFrontmatter($frontmatter, $padId);
+		$pad = $this->padFileService->readPad($content);
+		$padId = $pad->padId;
+		$accessMode = $pad->accessMode;
+		$padUrl = $pad->padUrl;
+		$isExternal = $pad->isExternal;
 
 		if (!$isExternal) {
 			$this->bindingService->assertConsistentMapping($fileId, $padId, $accessMode);

--- a/tests/phpunit/unit/LifecycleServiceTest.php
+++ b/tests/phpunit/unit/LifecycleServiceTest.php
@@ -13,6 +13,7 @@ use OCA\EtherpadNextcloud\Service\BindingService;
 use OCA\EtherpadNextcloud\Service\EtherpadClient;
 use OCA\EtherpadNextcloud\Service\LifecycleService;
 use OCA\EtherpadNextcloud\Service\PadFileService;
+use OCA\EtherpadNextcloud\Service\ParsedPadFile;
 use OCP\Files\File;
 use OCP\IConfig;
 use OCP\Security\ISecureRandom;
@@ -262,20 +263,18 @@ class LifecycleServiceTest extends TestCase {
 			->with($fileId, $newPadId, BindingService::ACCESS_PUBLIC);
 
 		$padFileService = $this->createMock(PadFileService::class);
-		$padFileService->method('parsePadFile')->with('doc-before')->willReturn([
-			'frontmatter' => [
+		$padFileService->method('readPad')->with('doc-before')->willReturn(new ParsedPadFile(
+			frontmatter: [
 				'pad_id' => $oldPadId,
 				'access_mode' => BindingService::ACCESS_PUBLIC,
 				'state' => 'trashed',
 			],
-			'body' => '',
-		]);
-		$padFileService->method('extractPadMetadata')->willReturn([
-			'pad_id' => $oldPadId,
-			'access_mode' => BindingService::ACCESS_PUBLIC,
-			'pad_url' => 'https://pad.example.test/p/' . rawurlencode($oldPadId),
-		]);
-		$padFileService->method('isExternalFrontmatter')->willReturn(false);
+			body: '',
+			padId: $oldPadId,
+			accessMode: BindingService::ACCESS_PUBLIC,
+			padUrl: 'https://pad.example.test/p/' . rawurlencode($oldPadId),
+			isExternal: false,
+		));
 		$padFileService->method('getSnapshotPartsFromBody')->willReturn([
 			'text' => 'plain text',
 			'html' => '',
@@ -337,16 +336,14 @@ class LifecycleServiceTest extends TestCase {
 			'remote_pad_id' => $remotePadId,
 		];
 		$padFileService = $this->createMock(PadFileService::class);
-		$padFileService->method('parsePadFile')->with('doc-before')->willReturn([
-			'frontmatter' => $frontmatter,
-			'body' => '',
-		]);
-		$padFileService->method('extractPadMetadata')->willReturn([
-			'pad_id' => $oldPadId,
-			'access_mode' => BindingService::ACCESS_PUBLIC,
-			'pad_url' => $padUrl,
-		]);
-		$padFileService->method('isExternalFrontmatter')->with($frontmatter, $oldPadId)->willReturn(true);
+		$padFileService->method('readPad')->with('doc-before')->willReturn(new ParsedPadFile(
+			frontmatter: $frontmatter,
+			body: '',
+			padId: $oldPadId,
+			accessMode: BindingService::ACCESS_PUBLIC,
+			padUrl: $padUrl,
+			isExternal: true,
+		));
 		$padFileService->expects($this->never())->method('getSnapshotPartsFromBody');
 		$padFileService->expects($this->never())->method('withStateAndSnapshot');
 
@@ -393,16 +390,14 @@ class LifecycleServiceTest extends TestCase {
 			'pad_url' => '',
 		];
 		$padFileService = $this->createMock(PadFileService::class);
-		$padFileService->method('parsePadFile')->with('doc-before')->willReturn([
-			'frontmatter' => $frontmatter,
-			'body' => '',
-		]);
-		$padFileService->method('extractPadMetadata')->willReturn([
-			'pad_id' => $oldPadId,
-			'access_mode' => BindingService::ACCESS_PUBLIC,
-			'pad_url' => '',
-		]);
-		$padFileService->method('isExternalFrontmatter')->with($frontmatter, $oldPadId)->willReturn(false);
+		$padFileService->method('readPad')->with('doc-before')->willReturn(new ParsedPadFile(
+			frontmatter: $frontmatter,
+			body: '',
+			padId: $oldPadId,
+			accessMode: BindingService::ACCESS_PUBLIC,
+			padUrl: '',
+			isExternal: false,
+		));
 		$padFileService->method('getSnapshotPartsFromBody')->willReturn([
 			'text' => 'external snapshot',
 			'html' => '',
@@ -457,16 +452,14 @@ class LifecycleServiceTest extends TestCase {
 			'remote_pad_id' => $remotePadId,
 		];
 		$padFileService = $this->createMock(PadFileService::class);
-		$padFileService->method('parsePadFile')->with('doc-before')->willReturn([
-			'frontmatter' => $frontmatter,
-			'body' => '',
-		]);
-		$padFileService->method('extractPadMetadata')->willReturn([
-			'pad_id' => $oldPadId,
-			'access_mode' => BindingService::ACCESS_PUBLIC,
-			'pad_url' => $padUrl,
-		]);
-		$padFileService->method('isExternalFrontmatter')->with($frontmatter, $oldPadId)->willReturn(true);
+		$padFileService->method('readPad')->with('doc-before')->willReturn(new ParsedPadFile(
+			frontmatter: $frontmatter,
+			body: '',
+			padId: $oldPadId,
+			accessMode: BindingService::ACCESS_PUBLIC,
+			padUrl: $padUrl,
+			isExternal: true,
+		));
 		$padFileService->method('getSnapshotPartsFromBody')->willReturn([
 			'text' => 'external snapshot',
 			'html' => '',
@@ -517,19 +510,17 @@ class LifecycleServiceTest extends TestCase {
 			->with($fileId, $newPadId, BindingService::ACCESS_PUBLIC);
 
 		$padFileService = $this->createMock(PadFileService::class);
-		$padFileService->method('parsePadFile')->willReturn([
-			'frontmatter' => [
+		$padFileService->method('readPad')->willReturn(new ParsedPadFile(
+			frontmatter: [
 				'pad_id' => $oldPadId,
 				'access_mode' => BindingService::ACCESS_PUBLIC,
 			],
-			'body' => '',
-		]);
-		$padFileService->method('extractPadMetadata')->willReturn([
-			'pad_id' => $oldPadId,
-			'access_mode' => BindingService::ACCESS_PUBLIC,
-			'pad_url' => 'https://pad.example.test/p/' . rawurlencode($oldPadId),
-		]);
-		$padFileService->method('isExternalFrontmatter')->willReturn(false);
+			body: '',
+			padId: $oldPadId,
+			accessMode: BindingService::ACCESS_PUBLIC,
+			padUrl: 'https://pad.example.test/p/' . rawurlencode($oldPadId),
+			isExternal: false,
+		));
 		$padFileService->method('getSnapshotPartsFromBody')->willReturn([
 			'text' => 'recovered content',
 			'html' => '',
@@ -585,16 +576,14 @@ class LifecycleServiceTest extends TestCase {
 		$bindingService->expects($this->never())->method('deleteByFileId');
 
 		$padFileService = $this->createMock(PadFileService::class);
-		$padFileService->method('parsePadFile')->willReturn([
-			'frontmatter' => ['pad_id' => $oldPadId, 'access_mode' => BindingService::ACCESS_PUBLIC],
-			'body' => '',
-		]);
-		$padFileService->method('extractPadMetadata')->willReturn([
-			'pad_id' => $oldPadId,
-			'access_mode' => BindingService::ACCESS_PUBLIC,
-			'pad_url' => '',
-		]);
-		$padFileService->method('isExternalFrontmatter')->willReturn(false);
+		$padFileService->method('readPad')->willReturn(new ParsedPadFile(
+			frontmatter: ['pad_id' => $oldPadId, 'access_mode' => BindingService::ACCESS_PUBLIC],
+			body: '',
+			padId: $oldPadId,
+			accessMode: BindingService::ACCESS_PUBLIC,
+			padUrl: '',
+			isExternal: false,
+		));
 		$padFileService->method('getSnapshotPartsFromBody')->willReturn(['text' => 'content', 'html' => '']);
 		$padFileService->method('withStateAndSnapshot')->willReturn('doc-after');
 

--- a/tests/phpunit/unit/PadControllerTest.php
+++ b/tests/phpunit/unit/PadControllerTest.php
@@ -22,6 +22,7 @@ use OCA\EtherpadNextcloud\Service\PadPathService;
 use OCA\EtherpadNextcloud\Service\PadResponseService;
 use OCA\EtherpadNextcloud\Service\PadSessionService;
 use OCA\EtherpadNextcloud\Service\PadSyncService;
+use OCA\EtherpadNextcloud\Service\ParsedPadFile;
 use OCA\EtherpadNextcloud\Service\SnapshotExtractor;
 use OCA\EtherpadNextcloud\Service\SnapshotHtmlSanitizer;
 use OCA\EtherpadNextcloud\Service\UserNodeResolver;
@@ -119,20 +120,19 @@ class PadControllerTest extends TestCase {
 
 		$padFileService = $this->createMock(PadFileService::class);
 		$padFileService->expects($this->once())
-			->method('parsePadFile')
+			->method('readPad')
 			->with('frontmatter')
-			->willReturn([
-				'frontmatter' => [
+			->willReturn(new ParsedPadFile(
+				frontmatter: [
 					'pad_id' => 'g.ABCDEFGHIJKLMNOP$pad-1',
 					'access_mode' => BindingService::ACCESS_PUBLIC,
 				],
-			]);
-		$padFileService->method('extractPadMetadata')->willReturn([
-			'pad_id' => 'g.ABCDEFGHIJKLMNOP$pad-1',
-			'access_mode' => BindingService::ACCESS_PUBLIC,
-			'pad_url' => '',
-		]);
-		$padFileService->method('isExternalFrontmatter')->willReturn(false);
+				body: '',
+				padId: 'g.ABCDEFGHIJKLMNOP$pad-1',
+				accessMode: BindingService::ACCESS_PUBLIC,
+				padUrl: '',
+				isExternal: false,
+			));
 
 		$bindingService = $this->createMock(BindingService::class);
 		$bindingService->expects($this->once())
@@ -244,21 +244,16 @@ class PadControllerTest extends TestCase {
 
 		$padFileService = $this->createMock(PadFileService::class);
 		$padFileService->expects($this->once())
-			->method('parsePadFile')
+			->method('readPad')
 			->with('frontmatter')
-			->willReturn(['frontmatter' => $frontmatter]);
-		$padFileService->expects($this->once())
-			->method('extractPadMetadata')
-			->with($frontmatter)
-			->willReturn([
-				'pad_id' => 'ext.abc123',
-				'access_mode' => BindingService::ACCESS_PUBLIC,
-				'pad_url' => 'https://pad.portal.fzs.de/p/Test',
-			]);
-		$padFileService->expects($this->once())
-			->method('isExternalFrontmatter')
-			->with($frontmatter, 'ext.abc123')
-			->willReturn(true);
+			->willReturn(new ParsedPadFile(
+				frontmatter: $frontmatter,
+				body: '',
+				padId: 'ext.abc123',
+				accessMode: BindingService::ACCESS_PUBLIC,
+				padUrl: 'https://pad.portal.fzs.de/p/Test',
+				isExternal: true,
+			));
 		$padFileService->expects($this->once())
 			->method('getTextSnapshotForRestore')
 			->with('frontmatter')
@@ -419,18 +414,17 @@ class PadControllerTest extends TestCase {
 		$rootFolder->method('getById')->with(138)->willReturn([$file]);
 
 		$padFileService = $this->createMock(PadFileService::class);
-		$padFileService->method('parsePadFile')->willReturn([
-			'frontmatter' => [
+		$padFileService->method('readPad')->willReturn(new ParsedPadFile(
+			frontmatter: [
 				'pad_id' => 'g.ABCDEFGHIJKLMNOP$pad-1',
 				'access_mode' => BindingService::ACCESS_PROTECTED,
 			],
-		]);
-		$padFileService->method('extractPadMetadata')->willReturn([
-			'pad_id' => 'g.ABCDEFGHIJKLMNOP$pad-1',
-			'access_mode' => BindingService::ACCESS_PROTECTED,
-			'pad_url' => '',
-		]);
-		$padFileService->method('isExternalFrontmatter')->willReturn(false);
+			body: '',
+			padId: 'g.ABCDEFGHIJKLMNOP$pad-1',
+			accessMode: BindingService::ACCESS_PROTECTED,
+			padUrl: '',
+			isExternal: false,
+		));
 		$padFileService->method('getSnapshotRevision')->willReturn(4);
 		$padFileService->method('withExportSnapshot')->with("frontmatter", 'hello', '<p>hello</p>', 5)->willReturn('updated-content');
 
@@ -474,18 +468,17 @@ class PadControllerTest extends TestCase {
 		$rootFolder->method('getById')->with(138)->willReturn([$file]);
 
 		$padFileService = $this->createMock(PadFileService::class);
-		$padFileService->method('parsePadFile')->willReturn([
-			'frontmatter' => [
+		$padFileService->method('readPad')->willReturn(new ParsedPadFile(
+			frontmatter: [
 				'pad_id' => 'g.ABCDEFGHIJKLMNOP$pad-1',
 				'access_mode' => BindingService::ACCESS_PROTECTED,
 			],
-		]);
-		$padFileService->method('extractPadMetadata')->willReturn([
-			'pad_id' => 'g.ABCDEFGHIJKLMNOP$pad-1',
-			'access_mode' => BindingService::ACCESS_PROTECTED,
-			'pad_url' => '',
-		]);
-		$padFileService->method('isExternalFrontmatter')->willReturn(false);
+			body: '',
+			padId: 'g.ABCDEFGHIJKLMNOP$pad-1',
+			accessMode: BindingService::ACCESS_PROTECTED,
+			padUrl: '',
+			isExternal: false,
+		));
 		$padFileService->method('getSnapshotRevision')->willReturn(1);
 		$padFileService->method('withExportSnapshot')->with("frontmatter", 'hello', '<p>hello</p>', 5)->willReturn('updated-content');
 
@@ -523,18 +516,17 @@ class PadControllerTest extends TestCase {
 		$rootFolder->method('getById')->with(138)->willReturn([$file]);
 
 		$padFileService = $this->createMock(PadFileService::class);
-		$padFileService->method('parsePadFile')->willReturn([
-			'frontmatter' => [
+		$padFileService->method('readPad')->willReturn(new ParsedPadFile(
+			frontmatter: [
 				'pad_id' => 'g.ABCDEFGHIJKLMNOP$pad-1',
 				'access_mode' => BindingService::ACCESS_PROTECTED,
 			],
-		]);
-		$padFileService->method('extractPadMetadata')->willReturn([
-			'pad_id' => 'g.ABCDEFGHIJKLMNOP$pad-1',
-			'access_mode' => BindingService::ACCESS_PROTECTED,
-			'pad_url' => '',
-		]);
-		$padFileService->method('isExternalFrontmatter')->willReturn(false);
+			body: '',
+			padId: 'g.ABCDEFGHIJKLMNOP$pad-1',
+			accessMode: BindingService::ACCESS_PROTECTED,
+			padUrl: '',
+			isExternal: false,
+		));
 		$padFileService->method('getSnapshotRevision')->willReturn(5);
 		$padFileService->method('getTextSnapshotForRestore')->with('frontmatter')->willReturn('hello');
 		$padFileService->method('getHtmlSnapshotForRestore')->with('frontmatter')->willReturn('<p>hello</p>');
@@ -578,21 +570,20 @@ class PadControllerTest extends TestCase {
 		$rootFolder->method('getById')->with(138)->willReturn([$file]);
 
 		$padFileService = $this->createMock(PadFileService::class);
-		$padFileService->method('parsePadFile')->willReturn([
-			'frontmatter' => [
+		$padFileService->method('readPad')->willReturn(new ParsedPadFile(
+			frontmatter: [
 				'pad_id' => 'ext.remote-pad',
 				'access_mode' => BindingService::ACCESS_PUBLIC,
 				'pad_url' => 'https://pad.example.test/p/public-pad',
 				'remote_pad_id' => 'public-pad',
 				'pad_origin' => 'https://pad.example.test',
 			],
-		]);
-		$padFileService->method('extractPadMetadata')->willReturn([
-			'pad_id' => 'ext.remote-pad',
-			'access_mode' => BindingService::ACCESS_PUBLIC,
-			'pad_url' => 'https://pad.example.test/p/public-pad',
-		]);
-		$padFileService->method('isExternalFrontmatter')->willReturn(true);
+			body: '',
+			padId: 'ext.remote-pad',
+			accessMode: BindingService::ACCESS_PUBLIC,
+			padUrl: 'https://pad.example.test/p/public-pad',
+			isExternal: true,
+		));
 		$padFileService->method('getTextSnapshotForRestore')->willReturn('same text');
 
 		$bindingService = $this->createMock(BindingService::class);
@@ -651,8 +642,14 @@ class PadControllerTest extends TestCase {
 		$userSession->method('getUser')->willReturn($user);
 
 		$padFileService = $this->createMock(PadFileService::class);
-		$padFileService->method('parsePadFile')->willReturn(['frontmatter' => ['pad_id' => 'orig']]);
-		$padFileService->method('extractPadMetadata')->willReturn(['pad_id' => 'orig']);
+		$padFileService->method('readPad')->willReturn(new ParsedPadFile(
+			frontmatter: ['pad_id' => 'orig'],
+			body: '',
+			padId: 'orig',
+			accessMode: '',
+			padUrl: '',
+			isExternal: false,
+		));
 
 		$bindingService = $this->createMock(BindingService::class);
 		$bindingService->method('findByPadId')
@@ -714,8 +711,14 @@ class PadControllerTest extends TestCase {
 		$rootFolder->method('getById')->with(800)->willReturn([$orphan]);
 
 		$padFileService = $this->createMock(PadFileService::class);
-		$padFileService->method('parsePadFile')->willReturn(['frontmatter' => ['pad_id' => 'orphan']]);
-		$padFileService->method('extractPadMetadata')->willReturn(['pad_id' => 'orphan']);
+		$padFileService->method('readPad')->willReturn(new ParsedPadFile(
+			frontmatter: ['pad_id' => 'orphan'],
+			body: '',
+			padId: 'orphan',
+			accessMode: '',
+			padUrl: '',
+			isExternal: false,
+		));
 
 		$controller = $this->buildController(
 			$this->createMock(IRequest::class),

--- a/tests/phpunit/unit/PadCreationServiceTest.php
+++ b/tests/phpunit/unit/PadCreationServiceTest.php
@@ -14,6 +14,7 @@ use OCA\EtherpadNextcloud\Service\PadCreateRollbackService;
 use OCA\EtherpadNextcloud\Service\PadCreationService;
 use OCA\EtherpadNextcloud\Service\PadFileCreator;
 use OCA\EtherpadNextcloud\Service\PadFileService;
+use OCA\EtherpadNextcloud\Service\ParsedPadFile;
 use OCA\EtherpadNextcloud\Service\PadPathService;
 use OCA\EtherpadNextcloud\Service\UserNodeResolver;
 use OCP\Files\File;
@@ -294,16 +295,14 @@ class PadCreationServiceTest extends TestCase {
 		$fileCreator->method('createUserFile')->with('alice', '/Meetings/Protokoll 18.05.2026.pad')->willReturn($newFile);
 
 		$padFileService = $this->createMock(PadFileService::class);
-		$padFileService->method('parsePadFile')->with('tpl-content')->willReturn([
-			'frontmatter' => ['pad_id' => 'g.tpl$pad', 'access_mode' => BindingService::ACCESS_PROTECTED],
-			'body' => 'body',
-		]);
-		$padFileService->method('extractPadMetadata')->willReturn([
-			'pad_id' => 'g.tpl$pad',
-			'access_mode' => BindingService::ACCESS_PROTECTED,
-			'pad_url' => '',
-		]);
-		$padFileService->method('isExternalFrontmatter')->willReturn(false);
+		$padFileService->method('readPad')->with('tpl-content')->willReturn(new ParsedPadFile(
+			frontmatter: ['pad_id' => 'g.tpl$pad', 'access_mode' => BindingService::ACCESS_PROTECTED],
+			body: 'body',
+			padId: 'g.tpl$pad',
+			accessMode: BindingService::ACCESS_PROTECTED,
+			padUrl: '',
+			isExternal: false,
+		));
 		$padFileService->method('getSnapshotPartsFromBody')->willReturn([
 			'text' => 'Datum: {{date:next monday|d.m.Y}}',
 			'html' => '',
@@ -366,11 +365,14 @@ class PadCreationServiceTest extends TestCase {
 		$userNodeResolver->method('resolveUserFileNodeById')->willReturn($templateNode);
 
 		$padFileService = $this->createMock(PadFileService::class);
-		$padFileService->method('parsePadFile')->willReturn([
-			'frontmatter' => ['pad_id' => 'ext.remote'],
-			'body' => '',
-		]);
-		$padFileService->method('extractPadMetadata')->willReturn(['pad_id' => 'ext.remote']);
+		$padFileService->method('readPad')->willReturn(new ParsedPadFile(
+			frontmatter: ['pad_id' => 'ext.remote'],
+			body: '',
+			padId: 'ext.remote',
+			accessMode: '',
+			padUrl: '',
+			isExternal: true,
+		));
 
 		$padPaths = $this->createMock(PadPathService::class);
 		$padPaths->method('normalizeCreatePath')->willReturn('/Out.pad');
@@ -395,11 +397,14 @@ class PadCreationServiceTest extends TestCase {
 		$userNodeResolver->method('resolveUserFileNodeById')->willReturn($templateNode);
 
 		$padFileService = $this->createMock(PadFileService::class);
-		$padFileService->method('parsePadFile')->willReturn([
-			'frontmatter' => [],
-			'body' => '',
-		]);
-		$padFileService->method('extractPadMetadata')->willReturn([]);
+		$padFileService->method('readPad')->willReturn(new ParsedPadFile(
+			frontmatter: [],
+			body: '',
+			padId: '',
+			accessMode: '',
+			padUrl: '',
+			isExternal: false,
+		));
 
 		$padPaths = $this->createMock(PadPathService::class);
 		$padPaths->method('normalizeCreatePath')->willReturn('/Out.pad');

--- a/tests/phpunit/unit/PadInitializationServiceTest.php
+++ b/tests/phpunit/unit/PadInitializationServiceTest.php
@@ -9,6 +9,7 @@ use OCA\EtherpadNextcloud\Service\BindingService;
 use OCA\EtherpadNextcloud\Service\PadBootstrapService;
 use OCA\EtherpadNextcloud\Service\PadFileService;
 use OCA\EtherpadNextcloud\Service\PadInitializationService;
+use OCA\EtherpadNextcloud\Service\ParsedPadFile;
 use OCA\EtherpadNextcloud\Service\PadPathService;
 use OCA\EtherpadNextcloud\Service\UserNodeResolver;
 use OCP\Files\File;
@@ -35,14 +36,19 @@ class PadInitializationServiceTest extends TestCase {
 		$userNodeResolver->method('toUserAbsolutePath')->with('alice', $file)->willReturn('/Existing.pad');
 
 		$padFileService = $this->createMock(PadFileService::class);
-		$padFileService->method('parsePadFile')
+		$padFileService->method('readPad')
 			->with('content')
-			->willReturn([
-				'frontmatter' => [
+			->willReturn(new ParsedPadFile(
+				frontmatter: [
 					'pad_id' => 'g.ABC$pad',
 					'access_mode' => BindingService::ACCESS_PUBLIC,
 				],
-			]);
+				body: '',
+				padId: 'g.ABC$pad',
+				accessMode: BindingService::ACCESS_PUBLIC,
+				padUrl: '',
+				isExternal: false,
+			));
 
 		$bootstrap = $this->createMock(PadBootstrapService::class);
 		$bootstrap->expects($this->never())->method('initializeMissingFrontmatter');
@@ -70,14 +76,19 @@ class PadInitializationServiceTest extends TestCase {
 		$userNodeResolver->method('toUserAbsolutePath')->with('alice', $file)->willReturn('/Existing.pad');
 
 		$padFileService = $this->createMock(PadFileService::class);
-		$padFileService->method('parsePadFile')
+		$padFileService->method('readPad')
 			->with('content')
-			->willReturn([
-				'frontmatter' => [
+			->willReturn(new ParsedPadFile(
+				frontmatter: [
 					'pad_id' => 'g.ABC$pad',
 					'access_mode' => BindingService::ACCESS_PUBLIC,
 				],
-			]);
+				body: '',
+				padId: 'g.ABC$pad',
+				accessMode: BindingService::ACCESS_PUBLIC,
+				padUrl: '',
+				isExternal: false,
+			));
 
 		$bootstrap = $this->createMock(PadBootstrapService::class);
 		$bootstrap->expects($this->never())->method('initializeMissingFrontmatter');
@@ -115,14 +126,19 @@ class PadInitializationServiceTest extends TestCase {
 		$userNodeResolver->method('toUserAbsolutePath')->with('alice', $file)->willReturn('/Existing.pad');
 
 		$padFileService = $this->createMock(PadFileService::class);
-		$padFileService->method('parsePadFile')
+		$padFileService->method('readPad')
 			->with('content')
-			->willReturn([
-				'frontmatter' => [
+			->willReturn(new ParsedPadFile(
+				frontmatter: [
 					'pad_id' => 'g.ABC$pad',
 					'access_mode' => BindingService::ACCESS_PUBLIC,
 				],
-			]);
+				body: '',
+				padId: 'g.ABC$pad',
+				accessMode: BindingService::ACCESS_PUBLIC,
+				padUrl: '',
+				isExternal: false,
+			));
 
 		$bootstrap = $this->createMock(PadBootstrapService::class);
 		$bootstrap->expects($this->never())->method('initializeMissingFrontmatter');
@@ -148,19 +164,24 @@ class PadInitializationServiceTest extends TestCase {
 		$padFileService = $this->createMock(PadFileService::class);
 		$parseCalls = 0;
 		$padFileService->expects($this->exactly(2))
-			->method('parsePadFile')
-			->willReturnCallback(static function (string $content) use (&$parseCalls): array {
+			->method('readPad')
+			->willReturnCallback(static function (string $content) use (&$parseCalls): ParsedPadFile {
 				$parseCalls++;
 				if ($parseCalls === 1) {
 					throw new MissingFrontmatterException('Missing frontmatter.');
 				}
 				TestCase::assertSame('updated-content', $content);
-				return [
-					'frontmatter' => [
+				return new ParsedPadFile(
+					frontmatter: [
 						'pad_id' => 'g.XYZ$pad',
 						'access_mode' => BindingService::ACCESS_PROTECTED,
 					],
-				];
+					body: '',
+					padId: 'g.XYZ$pad',
+					accessMode: BindingService::ACCESS_PROTECTED,
+					padUrl: '',
+					isExternal: false,
+				);
 			});
 
 		$bootstrap = $this->createMock(PadBootstrapService::class);
@@ -190,18 +211,23 @@ class PadInitializationServiceTest extends TestCase {
 		$padFileService = $this->createMock(PadFileService::class);
 		$parseCalls = 0;
 		$padFileService->expects($this->exactly(2))
-			->method('parsePadFile')
-			->willReturnCallback(static function (string $content) use (&$parseCalls): array {
+			->method('readPad')
+			->willReturnCallback(static function (string $content) use (&$parseCalls): ParsedPadFile {
 				$parseCalls++;
 				if ($parseCalls === 1) {
 					throw new MissingFrontmatterException('Missing frontmatter.');
 				}
-				return [
-					'frontmatter' => [
+				return new ParsedPadFile(
+					frontmatter: [
 						'pad_id' => 're-bound-pad',
 						'access_mode' => BindingService::ACCESS_PUBLIC,
 					],
-				];
+					body: '',
+					padId: 're-bound-pad',
+					accessMode: BindingService::ACCESS_PUBLIC,
+					padUrl: '',
+					isExternal: false,
+				);
 			});
 
 		$bootstrap = $this->createMock(PadBootstrapService::class);

--- a/tests/phpunit/unit/PadMetadataServiceTest.php
+++ b/tests/phpunit/unit/PadMetadataServiceTest.php
@@ -10,6 +10,7 @@ use OCA\EtherpadNextcloud\Service\PadFileLockRetryService;
 use OCA\EtherpadNextcloud\Service\PadFileService;
 use OCA\EtherpadNextcloud\Service\PadMetadataService;
 use OCA\EtherpadNextcloud\Service\PadPathService;
+use OCA\EtherpadNextcloud\Service\ParsedPadFile;
 use OCA\EtherpadNextcloud\Service\UserNodeResolver;
 use OCP\Files\File;
 use OCP\Files\NotFoundException;
@@ -31,18 +32,17 @@ class PadMetadataServiceTest extends TestCase {
 		$lockRetryService->method('readContentWithOpenLockRetry')->with($file)->willReturn('frontmatter');
 
 		$padFileService = $this->createMock(PadFileService::class);
-		$padFileService->method('parsePadFile')->with('frontmatter')->willReturn([
-			'frontmatter' => [
+		$padFileService->method('readPad')->with('frontmatter')->willReturn(new ParsedPadFile(
+			frontmatter: [
 				'pad_id' => 'ext.remote',
 				'access_mode' => BindingService::ACCESS_PUBLIC,
 			],
-		]);
-		$padFileService->method('extractPadMetadata')->willReturn([
-			'pad_id' => 'ext.remote',
-			'access_mode' => BindingService::ACCESS_PUBLIC,
-			'pad_url' => 'https://pad.example.test/p/External',
-		]);
-		$padFileService->method('isExternalFrontmatter')->with($this->isType('array'), 'ext.remote')->willReturn(true);
+			body: '',
+			padId: 'ext.remote',
+			accessMode: BindingService::ACCESS_PUBLIC,
+			padUrl: 'https://pad.example.test/p/External',
+			isExternal: true,
+		));
 
 		$etherpadClient = $this->createMock(EtherpadClient::class);
 		$etherpadClient->method('normalizeAndValidateExternalPublicPadUrl')
@@ -90,18 +90,17 @@ class PadMetadataServiceTest extends TestCase {
 		$userNodeResolver->method('toUserAbsolutePath')->with('alice', $file)->willReturn('/Public.pad');
 
 		$padFileService = $this->createMock(PadFileService::class);
-		$padFileService->method('parsePadFile')->with('frontmatter')->willReturn([
-			'frontmatter' => [
+		$padFileService->method('readPad')->with('frontmatter')->willReturn(new ParsedPadFile(
+			frontmatter: [
 				'pad_id' => 'g.ABC$pad',
 				'access_mode' => BindingService::ACCESS_PUBLIC,
 			],
-		]);
-		$padFileService->method('extractPadMetadata')->willReturn([
-			'pad_id' => 'g.ABC$pad',
-			'access_mode' => BindingService::ACCESS_PUBLIC,
-			'pad_url' => '',
-		]);
-		$padFileService->method('isExternalFrontmatter')->with($this->isType('array'), 'g.ABC$pad')->willReturn(false);
+			body: '',
+			padId: 'g.ABC$pad',
+			accessMode: BindingService::ACCESS_PUBLIC,
+			padUrl: '',
+			isExternal: false,
+		));
 
 		$etherpadClient = $this->createMock(EtherpadClient::class);
 		$etherpadClient->method('buildPadUrl')->with('g.ABC$pad')->willReturn('https://pad.example.test/p/g.ABC$pad');
@@ -130,8 +129,14 @@ class PadMetadataServiceTest extends TestCase {
 		$userNodeResolver->method('toUserAbsolutePath')->with('alice', $originalNode)->willReturn('/Folder/Original.pad');
 
 		$padFileService = $this->createMock(PadFileService::class);
-		$padFileService->method('parsePadFile')->willReturn(['frontmatter' => ['pad_id' => 'original-pad']]);
-		$padFileService->method('extractPadMetadata')->willReturn(['pad_id' => 'original-pad']);
+		$padFileService->method('readPad')->willReturn(new ParsedPadFile(
+			frontmatter: ['pad_id' => 'original-pad'],
+			body: '',
+			padId: 'original-pad',
+			accessMode: '',
+			padUrl: '',
+			isExternal: false,
+		));
 
 		$bindingService = $this->createMock(BindingService::class);
 		$bindingService->expects($this->once())
@@ -169,8 +174,14 @@ class PadMetadataServiceTest extends TestCase {
 		);
 
 		$padFileService = $this->createMock(PadFileService::class);
-		$padFileService->method('parsePadFile')->willReturn(['frontmatter' => ['pad_id' => 'original-pad']]);
-		$padFileService->method('extractPadMetadata')->willReturn(['pad_id' => 'original-pad']);
+		$padFileService->method('readPad')->willReturn(new ParsedPadFile(
+			frontmatter: ['pad_id' => 'original-pad'],
+			body: '',
+			padId: 'original-pad',
+			accessMode: '',
+			padUrl: '',
+			isExternal: false,
+		));
 
 		$bindingService = $this->createMock(BindingService::class);
 		$bindingService->method('findByPadId')->willReturn(['file_id' => 9999, 'pad_id' => 'original-pad']);
@@ -190,8 +201,14 @@ class PadMetadataServiceTest extends TestCase {
 		$userNodeResolver->method('resolveUserFileNodeById')->with('alice', 703)->willReturn($orphan);
 
 		$padFileService = $this->createMock(PadFileService::class);
-		$padFileService->method('parsePadFile')->willReturn(['frontmatter' => ['pad_id' => 'gone-pad']]);
-		$padFileService->method('extractPadMetadata')->willReturn(['pad_id' => 'gone-pad']);
+		$padFileService->method('readPad')->willReturn(new ParsedPadFile(
+			frontmatter: ['pad_id' => 'gone-pad'],
+			body: '',
+			padId: 'gone-pad',
+			accessMode: '',
+			padUrl: '',
+			isExternal: false,
+		));
 
 		$bindingService = $this->createMock(BindingService::class);
 		$bindingService->method('findByPadId')->willReturn(null);
@@ -213,8 +230,14 @@ class PadMetadataServiceTest extends TestCase {
 		$userNodeResolver->method('resolveUserFileNodeById')->with('alice', 704)->willReturn($orphan);
 
 		$padFileService = $this->createMock(PadFileService::class);
-		$padFileService->method('parsePadFile')->willReturn(['frontmatter' => ['pad_id' => 'ext.remote']]);
-		$padFileService->method('extractPadMetadata')->willReturn(['pad_id' => 'ext.remote']);
+		$padFileService->method('readPad')->willReturn(new ParsedPadFile(
+			frontmatter: ['pad_id' => 'ext.remote'],
+			body: '',
+			padId: 'ext.remote',
+			accessMode: '',
+			padUrl: '',
+			isExternal: true,
+		));
 
 		$bindingService = $this->createMock(BindingService::class);
 		$bindingService->expects($this->never())->method('findByPadId');
@@ -271,8 +294,14 @@ class PadMetadataServiceTest extends TestCase {
 		$userNodeResolver->method('resolveUserFileNodeById')->with('alice', 707)->willReturn($orphan);
 
 		$padFileService = $this->createMock(PadFileService::class);
-		$padFileService->method('parsePadFile')->willReturn(['frontmatter' => ['pad_id' => 'self-pad']]);
-		$padFileService->method('extractPadMetadata')->willReturn(['pad_id' => 'self-pad']);
+		$padFileService->method('readPad')->willReturn(new ParsedPadFile(
+			frontmatter: ['pad_id' => 'self-pad'],
+			body: '',
+			padId: 'self-pad',
+			accessMode: '',
+			padUrl: '',
+			isExternal: false,
+		));
 
 		$bindingService = $this->createMock(BindingService::class);
 		$bindingService->method('findByPadId')->willReturn(['file_id' => 707, 'pad_id' => 'self-pad']);

--- a/tests/phpunit/unit/PadSyncServiceTest.php
+++ b/tests/phpunit/unit/PadSyncServiceTest.php
@@ -9,6 +9,7 @@ use OCA\EtherpadNextcloud\Service\EtherpadClient;
 use OCA\EtherpadNextcloud\Service\PadFileLockRetryService;
 use OCA\EtherpadNextcloud\Service\PadFileService;
 use OCA\EtherpadNextcloud\Service\PadSyncService;
+use OCA\EtherpadNextcloud\Service\ParsedPadFile;
 use OCA\EtherpadNextcloud\Service\UserNodeResolver;
 use OCP\Files\File;
 use PHPUnit\Framework\TestCase;
@@ -23,18 +24,17 @@ class PadSyncServiceTest extends TestCase {
 		$userNodeResolver->method('resolveUserFileNodeById')->with('alice', 138)->willReturn($file);
 
 		$padFileService = $this->createMock(PadFileService::class);
-		$padFileService->method('parsePadFile')->with('frontmatter')->willReturn([
-			'frontmatter' => [
+		$padFileService->method('readPad')->with('frontmatter')->willReturn(new ParsedPadFile(
+			frontmatter: [
 				'pad_id' => 'ext.remote',
 				'access_mode' => BindingService::ACCESS_PUBLIC,
 			],
-		]);
-		$padFileService->method('extractPadMetadata')->willReturn([
-			'pad_id' => 'ext.remote',
-			'access_mode' => BindingService::ACCESS_PUBLIC,
-			'pad_url' => 'https://pad.example.test/p/remote',
-		]);
-		$padFileService->method('isExternalFrontmatter')->willReturn(true);
+			body: '',
+			padId: 'ext.remote',
+			accessMode: BindingService::ACCESS_PUBLIC,
+			padUrl: 'https://pad.example.test/p/remote',
+			isExternal: true,
+		));
 
 		$bindingService = $this->createMock(BindingService::class);
 		$bindingService->expects($this->never())->method('assertConsistentMapping');
@@ -55,18 +55,17 @@ class PadSyncServiceTest extends TestCase {
 		$userNodeResolver->method('resolveUserFileNodeById')->with('alice', 138)->willReturn($file);
 
 		$padFileService = $this->createMock(PadFileService::class);
-		$padFileService->method('parsePadFile')->with('frontmatter')->willReturn([
-			'frontmatter' => [
+		$padFileService->method('readPad')->with('frontmatter')->willReturn(new ParsedPadFile(
+			frontmatter: [
 				'pad_id' => 'g.ABC$pad',
 				'access_mode' => BindingService::ACCESS_PROTECTED,
 			],
-		]);
-		$padFileService->method('extractPadMetadata')->willReturn([
-			'pad_id' => 'g.ABC$pad',
-			'access_mode' => BindingService::ACCESS_PROTECTED,
-			'pad_url' => '',
-		]);
-		$padFileService->method('isExternalFrontmatter')->willReturn(false);
+			body: '',
+			padId: 'g.ABC$pad',
+			accessMode: BindingService::ACCESS_PROTECTED,
+			padUrl: '',
+			isExternal: false,
+		));
 		$padFileService->method('getSnapshotRevision')->with('frontmatter')->willReturn(3);
 
 		$bindingService = $this->createMock(BindingService::class);
@@ -99,18 +98,17 @@ class PadSyncServiceTest extends TestCase {
 		$userNodeResolver->method('toUserAbsolutePath')->with('alice', $file)->willReturn('/Remote.pad');
 
 		$padFileService = $this->createMock(PadFileService::class);
-		$padFileService->method('parsePadFile')->with('frontmatter')->willReturn([
-			'frontmatter' => [
+		$padFileService->method('readPad')->with('frontmatter')->willReturn(new ParsedPadFile(
+			frontmatter: [
 				'pad_id' => 'ext.remote',
 				'access_mode' => BindingService::ACCESS_PUBLIC,
 			],
-		]);
-		$padFileService->method('extractPadMetadata')->willReturn([
-			'pad_id' => 'ext.remote',
-			'access_mode' => BindingService::ACCESS_PUBLIC,
-			'pad_url' => 'https://pad.example.test/p/remote',
-		]);
-		$padFileService->method('isExternalFrontmatter')->willReturn(true);
+			body: '',
+			padId: 'ext.remote',
+			accessMode: BindingService::ACCESS_PUBLIC,
+			padUrl: 'https://pad.example.test/p/remote',
+			isExternal: true,
+		));
 		$padFileService->expects($this->once())
 			->method('getTextSnapshotForRestore')
 			->with('frontmatter')

--- a/tests/phpunit/unit/PublicPadContextServiceTest.php
+++ b/tests/phpunit/unit/PublicPadContextServiceTest.php
@@ -6,6 +6,7 @@ namespace OCA\EtherpadNextcloud\Tests\Unit;
 
 use OCA\EtherpadNextcloud\Service\BindingService;
 use OCA\EtherpadNextcloud\Service\PadFileService;
+use OCA\EtherpadNextcloud\Service\ParsedPadFile;
 use OCA\EtherpadNextcloud\Service\PublicPadContextService;
 use OCA\EtherpadNextcloud\Service\PublicPadOpenService;
 use OCA\EtherpadNextcloud\Service\PublicPadOpenTarget;
@@ -38,13 +39,14 @@ class PublicPadContextServiceTest extends TestCase {
 			'pad_url' => '',
 		];
 		$padFiles = $this->createMock(PadFileService::class);
-		$padFiles->expects($this->once())->method('parsePadFile')->with('frontmatter')->willReturn(['frontmatter' => $frontmatter]);
-		$padFiles->expects($this->once())->method('extractPadMetadata')->with($frontmatter)->willReturn([
-			'pad_id' => 'g.group$pad',
-			'access_mode' => BindingService::ACCESS_PROTECTED,
-			'pad_url' => '',
-		]);
-		$padFiles->expects($this->once())->method('isExternalFrontmatter')->with($frontmatter, 'g.group$pad')->willReturn(false);
+		$padFiles->expects($this->once())->method('readPad')->with('frontmatter')->willReturn(new ParsedPadFile(
+			frontmatter: $frontmatter,
+			body: '',
+			padId: 'g.group$pad',
+			accessMode: BindingService::ACCESS_PROTECTED,
+			padUrl: '',
+			isExternal: false,
+		));
 
 		$bindings = $this->createMock(BindingService::class);
 		$bindings->expects($this->once())

--- a/tests/phpunit/unit/PublicViewerControllerTest.php
+++ b/tests/phpunit/unit/PublicViewerControllerTest.php
@@ -10,6 +10,7 @@ use OCA\EtherpadNextcloud\Service\BindingService;
 use OCA\EtherpadNextcloud\Service\EtherpadClient;
 use OCA\EtherpadNextcloud\Service\PadFileService;
 use OCA\EtherpadNextcloud\Service\PadSessionService;
+use OCA\EtherpadNextcloud\Service\ParsedPadFile;
 use OCA\EtherpadNextcloud\Service\PublicPadContextService;
 use OCA\EtherpadNextcloud\Service\PublicPadOpenService;
 use OCA\EtherpadNextcloud\Service\PublicShareResolver;
@@ -53,21 +54,16 @@ class PublicViewerControllerTest extends TestCase {
 
 		$padFileService = $this->createMock(PadFileService::class);
 		$padFileService->expects($this->once())
-			->method('parsePadFile')
+			->method('readPad')
 			->with('frontmatter')
-			->willReturn(['frontmatter' => $frontmatter]);
-		$padFileService->expects($this->once())
-			->method('extractPadMetadata')
-			->with($frontmatter)
-			->willReturn([
-				'pad_id' => 'g.abcdefghijklmnop$Shared',
-				'access_mode' => BindingService::ACCESS_PROTECTED,
-				'pad_url' => '',
-			]);
-		$padFileService->expects($this->once())
-			->method('isExternalFrontmatter')
-			->with($frontmatter, 'g.abcdefghijklmnop$Shared')
-			->willReturn(false);
+			->willReturn(new ParsedPadFile(
+				frontmatter: $frontmatter,
+				body: '',
+				padId: 'g.abcdefghijklmnop$Shared',
+				accessMode: BindingService::ACCESS_PROTECTED,
+				padUrl: '',
+				isExternal: false,
+			));
 		$padFileService->expects($this->once())
 			->method('getTextSnapshotForRestore')
 			->with('frontmatter')
@@ -132,21 +128,16 @@ class PublicViewerControllerTest extends TestCase {
 
 		$padFileService = $this->createMock(PadFileService::class);
 		$padFileService->expects($this->once())
-			->method('parsePadFile')
+			->method('readPad')
 			->with('frontmatter')
-			->willReturn(['frontmatter' => $frontmatter]);
-		$padFileService->expects($this->once())
-			->method('extractPadMetadata')
-			->with($frontmatter)
-			->willReturn([
-				'pad_id' => 'ext.abc123',
-				'access_mode' => BindingService::ACCESS_PUBLIC,
-				'pad_url' => 'https://pad.portal.example/p/Test',
-			]);
-		$padFileService->expects($this->once())
-			->method('isExternalFrontmatter')
-			->with($frontmatter, 'ext.abc123')
-			->willReturn(true);
+			->willReturn(new ParsedPadFile(
+				frontmatter: $frontmatter,
+				body: '',
+				padId: 'ext.abc123',
+				accessMode: BindingService::ACCESS_PUBLIC,
+				padUrl: 'https://pad.portal.example/p/Test',
+				isExternal: true,
+			));
 		$padFileService->expects($this->once())
 			->method('getTextSnapshotForRestore')
 			->with('frontmatter')
@@ -205,34 +196,22 @@ class PublicViewerControllerTest extends TestCase {
 
 		$padFileService = $this->createMock(PadFileService::class);
 		$padFileService->expects($this->once())
-			->method('parsePadFile')
+			->method('readPad')
 			->with('frontmatter')
-			->willReturn([
-				'frontmatter' => [
+			->willReturn(new ParsedPadFile(
+				frontmatter: [
 					'pad_id' => 'ext.123',
 					'access_mode' => BindingService::ACCESS_PROTECTED,
 					'pad_url' => 'https://remote.example.test/p/demo',
 					'pad_origin' => 'https://remote.example.test',
 					'remote_pad_id' => 'demo',
 				],
-			]);
-		$padFileService->expects($this->once())
-			->method('extractPadMetadata')
-			->willReturn([
-				'pad_id' => 'ext.123',
-				'access_mode' => BindingService::ACCESS_PROTECTED,
-				'pad_url' => 'https://remote.example.test/p/demo',
-			]);
-		$padFileService->expects($this->once())
-			->method('isExternalFrontmatter')
-			->with([
-				'pad_id' => 'ext.123',
-				'access_mode' => BindingService::ACCESS_PROTECTED,
-				'pad_url' => 'https://remote.example.test/p/demo',
-				'pad_origin' => 'https://remote.example.test',
-				'remote_pad_id' => 'demo',
-			], 'ext.123')
-			->willReturn(true);
+				body: '',
+				padId: 'ext.123',
+				accessMode: BindingService::ACCESS_PROTECTED,
+				padUrl: 'https://remote.example.test/p/demo',
+				isExternal: true,
+			));
 
 		$bindingService = $this->createMock(BindingService::class);
 		$bindingService->expects($this->never())->method('assertConsistentMapping');


### PR DESCRIPTION
Closes #61.

Seven production sites used to open-code the same 3-step incantation:

```php
$parsed = $this->padFileService->parsePadFile($content);
$frontmatter = $parsed['frontmatter'];
$meta = $this->padFileService->extractPadMetadata($frontmatter);
$padId = $meta['pad_id'];
$accessMode = $meta['access_mode'];
$padUrl = $meta['pad_url'];
$isExternal = $this->padFileService->isExternalFrontmatter($frontmatter, $padId);
```

That's now one call returning a typed value object:

```php
$pad = $this->padFileService->readPad($content);
// $pad->padId, accessMode, padUrl, isExternal, frontmatter, body
```

## Affected sites

`PadOpenService`, `PadSyncService` (x2), `PadCreationService::createFromTemplate`, `PadMetadataService` (x2), `PublicPadContextService`, `LifecycleService` (x2), `PadInitializationService` (x2).

## Why this matters

Every new pad-related feature was adding another copy of the same 4-line block. The first divergent variant (forgotten `isExternal` check, wrong default, missed `pad_url` field) would become a silent bug. One typed entry point eliminates that footgun.

## Compatibility

`parsePadFile` / `extractPadMetadata` / `isExternalFrontmatter` remain public — only `readPad` composes them. `PadFileServiceTest` continues to exercise the constituent methods directly. No external API surface changes.

## Tests

396 stay green. 8 test files adjusted to mock `readPad()` returning a `ParsedPadFile` instead of stubbing the three constituent methods.