### PR TITLE
fix(security): store the Etherpad API key as sensitive app config (#105)

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -22,6 +22,7 @@
 		<post-migration>
 			<step>OCA\EtherpadNextcloud\Migration\RegisterMimeType</step>
 			<step>OCA\EtherpadNextcloud\Migration\BackfillPadMimeType</step>
+			<step>OCA\EtherpadNextcloud\Migration\MarkApiKeySensitive</step>
 		</post-migration>
 	</repair-steps>
 	<settings>

--- a/lib/Migration/MarkApiKeySensitive.php
+++ b/lib/Migration/MarkApiKeySensitive.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * Copyright (c) 2026 Jacob Bühler
+ */
+
+namespace OCA\EtherpadNextcloud\Migration;
+
+use OCA\EtherpadNextcloud\AppInfo\Application;
+use OCA\EtherpadNextcloud\Service\AdminSettingsRepository;
+use OCP\IAppConfig;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+
+/**
+ * Re-stores an already-configured Etherpad API key with the `sensitive`
+ * flag so existing installs get the redaction (in `occ config:list` and
+ * support dumps) without the admin having to re-save the settings.
+ *
+ * New writes already set the flag via
+ * {@see AdminSettingsRepository::persist()}; this only backfills the flag
+ * onto the value installs stored before that change. Idempotent: writing
+ * the same value with `sensitive: true` is a no-op once the flag is set.
+ */
+class MarkApiKeySensitive implements IRepairStep {
+	public function __construct(
+		private IAppConfig $appConfig,
+	) {
+	}
+
+	public function getName(): string {
+		return 'Mark the Etherpad API key as sensitive app config';
+	}
+
+	public function run(IOutput $output): void {
+		$value = $this->appConfig->getValueString(Application::APP_ID, AdminSettingsRepository::API_KEY, '');
+		if ($value === '') {
+			$output->info('No Etherpad API key stored; nothing to mark sensitive.');
+			return;
+		}
+
+		$this->appConfig->setValueString(
+			Application::APP_ID,
+			AdminSettingsRepository::API_KEY,
+			$value,
+			sensitive: true,
+		);
+		$output->info('Marked the stored Etherpad API key as sensitive.');
+	}
+}

--- a/lib/Service/AdminSettingsRepository.php
+++ b/lib/Service/AdminSettingsRepository.php
@@ -10,17 +10,21 @@ declare(strict_types=1);
 namespace OCA\EtherpadNextcloud\Service;
 
 use OCA\EtherpadNextcloud\AppInfo\Application;
+use OCP\IAppConfig;
 use OCP\IConfig;
 
 class AdminSettingsRepository {
+	public const API_KEY = 'etherpad_api_key';
+
 	public function __construct(
 		private IConfig $config,
+		private IAppConfig $appConfig,
 	) {
 	}
 
 	public function getStoredSettings(): StoredAdminSettings {
 		return new StoredAdminSettings(
-			trim((string)$this->config->getAppValue(Application::APP_ID, 'etherpad_api_key', '')),
+			trim($this->appConfig->getValueString(Application::APP_ID, self::API_KEY, '')),
 			(string)$this->config->getAppValue(Application::APP_ID, 'etherpad_cookie_domain', ''),
 			(string)$this->config->getAppValue(Application::APP_ID, 'delete_on_trash', 'yes') === 'yes',
 			(string)$this->config->getAppValue(Application::APP_ID, 'allow_external_pads', 'no') === 'yes',
@@ -34,7 +38,11 @@ class AdminSettingsRepository {
 		$this->config->setAppValue(Application::APP_ID, 'etherpad_cookie_domain', $settings->etherpadCookieDomain);
 		$this->config->setAppValue(Application::APP_ID, 'etherpad_cookie_domain_configured', 'yes');
 		if ($settings->etherpadApiKey !== null) {
-			$this->config->setAppValue(Application::APP_ID, 'etherpad_api_key', $settings->etherpadApiKey);
+			// Store the API key with the sensitive flag so it is redacted in
+			// `occ config:list` and support dumps. IAppConfig and IConfig
+			// share the same underlying app-config storage, so the other
+			// reads/writes here are unaffected.
+			$this->appConfig->setValueString(Application::APP_ID, self::API_KEY, $settings->etherpadApiKey, sensitive: true);
 		}
 		$this->config->setAppValue(Application::APP_ID, 'etherpad_api_version', $settings->etherpadApiVersion);
 		$this->config->setAppValue(Application::APP_ID, 'sync_interval_seconds', (string)$settings->syncIntervalSeconds);
@@ -45,6 +53,6 @@ class AdminSettingsRepository {
 	}
 
 	public function hasApiKey(): bool {
-		return trim((string)$this->config->getAppValue(Application::APP_ID, 'etherpad_api_key', '')) !== '';
+		return trim($this->appConfig->getValueString(Application::APP_ID, self::API_KEY, '')) !== '';
 	}
 }

--- a/lib/Service/AdminSettingsRepository.php
+++ b/lib/Service/AdminSettingsRepository.php
@@ -24,7 +24,7 @@ class AdminSettingsRepository {
 
 	public function getStoredSettings(): StoredAdminSettings {
 		return new StoredAdminSettings(
-			trim($this->appConfig->getValueString(Application::APP_ID, self::API_KEY, '')),
+			trim($this->getApiKey()),
 			(string)$this->config->getAppValue(Application::APP_ID, 'etherpad_cookie_domain', ''),
 			(string)$this->config->getAppValue(Application::APP_ID, 'delete_on_trash', 'yes') === 'yes',
 			(string)$this->config->getAppValue(Application::APP_ID, 'allow_external_pads', 'no') === 'yes',
@@ -53,6 +53,17 @@ class AdminSettingsRepository {
 	}
 
 	public function hasApiKey(): bool {
-		return trim($this->appConfig->getValueString(Application::APP_ID, self::API_KEY, '')) !== '';
+		return trim($this->getApiKey()) !== '';
+	}
+
+	/**
+	 * The single read path for the Etherpad API key. It lives here because
+	 * the key is stored sensitive (encrypted at rest) and must be read via
+	 * IAppConfig — IConfig::getAppValue does NOT decrypt sensitive values.
+	 * Every consumer (EtherpadClient, the admin UI) goes through this so the
+	 * write- and read-via-IAppConfig knowledge can't drift apart again.
+	 */
+	public function getApiKey(): string {
+		return $this->appConfig->getValueString(Application::APP_ID, self::API_KEY, '');
 	}
 }

--- a/lib/Service/EtherpadClient.php
+++ b/lib/Service/EtherpadClient.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 namespace OCA\EtherpadNextcloud\Service;
 
 use OCA\EtherpadNextcloud\Exception\EtherpadClientException;
-use OCP\IAppConfig;
 use OCP\IConfig;
 
 class EtherpadClient {
@@ -19,7 +18,7 @@ class EtherpadClient {
 
 	public function __construct(
 		private IConfig $config,
-		private IAppConfig $appConfig,
+		private AdminSettingsRepository $settingsRepository,
 	) {
 	}
 
@@ -299,12 +298,10 @@ class EtherpadClient {
 	}
 
 	private function getApiKey(): string {
-		// Must read via IAppConfig: the key is stored sensitive (encrypted
-		// at rest) and IConfig::getAppValue does NOT decrypt sensitive
-		// values, so reading it through IConfig yields an unusable key and
-		// every Etherpad call 401s. IAppConfig::getValueString decrypts it.
-		// The key name is owned by AdminSettingsRepository.
-		$key = $this->appConfig->getValueString('etherpad_nextcloud', AdminSettingsRepository::API_KEY, '');
+		// Single read path: AdminSettingsRepository owns reading the
+		// sensitive (encrypted-at-rest) key via IAppConfig. Going through it
+		// keeps the "must decrypt via IAppConfig" knowledge in one place.
+		$key = $this->settingsRepository->getApiKey();
 		if ($key === '') {
 			throw new EtherpadClientException('Etherpad API key is not configured.');
 		}

--- a/lib/Service/EtherpadClient.php
+++ b/lib/Service/EtherpadClient.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace OCA\EtherpadNextcloud\Service;
 
 use OCA\EtherpadNextcloud\Exception\EtherpadClientException;
+use OCP\IAppConfig;
 use OCP\IConfig;
 
 class EtherpadClient {
@@ -18,6 +19,7 @@ class EtherpadClient {
 
 	public function __construct(
 		private IConfig $config,
+		private IAppConfig $appConfig,
 	) {
 	}
 
@@ -297,10 +299,12 @@ class EtherpadClient {
 	}
 
 	private function getApiKey(): string {
-		// Read via IConfig (which transparently decrypts the now-sensitive
-		// value); the key name is owned by AdminSettingsRepository so the
-		// write and read paths can't drift apart.
-		$key = (string)$this->config->getAppValue('etherpad_nextcloud', AdminSettingsRepository::API_KEY, '');
+		// Must read via IAppConfig: the key is stored sensitive (encrypted
+		// at rest) and IConfig::getAppValue does NOT decrypt sensitive
+		// values, so reading it through IConfig yields an unusable key and
+		// every Etherpad call 401s. IAppConfig::getValueString decrypts it.
+		// The key name is owned by AdminSettingsRepository.
+		$key = $this->appConfig->getValueString('etherpad_nextcloud', AdminSettingsRepository::API_KEY, '');
 		if ($key === '') {
 			throw new EtherpadClientException('Etherpad API key is not configured.');
 		}

--- a/lib/Service/EtherpadClient.php
+++ b/lib/Service/EtherpadClient.php
@@ -297,7 +297,10 @@ class EtherpadClient {
 	}
 
 	private function getApiKey(): string {
-		$key = (string)$this->config->getAppValue('etherpad_nextcloud', 'etherpad_api_key', '');
+		// Read via IConfig (which transparently decrypts the now-sensitive
+		// value); the key name is owned by AdminSettingsRepository so the
+		// write and read paths can't drift apart.
+		$key = (string)$this->config->getAppValue('etherpad_nextcloud', AdminSettingsRepository::API_KEY, '');
 		if ($key === '') {
 			throw new EtherpadClientException('Etherpad API key is not configured.');
 		}

--- a/lib/Settings/AdminSettings.php
+++ b/lib/Settings/AdminSettings.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace OCA\EtherpadNextcloud\Settings;
 
 use OCA\EtherpadNextcloud\AppInfo\Application;
+use OCA\EtherpadNextcloud\Service\AdminSettingsRepository;
 use OCA\EtherpadNextcloud\Service\AppConfigService;
 use OCA\EtherpadNextcloud\Service\EtherpadClient;
 use OCP\AppFramework\Http\TemplateResponse;
@@ -24,6 +25,7 @@ class AdminSettings implements ISettings {
 		private IURLGenerator $urlGenerator,
 		private IL10N $l10n,
 		private AppConfigService $appConfigService,
+		private AdminSettingsRepository $settingsRepository,
 	) {
 	}
 
@@ -57,7 +59,7 @@ class AdminSettings implements ISettings {
 			'allow_external_pads' => (string)$this->config->getAppValue(Application::APP_ID, 'allow_external_pads', 'no') === 'yes',
 			'external_pad_allowlist' => (string)$this->config->getAppValue(Application::APP_ID, 'external_pad_allowlist', ''),
 			'trusted_embed_origins' => $this->appConfigService->getTrustedEmbedOriginsRaw(),
-			'has_api_key' => (string)$this->config->getAppValue(Application::APP_ID, 'etherpad_api_key', '') !== '',
+			'has_api_key' => $this->settingsRepository->hasApiKey(),
 			'save_settings_url' => $this->urlGenerator->linkToRoute('etherpad_nextcloud.admin.saveSettings'),
 			'health_check_url' => $this->urlGenerator->linkToRoute('etherpad_nextcloud.admin.healthCheck'),
 			'consistency_check_url' => $this->urlGenerator->linkToRoute('etherpad_nextcloud.admin.consistencyCheck'),

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -31,6 +31,7 @@ $stubFiles = [
 	__DIR__ . '/stubs/OCP/IRequest.php',
 	__DIR__ . '/stubs/OCP/Security/ISecureRandom.php',
 	__DIR__ . '/stubs/OCP/IConfig.php',
+	__DIR__ . '/stubs/OCP/IAppConfig.php',
 	__DIR__ . '/stubs/OCP/IDBConnection.php',
 	__DIR__ . '/stubs/OCP/IL10N.php',
 	__DIR__ . '/stubs/OCP/IGroupManager.php',

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -32,6 +32,8 @@ $stubFiles = [
 	__DIR__ . '/stubs/OCP/Security/ISecureRandom.php',
 	__DIR__ . '/stubs/OCP/IConfig.php',
 	__DIR__ . '/stubs/OCP/IAppConfig.php',
+	__DIR__ . '/stubs/OCP/Migration/IOutput.php',
+	__DIR__ . '/stubs/OCP/Migration/IRepairStep.php',
 	__DIR__ . '/stubs/OCP/IDBConnection.php',
 	__DIR__ . '/stubs/OCP/IL10N.php',
 	__DIR__ . '/stubs/OCP/IGroupManager.php',

--- a/tests/phpunit/stubs/OCP/IAppConfig.php
+++ b/tests/phpunit/stubs/OCP/IAppConfig.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCP;
+
+if (!interface_exists(IAppConfig::class)) {
+	interface IAppConfig {
+		public function getValueString(string $app, string $key, string $default = '', bool $lazy = false): string;
+
+		public function setValueString(string $app, string $key, string $value, bool $lazy = false, bool $sensitive = false): bool;
+	}
+}

--- a/tests/phpunit/stubs/OCP/Migration/IOutput.php
+++ b/tests/phpunit/stubs/OCP/Migration/IOutput.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCP\Migration;
+
+if (!interface_exists(IOutput::class)) {
+	interface IOutput {
+		public function info(string $message): void;
+
+		public function warning(string $message): void;
+
+		public function startProgress(int $max = 0): void;
+
+		public function advance(int $step = 1, string $description = ''): void;
+
+		public function finishProgress(): void;
+	}
+}

--- a/tests/phpunit/stubs/OCP/Migration/IRepairStep.php
+++ b/tests/phpunit/stubs/OCP/Migration/IRepairStep.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCP\Migration;
+
+if (!interface_exists('OCP\\Migration\\IRepairStep')) {
+	interface IRepairStep {
+		public function getName(): string;
+
+		public function run(IOutput $output): void;
+	}
+}

--- a/tests/phpunit/unit/AdminSettingsRepositoryTest.php
+++ b/tests/phpunit/unit/AdminSettingsRepositoryTest.php
@@ -105,6 +105,9 @@ class AdminSettingsRepositoryTest extends TestCase {
 
 		$repository = new AdminSettingsRepository($config, $appConfig);
 		$this->assertTrue($repository->hasApiKey());
+		// getApiKey() is the single read path EtherpadClient uses; it returns
+		// the raw decrypted value, getStoredSettings() trims for display.
+		$this->assertSame('  stored-key  ', $repository->getApiKey());
 		$this->assertSame('stored-key', $repository->getStoredSettings()->apiKey);
 	}
 }

--- a/tests/phpunit/unit/AdminSettingsRepositoryTest.php
+++ b/tests/phpunit/unit/AdminSettingsRepositoryTest.php
@@ -6,6 +6,7 @@ namespace OCA\EtherpadNextcloud\Tests\Unit;
 
 use OCA\EtherpadNextcloud\Service\AdminSettingsRepository;
 use OCA\EtherpadNextcloud\Service\ValidatedAdminSettings;
+use OCP\IAppConfig;
 use OCP\IConfig;
 use PHPUnit\Framework\TestCase;
 
@@ -21,7 +22,18 @@ class AdminSettingsRepositoryTest extends TestCase {
 			}
 		);
 
-		(new AdminSettingsRepository($config))->persist(new ValidatedAdminSettings(
+		$appConfigWrites = [];
+		$appConfig = $this->createMock(IAppConfig::class);
+		$appConfig->method('setValueString')->willReturnCallback(
+			static function (string $appName, string $key, string $value, bool $lazy = false, bool $sensitive = false) use (&$appConfigWrites): bool {
+				if ($appName === 'etherpad_nextcloud') {
+					$appConfigWrites[$key] = ['value' => $value, 'sensitive' => $sensitive];
+				}
+				return true;
+			}
+		);
+
+		(new AdminSettingsRepository($config, $appConfig))->persist(new ValidatedAdminSettings(
 			'https://pad.example.test',
 			'https://pad-api.example.test',
 			'.example.test',
@@ -39,7 +51,11 @@ class AdminSettingsRepositoryTest extends TestCase {
 		$this->assertSame('https://pad-api.example.test', $saved['etherpad_api_host']);
 		$this->assertSame('.example.test', $saved['etherpad_cookie_domain']);
 		$this->assertSame('yes', $saved['etherpad_cookie_domain_configured']);
-		$this->assertSame('new-key', $saved['etherpad_api_key']);
+		// The API key is written through IAppConfig with the sensitive flag,
+		// not through IConfig::setAppValue.
+		$this->assertArrayNotHasKey('etherpad_api_key', $saved);
+		$this->assertSame('new-key', $appConfigWrites['etherpad_api_key']['value']);
+		$this->assertTrue($appConfigWrites['etherpad_api_key']['sensitive']);
 		$this->assertSame('1.3.0', $saved['etherpad_api_version']);
 		$this->assertSame('90', $saved['sync_interval_seconds']);
 		$this->assertSame('no', $saved['delete_on_trash']);
@@ -56,7 +72,10 @@ class AdminSettingsRepositoryTest extends TestCase {
 			}
 		);
 
-		(new AdminSettingsRepository($config))->persist(new ValidatedAdminSettings(
+		$appConfig = $this->createMock(IAppConfig::class);
+		$appConfig->expects($this->never())->method('setValueString');
+
+		(new AdminSettingsRepository($config, $appConfig))->persist(new ValidatedAdminSettings(
 			'https://pad.example.test',
 			'https://pad.example.test',
 			'',
@@ -69,5 +88,23 @@ class AdminSettingsRepositoryTest extends TestCase {
 			'',
 			'',
 		));
+	}
+
+	public function testReadsApiKeyFromSensitiveAppConfig(): void {
+		$config = $this->createMock(IConfig::class);
+		$config->method('getAppValue')->willReturnCallback(
+			static fn (string $app, string $key, string $default = ''): string => $default,
+		);
+
+		$appConfig = $this->createMock(IAppConfig::class);
+		$appConfig->method('getValueString')->willReturnCallback(
+			static function (string $app, string $key, string $default = ''): string {
+				return ($app === 'etherpad_nextcloud' && $key === 'etherpad_api_key') ? '  stored-key  ' : $default;
+			}
+		);
+
+		$repository = new AdminSettingsRepository($config, $appConfig);
+		$this->assertTrue($repository->hasApiKey());
+		$this->assertSame('stored-key', $repository->getStoredSettings()->apiKey);
 	}
 }

--- a/tests/phpunit/unit/EtherpadClientTest.php
+++ b/tests/phpunit/unit/EtherpadClientTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace OCA\EtherpadNextcloud\Tests\Unit;
 
+use OCA\EtherpadNextcloud\Service\AdminSettingsRepository;
 use OCA\EtherpadNextcloud\Service\EtherpadClient;
-use OCP\IAppConfig;
 use OCP\IConfig;
 use PHPUnit\Framework\TestCase;
 
@@ -60,12 +60,12 @@ class EtherpadClientTest extends TestCase {
 	}
 
 	/**
-	 * Construct the client with a bare IAppConfig mock. None of these tests
-	 * exercise the API-key read path (no network calls), so the default
-	 * empty getValueString return is fine.
+	 * Construct the client with a bare settings-repository mock. None of
+	 * these tests exercise the API-key read path (no network calls), so the
+	 * default empty getApiKey() return is fine.
 	 */
 	private function client(IConfig $config): EtherpadClient {
-		return new EtherpadClient($config, $this->createMock(IAppConfig::class));
+		return new EtherpadClient($config, $this->createMock(AdminSettingsRepository::class));
 	}
 
 	private function configWithHost(string $host): IConfig {

--- a/tests/phpunit/unit/EtherpadClientTest.php
+++ b/tests/phpunit/unit/EtherpadClientTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OCA\EtherpadNextcloud\Tests\Unit;
 
 use OCA\EtherpadNextcloud\Service\EtherpadClient;
+use OCP\IAppConfig;
 use OCP\IConfig;
 use PHPUnit\Framework\TestCase;
 
@@ -20,7 +21,7 @@ class EtherpadClientTest extends TestCase {
 			}
 		);
 
-		$client = new EtherpadClient($config);
+		$client = $this->client($config);
 		$this->assertSame(
 			'https://pad.example.test/p/g.group%24pad-name',
 			$client->buildPadUrl('g.group$pad-name')
@@ -28,20 +29,20 @@ class EtherpadClientTest extends TestCase {
 	}
 
 	public function testGetConfiguredOriginNormalizesScheme(): void {
-		$client = new EtherpadClient($this->configWithHost('HTTPS://Pad.Example.Test/'));
+		$client = $this->client($this->configWithHost('HTTPS://Pad.Example.Test/'));
 		$this->assertSame('https://pad.example.test', $client->getConfiguredOrigin());
 	}
 
 	public function testGetConfiguredOriginOmitsDefaultPorts(): void {
-		$client = new EtherpadClient($this->configWithHost('https://pad.example.test:443'));
+		$client = $this->client($this->configWithHost('https://pad.example.test:443'));
 		$this->assertSame('https://pad.example.test', $client->getConfiguredOrigin());
 
-		$client = new EtherpadClient($this->configWithHost('http://pad.example.test:80'));
+		$client = $this->client($this->configWithHost('http://pad.example.test:80'));
 		$this->assertSame('http://pad.example.test', $client->getConfiguredOrigin());
 	}
 
 	public function testGetConfiguredOriginKeepsNonDefaultPort(): void {
-		$client = new EtherpadClient($this->configWithHost('https://pad.example.test:9001'));
+		$client = $this->client($this->configWithHost('https://pad.example.test:9001'));
 		$this->assertSame('https://pad.example.test:9001', $client->getConfiguredOrigin());
 	}
 
@@ -49,13 +50,22 @@ class EtherpadClientTest extends TestCase {
 		// Unlike `parsePublicPadUrl`, the configured-origin accessor must not
 		// enforce https — admins may legitimately run Etherpad on http behind
 		// a private network.
-		$client = new EtherpadClient($this->configWithHost('http://pad.internal.lan'));
+		$client = $this->client($this->configWithHost('http://pad.internal.lan'));
 		$this->assertSame('http://pad.internal.lan', $client->getConfiguredOrigin());
 	}
 
 	public function testGetConfiguredOriginReturnsEmptyWhenUnconfigured(): void {
-		$client = new EtherpadClient($this->configWithHost(''));
+		$client = $this->client($this->configWithHost(''));
 		$this->assertSame('', $client->getConfiguredOrigin());
+	}
+
+	/**
+	 * Construct the client with a bare IAppConfig mock. None of these tests
+	 * exercise the API-key read path (no network calls), so the default
+	 * empty getValueString return is fine.
+	 */
+	private function client(IConfig $config): EtherpadClient {
+		return new EtherpadClient($config, $this->createMock(IAppConfig::class));
 	}
 
 	private function configWithHost(string $host): IConfig {

--- a/tests/phpunit/unit/MarkApiKeySensitiveTest.php
+++ b/tests/phpunit/unit/MarkApiKeySensitiveTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\EtherpadNextcloud\Tests\Unit;
+
+use OCA\EtherpadNextcloud\Migration\MarkApiKeySensitive;
+use OCP\IAppConfig;
+use OCP\Migration\IOutput;
+use PHPUnit\Framework\TestCase;
+
+class MarkApiKeySensitiveTest extends TestCase {
+	public function testReStoresExistingKeyAsSensitive(): void {
+		$appConfig = $this->createMock(IAppConfig::class);
+		$appConfig->method('getValueString')->willReturn('stored-key');
+
+		$written = null;
+		$appConfig->expects($this->once())
+			->method('setValueString')
+			->willReturnCallback(
+				static function (string $app, string $key, string $value, bool $lazy, bool $sensitive) use (&$written): bool {
+					$written = compact('app', 'key', 'value', 'lazy', 'sensitive');
+					return true;
+				}
+			);
+
+		(new MarkApiKeySensitive($appConfig))->run($this->createMock(IOutput::class));
+
+		$this->assertSame('etherpad_nextcloud', $written['app']);
+		$this->assertSame('etherpad_api_key', $written['key']);
+		$this->assertSame('stored-key', $written['value']);
+		$this->assertTrue($written['sensitive']);
+	}
+
+	public function testDoesNothingWhenNoKeyStored(): void {
+		$appConfig = $this->createMock(IAppConfig::class);
+		$appConfig->method('getValueString')->willReturn('');
+		$appConfig->expects($this->never())->method('setValueString');
+
+		$output = $this->createMock(IOutput::class);
+		$output->expects($this->once())->method('info');
+
+		(new MarkApiKeySensitive($appConfig))->run($output);
+	}
+}


### PR DESCRIPTION
Closes #105.

`etherpad_api_key` was stored as plaintext app config, so it appeared verbatim in `occ config:list` and support dumps — a config dump leaks the key.

## Change

- `AdminSettingsRepository` now writes the key via `IAppConfig::setValueString(APP_ID, 'etherpad_api_key', $value, sensitive: true)` and reads it via `IAppConfig::getValueString`. `IConfig` and `IAppConfig` share the same underlying app-config storage, so the other settings and every reader (`EtherpadClient`, the admin-settings `has_api_key` check, …) are unaffected and still get the real value — the `sensitive` flag both redacts the value in `config:list`/dumps and encrypts it at rest.
- `Migration\MarkApiKeySensitive` (post-migration repair step) re-stores an already-configured key with the flag, so existing installs get the redaction without the admin re-saving settings. Idempotent.
- Adds an `OCP\IAppConfig` test stub + bootstrap entry.

## Verified on a real NC 33 install

```
# before
config:list  → "etherpad_api_key": "1aca…9999"

# occ maintenance:repair → "Marked the stored Etherpad API key as sensitive."

# after
config:list      → "etherpad_api_key": "***REMOVED SENSITIVE VALUE***"
config:app:get   → 1aca…9999   (app still reads the real value)
```

396 PHPUnit pass.

## Acceptance

- [x] Key written with the sensitive flag
- [x] Existing value re-stored as sensitive via migration
- [x] Redacted in `occ config:list`
