### PR TITLE
fix(csp): require explicit allowlist for external-pad framing (#102)

### DIFF
--- a/lib/Listeners/CSPListener.php
+++ b/lib/Listeners/CSPListener.php
@@ -53,9 +53,14 @@ class CSPListener implements IEventListener {
 
 		$rawAllowlist = trim((string)$this->config->getAppValue('etherpad_nextcloud', 'external_pad_allowlist', ''));
 		if ($rawAllowlist === '') {
-			// Empty allowlist means "allow all public HTTPS hosts" for external pad linking.
-			// Mirror that behavior in CSP so valid external pads can actually load in the iframe.
-			$domains['https:'] = true;
+			// An empty allowlist means "allow all public HTTPS hosts" for the
+			// server-side snapshot fetch (see ExternalPadExportFetcher), but we
+			// must NOT mirror that into CSP: this listener handles *every*
+			// AddContentSecurityPolicyEvent, so emitting `https:` here would
+			// relax frame-src/child-src on all of Nextcloud, not just pad pages.
+			// External pads are shown as locally rendered snapshots (no live
+			// iframe to the external host), so framing them is unnecessary;
+			// only concrete allowlisted hosts ever get a frame relaxation.
 			return array_keys($domains);
 		}
 

--- a/tests/phpunit/unit/CSPListenerTest.php
+++ b/tests/phpunit/unit/CSPListenerTest.php
@@ -46,7 +46,10 @@ class CSPListenerTest extends TestCase {
 		], $policies[0]->getAllowedChildSrcDomains());
 	}
 
-	public function testHandleAllowsAllHttpsWhenExternalAllowlistIsEmpty(): void {
+	public function testHandleNeverEmitsBlanketHttpsWhenExternalAllowlistIsEmpty(): void {
+		// Regression for #102: external pads enabled + empty allowlist must NOT
+		// relax frame-src/child-src to `https:` globally. Only the concrete
+		// configured Etherpad host is allowed to be framed.
 		$config = $this->createMock(IConfig::class);
 		$config->method('getAppValue')->willReturnCallback(
 			static function (string $app, string $key, string $default = ''): string {
@@ -70,13 +73,43 @@ class CSPListenerTest extends TestCase {
 
 		$policies = $event->getPolicies();
 		$this->assertCount(1, $policies);
-		$this->assertSame([
-			'https://pad.jaggob.uber.space',
-			'https:',
-		], $policies[0]->getAllowedFrameDomains());
-		$this->assertSame([
-			'https://pad.jaggob.uber.space',
-			'https:',
-		], $policies[0]->getAllowedChildSrcDomains());
+		$this->assertSame(
+			['https://pad.jaggob.uber.space'],
+			$policies[0]->getAllowedFrameDomains()
+		);
+		$this->assertSame(
+			['https://pad.jaggob.uber.space'],
+			$policies[0]->getAllowedChildSrcDomains()
+		);
+		$this->assertNotContains('https:', $policies[0]->getAllowedFrameDomains());
+		$this->assertNotContains('https:', $policies[0]->getAllowedChildSrcDomains());
+	}
+
+	public function testHandleEmitsNoPolicyWhenOnlyExternalEmptyAllowlistAndNoLocalHost(): void {
+		// With no local Etherpad host and an empty external allowlist there is
+		// nothing concrete to allow, so the listener must add no policy at all
+		// (rather than a blanket `https:`).
+		$config = $this->createMock(IConfig::class);
+		$config->method('getAppValue')->willReturnCallback(
+			static function (string $app, string $key, string $default = ''): string {
+				if ($app !== 'etherpad_nextcloud') {
+					return $default;
+				}
+
+				return match ($key) {
+					'etherpad_host' => '',
+					'allow_external_pads' => 'yes',
+					'external_pad_allowlist' => '',
+					default => $default,
+				};
+			}
+		);
+
+		$listener = new CSPListener($config);
+		$event = new AddContentSecurityPolicyEvent();
+
+		$listener->handle($event);
+
+		$this->assertSame([], $event->getPolicies());
 	}
 }


### PR DESCRIPTION
## Problem

`CSPListener` handles **every** `AddContentSecurityPolicyEvent`. When external pads were enabled (`allow_external_pads=yes`) with an empty `external_pad_allowlist`, it emitted a blanket `https:` into `frame-src`/`child-src` — loosening framing on **all** Nextcloud pages, not just pad pages.

## Fix

External pads are rendered as locally fetched read-only snapshots (no live iframe to the external host), so the blanket relaxation bought nothing and only widened the site-wide framing surface. An empty allowlist now contributes **no** frame domains; only concrete allowlisted hosts (plus the configured local Etherpad host) are ever added to `frame-src`/`child-src`.

The server-side snapshot fetch keeps its existing "empty allowlist = allow all public HTTPS hosts" behaviour (`ExternalPadExportFetcher`, still guarded by the public-IP / DNS-rebinding checks). Only the browser-facing CSP is tightened — so this fixes all existing installs immediately, with no admin re-save required.

## Acceptance

- [x] No config path emits `frame-src https:` globally
- [x] External pads still load when a host is allowlisted (concrete-host framing unchanged)
- [x] Test covers the empty-allowlist case

## Verification

- `phpunit`: 399 tests green (CSP suite covers empty-allowlist + no-local-host cases asserting no `https:` blanket).
- Live on NC 33 in the exact vulnerable config (`allow_external_pads=yes`, empty allowlist): the served login-page CSP is now
  ```
  frame-src https://pad.jaggob.uber.space 'self' nc: https://demo.eu.collaboraonline.com
  child-src https://pad.jaggob.uber.space
  ```
  — concrete host only, no blanket `https:`.

Closes #102.