### PR TITLE
Fix appinfo/info.xml schema + add John McLear as author

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -8,21 +8,24 @@
 	<version>1.1.0-alpha.1</version>
 	<licence>agpl</licence>
 	<author>Jacob Bühler</author>
+	<author>John McLear</author>
 	<namespace>EtherpadNextcloud</namespace>
-	<types>
-		<filesystem/>
-	</types>
+	<category>office</category>
+	<website>https://github.com/Jaggob/etherpad-integration-for-nextcloud</website>
+	<bugs>https://github.com/Jaggob/etherpad-integration-for-nextcloud/issues</bugs>
+	<repository type="git">https://github.com/Jaggob/etherpad-integration-for-nextcloud.git</repository>
 	<dependencies>
-		<nextcloud min-version="30" max-version="33"/>
+		<php min-version="8.1" max-version="8.5"/>
+		<nextcloud min-version="31" max-version="33"/>
 	</dependencies>
-	<settings>
-		<admin-section>OCA\EtherpadNextcloud\Settings\AdminSection</admin-section>
-		<admin>OCA\EtherpadNextcloud\Settings\AdminSettings</admin>
-	</settings>
 	<repair-steps>
 		<post-migration>
 			<step>OCA\EtherpadNextcloud\Migration\RegisterMimeType</step>
 			<step>OCA\EtherpadNextcloud\Migration\BackfillPadMimeType</step>
 		</post-migration>
 	</repair-steps>
+	<settings>
+		<admin>OCA\EtherpadNextcloud\Settings\AdminSettings</admin>
+		<admin-section>OCA\EtherpadNextcloud\Settings\AdminSection</admin-section>
+	</settings>
 </info>


### PR DESCRIPTION
First real test of the CI workflows that landed in e5e1a87. The new `lint-info-xml` job immediately surfaced real schema violations in our manifest that would have blocked app-store submission.

## What changed

- **Add `<category>office</category>`.** Required by the schema (`minOccurs=1`); without it `xmllint` fails regardless of all the other content.
- **Re-order top-level elements** to match the strict `<xs:sequence>` from `info.xsd`: `category, website, bugs, repository, dependencies, repair-steps, settings`.
- **Re-order `<admin>` before `<admin-section>`** inside `<settings>` for the same reason.
- **Declare PHP range** (`<php min-version="8.1" max-version="8.5"/>`) inside `<dependencies>`. We were silent on PHP previously.
- **Bump NC `min-version` from 30 to 31** so the CI matrix doesn't have to test PHP 8.1. NC30 is EOL and dropping it lets the matrix stay at 8.2+ without drifting from the declared compat. Saves CI minutes and avoids testing a version we'd otherwise barely use.
- **Drop the deprecated `<types><filesystem/></types>`** wrapper that newer NC apps don't use.
- **Add `<website>`, `<bugs>`, `<repository>`** pointing at the GitHub repo so the app-store listing has the right outbound links.
- **Add John McLear as second `<author>`.**

## Verified

- `xmllint --schema info.xsd appinfo/info.xml --noout` → validates
- `composer test:phpunit` → 395/395 (no behaviour change)

This PR is also the first one that will actually trigger the new CI workflows on GitHub's runners — so we'll get live feedback on whether the YAMLs themselves work end-to-end.