### PR TITLE
ci: add GitHub Actions workflows + dependabot (closes #75)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2026 Etherpad contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# Modeled on https://github.com/nextcloud/notes/blob/main/.github/dependabot.yml
+
+version: 2
+updates:
+  - package-ecosystem: composer
+    directory: "/"
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10

--- a/.github/workflows/lint-info-xml.yml
+++ b/.github/workflows/lint-info-xml.yml
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: 2026 Etherpad contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# Modeled on https://github.com/nextcloud/notes/blob/main/.github/workflows/lint-info-xml.yml
+# Validates appinfo/info.xml against the published apps.nextcloud.com schema.
+
+name: Lint info.xml
+
+on: pull_request
+
+permissions:
+  contents: read
+
+concurrency:
+  group: lint-info-xml-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  xml-linters:
+    runs-on: ubuntu-latest
+
+    name: info.xml lint
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Download schema
+        run: wget --quiet https://raw.githubusercontent.com/nextcloud/appstore/master/nextcloudappstore/api/v1/release/info.xsd
+
+      - name: Lint info.xml
+        uses: ChristophWurst/xmllint-action@36f2a302f84f8c83fceea0b9c59e1eb4a616d3c1 # v1.2
+        with:
+          xml-file: ./appinfo/info.xml
+          xml-schema-file: ./info.xsd

--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: 2026 Etherpad contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# Modeled on https://github.com/nextcloud/notes/blob/main/.github/workflows/lint-php.yml
+# Parse-lint every PHP file with the lowest supported PHP toolchain, then
+# repeat on the highest to catch version-specific syntax issues.
+
+name: Lint PHP
+
+on: pull_request
+
+permissions:
+  contents: read
+
+concurrency:
+  group: lint-php-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  php-lint:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php-versions: ['8.2', '8.4']
+
+    name: PHP ${{ matrix.php-versions }} parse-lint
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@9e72090525849c5e82e596468b86eb55e9cc5401 # v2.32.0
+        with:
+          php-version: ${{ matrix.php-versions }}
+          coverage: none
+          tools: none
+
+      - name: Lint
+        run: |
+          set -euo pipefail
+          find lib tests scripts -type f -name '*.php' -print0 \
+            | xargs -0 -n1 -P4 php -l > /dev/null

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -1,0 +1,81 @@
+# SPDX-FileCopyrightText: 2026 Etherpad contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# Modeled on https://github.com/nextcloud/notes/blob/main/.github/workflows/node.yml
+# Runs vitest plus a production build to catch regressions in the frontend bundle.
+
+name: Node
+
+on: pull_request
+
+permissions:
+  contents: read
+
+concurrency:
+  group: node-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+
+    outputs:
+      src: ${{ steps.changes.outputs.src }}
+
+    steps:
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: changes
+        continue-on-error: true
+        with:
+          filters: |
+            src:
+              - '.github/workflows/node.yml'
+              - 'package.json'
+              - 'package-lock.json'
+              - 'vite.config.*'
+              - 'vitest.config.*'
+              - 'src/**'
+              - 'js/**'
+              - 'tests/js/**'
+
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    needs: changes
+    if: needs.changes.outputs.src != 'false'
+
+    name: npm build + vitest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Read package.json node and npm engines
+        id: versions
+        uses: skjnldsv/read-package-engines-version-actions@8205673bab74a63eb9b8093402fd9e0e018663a1 # v3
+        with:
+          fallbackNode: '^20'
+          fallbackNpm: '^10'
+
+      - name: Set up node ${{ steps.versions.outputs.nodeVersion }}
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: ${{ steps.versions.outputs.nodeVersion }}
+          cache: npm
+
+      - name: Set up npm ${{ steps.versions.outputs.npmVersion }}
+        run: npm i -g 'npm@${{ steps.versions.outputs.npmVersion }}'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run vitest
+        run: npm test
+
+      - name: Production build
+        run: npm run build

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -84,7 +84,7 @@ jobs:
         run: composer test:phpunit
 
   summary:
-    runs-on: ubuntu-latest-low
+    runs-on: ubuntu-latest
     needs: phpunit
     if: always()
 

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -1,0 +1,98 @@
+# SPDX-FileCopyrightText: 2026 Etherpad contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# Modeled on https://github.com/nextcloud/notes/blob/main/.github/workflows/phpunit.yml
+# The test suite is stub-based (see tests/phpunit/bootstrap.php), so no real
+# Nextcloud server is required — only a PHP toolchain with composer.
+
+name: PHPUnit
+
+on: pull_request
+
+permissions:
+  contents: read
+
+concurrency:
+  group: phpunit-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+
+    outputs:
+      src: ${{ steps.changes.outputs.src }}
+
+    steps:
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: changes
+        continue-on-error: true
+        with:
+          filters: |
+            src:
+              - '.github/workflows/phpunit.yml'
+              - 'composer.*'
+              - 'lib/**'
+              - 'tests/phpunit/**'
+              - 'phpunit.xml.dist'
+
+  phpunit:
+    runs-on: ubuntu-latest
+
+    needs: changes
+    if: needs.changes.outputs.src != 'false'
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php-versions: ['8.2', '8.3', '8.4']
+
+    name: PHP ${{ matrix.php-versions }} unit tests
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@9e72090525849c5e82e596468b86eb55e9cc5401 # v2.32.0
+        with:
+          php-version: ${{ matrix.php-versions }}
+          coverage: none
+          tools: composer:v2
+
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache composer dependencies
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ matrix.php-versions }}-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-${{ matrix.php-versions }}-
+
+      - name: Install dependencies
+        run: composer install --no-progress --prefer-dist
+
+      - name: Run PHPUnit
+        run: composer test:phpunit
+
+  summary:
+    runs-on: ubuntu-latest-low
+    needs: phpunit
+    if: always()
+
+    name: phpunit-summary
+
+    steps:
+      - run: |
+          result="${{ needs.phpunit.result }}"
+          if [ "$result" != "success" ] && [ "$result" != "skipped" ]; then
+            exit 1
+          fi


### PR DESCRIPTION
Closes #75.

Per the offer in #57: five workflows + dependabot config, each modeled on the equivalent in [nextcloud/notes](https://github.com/nextcloud/notes/tree/main/.github) so they keep tracking the org template repo (`nextcloud/.github`) cleanly later.

## Workflows

| File | What it gates |
|---|---|
| `phpunit.yml` | PHP 8.2/8.3/8.4 matrix → `composer test:phpunit`. Suite is stub-based (`tests/phpunit/bootstrap.php`), so no real NC server is needed in CI. |
| `lint-php.yml` | Parse-lint every PHP file on the lowest + highest supported PHP. |
| `lint-info-xml.yml` | Validates `appinfo/info.xml` against the published apps.nextcloud.com schema — prerequisite for #76. |
| `node.yml` | vitest + production build, Node from `package.json` engines. |
| `dependabot.yml` | composer monthly, npm + github-actions weekly. |

## Conventions inherited from upstream

- Actions pinned by full SHA (first-party security baseline)
- `persist-credentials: false` on every checkout
- Per-workflow concurrency groups with `cancel-in-progress`
- `dorny/paths-filter` so PHP-only changes skip Node CI and vice versa

## Verified locally

- `npm ci && npm test`: **98 / 98** passing across 12 files
- `npm run build`: succeeds
- All workflow YAML parses cleanly

PHP toolchain wasn't available on my box, so the phpunit matrix gets its first real run on this PR. Happy to iterate if anything's red.

## Out of scope (suggested follow-ups, not blockers)

- `appstore-build-publish.yml` — release automation; deserves its own PR once #76's submission process is settled
- `psalm-matrix.yml` — static analysis; the app would need a `psalm.xml` first
- `lint-eslint.yml` / `lint-stylelint.yml` — skipped because no eslint/stylelint config is in the repo today; trivial to add later