### PR TITLE
ci: fail the build when committed js/ assets are stale (#101)

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -79,3 +79,8 @@ jobs:
 
       - name: Production build
         run: npm run build
+
+      - name: Fail if built assets are stale
+        # The committed js/ bundles must match a fresh build of src/.
+        # If this fails, run `npm run build` locally and commit js/.
+        run: git diff --exit-code -- js/

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -82,5 +82,13 @@ jobs:
 
       - name: Fail if built assets are stale
         # The committed js/ bundles must match a fresh build of src/.
+        # Use `git status --porcelain` (not `git diff`) so a brand-new,
+        # still-untracked chunk/entry point also fails the check.
         # If this fails, run `npm run build` locally and commit js/.
-        run: git diff --exit-code -- js/
+        run: |
+          changes="$(git status --porcelain -- js/)"
+          if [ -n "$changes" ]; then
+            echo "Built js/ assets are out of date with src/. Run 'npm run build' and commit js/:" >&2
+            echo "$changes" >&2
+            exit 1
+          fi


### PR DESCRIPTION
Closes #101.

Committed `js/*.mjs` bundles can drift from `src/` — a renamed string can land in `src/` while the shipped bundle still carries the old one (exactly what happened with the i18n rename). This adds a guard so it can't be merged.

## Change

After the existing `npm run build` step in the Node workflow:

```yaml
- name: Fail if built assets are stale
  run: git diff --exit-code -- js/
```

A fresh build that produces any change under `js/` now fails CI, with a hint to run `npm run build` and commit.

## Notes

- No current drift: HEAD's bundles already match a fresh build (the recent rebuilds cleared it), so this PR only adds the guard.
- The build is deterministic (chunk hashes are stable across rebuilds with the pinned `package-lock.json`), so the check won't false-positive.
- Gated by the existing `changes` paths filter (`src/**`, `js/**`, vite/vitest config, package files), so it only runs when relevant.