### PR TITLE
chore: remove dead code (#104)

### DIFF
--- a/lib/Service/EtherpadClient.php
+++ b/lib/Service/EtherpadClient.php
@@ -94,13 +94,6 @@ class EtherpadClient {
 		return $authorId;
 	}
 
-	public function setAuthorName(string $authorId, string $name): void {
-		$this->apiCall('setAuthorName', [
-			'authorID' => $authorId,
-			'name' => $name,
-		], 'POST');
-	}
-
 	public function createSession(string $groupId, string $authorId, int $validUntil): string {
 		$data = $this->apiCall('createSession', [
 			'groupID' => $groupId,

--- a/lib/Service/ExternalPadExportFetcher.php
+++ b/lib/Service/ExternalPadExportFetcher.php
@@ -21,11 +21,6 @@ class ExternalPadExportFetcher {
 	) {
 	}
 
-	public function getPublicTextFromPadUrl(string $padUrl): string {
-		$resolved = $this->resolveAndValidateExternalPublicPadUrl($padUrl);
-		return $this->getPublicTextFromResolvedExternalPad($resolved);
-	}
-
 	/** @return array{origin:string,pad_id:string,pad_url:string,text:string} */
 	public function normalizeAndFetchExternalPublicPadText(string $padUrl): array {
 		$resolved = $this->resolveAndValidateExternalPublicPadUrl($padUrl);
@@ -57,10 +52,6 @@ class ExternalPadExportFetcher {
 			'text' => $text,
 			'snapshot_unavailable' => $snapshotUnavailable,
 		];
-	}
-
-	public function assertPublicPadAvailable(string $padUrl): void {
-		$this->getPublicTextFromPadUrl($padUrl);
 	}
 
 	/** @return array{origin:string,pad_id:string,pad_url:string} */

--- a/lib/Service/PublicShareUrlBuilder.php
+++ b/lib/Service/PublicShareUrlBuilder.php
@@ -70,32 +70,4 @@ class PublicShareUrlBuilder {
 
 		return $base . '?path=' . rawurlencode($dir) . '&files=' . rawurlencode($fileName);
 	}
-
-	public function buildDownloadUrl(string $token, string $selectedRelativePath, bool $isFolderShare, string $fileName): string {
-		$base = $this->buildShareBaseUrl($token) . '/download';
-		if (!$isFolderShare) {
-			return $base;
-		}
-
-		$path = trim($selectedRelativePath, '/');
-		if ($path === '') {
-			return '';
-		}
-
-		$dir = dirname($path);
-		if ($dir === '.' || $dir === '') {
-			$dir = '/';
-		} else {
-			$dir = '/' . $dir;
-		}
-		$name = basename($path);
-		if ($name === '') {
-			$name = $fileName;
-		}
-		if ($name === '') {
-			return '';
-		}
-
-		return $base . '?path=' . rawurlencode($dir) . '&files=' . rawurlencode($name);
-	}
 }

--- a/tests/phpunit/unit/PublicShareUrlBuilderTest.php
+++ b/tests/phpunit/unit/PublicShareUrlBuilderTest.php
@@ -57,21 +57,6 @@ class PublicShareUrlBuilderTest extends TestCase {
 		}
 	}
 
-	public function testBuildDownloadUrlForSingleFileShare(): void {
-		$this->assertSame('/s/share-token/download', $this->buildBuilder()->buildDownloadUrl('share-token', '', false, 'Shared.pad'));
-	}
-
-	public function testBuildDownloadUrlForFolderShare(): void {
-		$this->assertSame(
-			'/s/share-token/download?path=%2FFolder&files=Shared.pad',
-			$this->buildBuilder()->buildDownloadUrl('share-token', '/Folder/Shared.pad', true, 'Shared.pad')
-		);
-	}
-
-	public function testBuildDownloadUrlReturnsEmptyForFolderShareWithoutSelection(): void {
-		$this->assertSame('', $this->buildBuilder()->buildDownloadUrl('share-token', '', true, 'Shared.pad'));
-	}
-
 	private function buildBuilder(string $webroot = ''): PublicShareUrlBuilder {
 		$urlGenerator = $this->createMock(IURLGenerator::class);
 		$urlGenerator->method('getWebroot')->willReturn($webroot);


### PR DESCRIPTION
Removes service methods with no production callers (each verified via repo-wide grep across `lib/ src/ templates/ appinfo/ tests/`):

- **`EtherpadClient::setAuthorName()`** — author name is synced via `createAuthorIfNotExistsFor`; no caller anywhere.
- **`ExternalPadExportFetcher::assertPublicPadAvailable()`** + its only caller **`getPublicTextFromPadUrl()`** — the latter was reachable solely through the former, so both are dead once `assertPublicPadAvailable` goes. The shared helpers (`resolveAndValidateExternalPublicPadUrl`, `getPublicTextFromResolvedExternalPad`) stay — they back the still-used `normalizeAndFetch*` methods.
- **`PublicShareUrlBuilder::buildDownloadUrl()`** — referenced only by its own three unit tests; method + those tests removed.

## Acceptance
- [x] Methods + now-orphaned tests removed
- [x] `phpunit` (396) + `vitest` (107) green

## Verification
- PHPUnit 396 (399 − 3 removed `buildDownloadUrl` tests), vitest 107 green.
- No frontend source touched → no `js/` rebuild.
- Deployed to NC 33 + full Playwright suite **23 passed, 0 flaky** — confirms no production path relied on the removed methods.

Closes #104.