### PR TITLE
chore: align version metadata + version-consistency CI guard (#107, #119)

### DIFF
--- a/.github/workflows/lint-info-xml.yml
+++ b/.github/workflows/lint-info-xml.yml
@@ -35,3 +35,34 @@ jobs:
         with:
           xml-file: ./appinfo/info.xml
           xml-schema-file: ./info.xsd
+
+  version-consistency:
+    runs-on: ubuntu-latest
+
+    name: version consistency
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      # appinfo/info.xml is the single source of truth for the app version.
+      # package.json / package-lock.json are aligned manually, so guard against
+      # drift (#119): fail the build if they disagree.
+      - name: Compare info.xml and package.json versions
+        run: |
+          INFO_VERSION="$(grep -oE '<version>[^<]+</version>' appinfo/info.xml | sed -E 's|</?version>||g' | head -n1)"
+          PKG_VERSION="$(jq -r '.version' package.json)"
+          LOCK_VERSION="$(jq -r '.version' package-lock.json)"
+          echo "info.xml:          $INFO_VERSION"
+          echo "package.json:      $PKG_VERSION"
+          echo "package-lock.json: $LOCK_VERSION"
+          if [ -z "$INFO_VERSION" ]; then
+            echo "::error::could not read <version> from appinfo/info.xml" >&2
+            exit 1
+          fi
+          if [ "$PKG_VERSION" != "$INFO_VERSION" ] || [ "$LOCK_VERSION" != "$INFO_VERSION" ]; then
+            echo "::error::Version mismatch. appinfo/info.xml is the source of truth ($INFO_VERSION); align package.json and package-lock.json to it." >&2
+            exit 1
+          fi

--- a/.github/workflows/lint-info-xml.yml
+++ b/.github/workflows/lint-info-xml.yml
@@ -55,14 +55,19 @@ jobs:
           INFO_VERSION="$(grep -oE '<version>[^<]+</version>' appinfo/info.xml | sed -E 's|</?version>||g' | head -n1)"
           PKG_VERSION="$(jq -r '.version' package.json)"
           LOCK_VERSION="$(jq -r '.version' package-lock.json)"
-          echo "info.xml:          $INFO_VERSION"
-          echo "package.json:      $PKG_VERSION"
-          echo "package-lock.json: $LOCK_VERSION"
+          # npm stores the version twice in the lockfile: the top-level
+          # .version and the root package entry .packages[""].version. Check
+          # both so drift inside the lockfile is caught too.
+          LOCK_PKG_VERSION="$(jq -r '.packages[""].version' package-lock.json)"
+          echo "info.xml:                       $INFO_VERSION"
+          echo "package.json:                   $PKG_VERSION"
+          echo "package-lock.json (.version):   $LOCK_VERSION"
+          echo "package-lock.json (packages[\"\"]): $LOCK_PKG_VERSION"
           if [ -z "$INFO_VERSION" ]; then
             echo "::error::could not read <version> from appinfo/info.xml" >&2
             exit 1
           fi
-          if [ "$PKG_VERSION" != "$INFO_VERSION" ] || [ "$LOCK_VERSION" != "$INFO_VERSION" ]; then
-            echo "::error::Version mismatch. appinfo/info.xml is the source of truth ($INFO_VERSION); align package.json and package-lock.json to it." >&2
+          if [ "$PKG_VERSION" != "$INFO_VERSION" ] || [ "$LOCK_VERSION" != "$INFO_VERSION" ] || [ "$LOCK_PKG_VERSION" != "$INFO_VERSION" ]; then
+            echo "::error::Version mismatch. appinfo/info.xml is the source of truth ($INFO_VERSION); align package.json and both version fields in package-lock.json to it." >&2
             exit 1
           fi

--- a/js/api-client-BXEMiUh7.chunk.mjs.license
+++ b/js/api-client-BXEMiUh7.chunk.mjs.license
@@ -3,5 +3,5 @@ SPDX-FileCopyrightText: etherpad-nextcloud developers
 
 This file is generated from multiple sources. Included packages:
 - etherpad-nextcloud
-	- version: 1.0.0
+	- version: 1.1.0-alpha.2
 	- license: AGPL-3.0-or-later

--- a/js/etherpad_nextcloud-admin-settings.mjs.license
+++ b/js/etherpad_nextcloud-admin-settings.mjs.license
@@ -3,5 +3,5 @@ SPDX-FileCopyrightText: etherpad-nextcloud developers
 
 This file is generated from multiple sources. Included packages:
 - etherpad-nextcloud
-	- version: 1.0.0
+	- version: 1.1.0-alpha.2
 	- license: AGPL-3.0-or-later

--- a/js/etherpad_nextcloud-embed-create-main.mjs.license
+++ b/js/etherpad_nextcloud-embed-create-main.mjs.license
@@ -3,5 +3,5 @@ SPDX-FileCopyrightText: etherpad-nextcloud developers
 
 This file is generated from multiple sources. Included packages:
 - etherpad-nextcloud
-	- version: 1.0.0
+	- version: 1.1.0-alpha.2
 	- license: AGPL-3.0-or-later

--- a/js/etherpad_nextcloud-embed-main.mjs.license
+++ b/js/etherpad_nextcloud-embed-main.mjs.license
@@ -3,5 +3,5 @@ SPDX-FileCopyrightText: etherpad-nextcloud developers
 
 This file is generated from multiple sources. Included packages:
 - etherpad-nextcloud
-	- version: 1.0.0
+	- version: 1.1.0-alpha.2
 	- license: AGPL-3.0-or-later

--- a/js/etherpad_nextcloud-files-main.mjs.license
+++ b/js/etherpad_nextcloud-files-main.mjs.license
@@ -3,5 +3,5 @@ SPDX-FileCopyrightText: etherpad-nextcloud developers
 
 This file is generated from multiple sources. Included packages:
 - etherpad-nextcloud
-	- version: 1.0.0
+	- version: 1.1.0-alpha.2
 	- license: AGPL-3.0-or-later

--- a/js/etherpad_nextcloud-viewer-main.mjs.license
+++ b/js/etherpad_nextcloud-viewer-main.mjs.license
@@ -3,5 +3,5 @@ SPDX-FileCopyrightText: etherpad-nextcloud developers
 
 This file is generated from multiple sources. Included packages:
 - etherpad-nextcloud
-	- version: 1.0.0
+	- version: 1.1.0-alpha.2
 	- license: AGPL-3.0-or-later

--- a/js/fetch-helpers-C4MxuNvt.chunk.mjs.license
+++ b/js/fetch-helpers-C4MxuNvt.chunk.mjs.license
@@ -3,5 +3,5 @@ SPDX-FileCopyrightText: etherpad-nextcloud developers
 
 This file is generated from multiple sources. Included packages:
 - etherpad-nextcloud
-	- version: 1.0.0
+	- version: 1.1.0-alpha.2
 	- license: AGPL-3.0-or-later

--- a/js/oc-compat-hVqZy-MX.chunk.mjs.license
+++ b/js/oc-compat-hVqZy-MX.chunk.mjs.license
@@ -3,5 +3,5 @@ SPDX-FileCopyrightText: etherpad-nextcloud developers
 
 This file is generated from multiple sources. Included packages:
 - etherpad-nextcloud
-	- version: 1.0.0
+	- version: 1.1.0-alpha.2
 	- license: AGPL-3.0-or-later

--- a/lib/Service/EtherpadClient.php
+++ b/lib/Service/EtherpadClient.php
@@ -12,7 +12,7 @@ use OCA\EtherpadNextcloud\Exception\EtherpadClientException;
 use OCP\IConfig;
 
 class EtherpadClient {
-	public const DEFAULT_API_VERSION = '1.2.15';
+	public const DEFAULT_API_VERSION = '1.3.0';
 
 	private const EXTERNAL_REQUEST_TIMEOUT_SECONDS = 15;
 

--- a/lib/Service/EtherpadClient.php
+++ b/lib/Service/EtherpadClient.php
@@ -12,7 +12,17 @@ use OCA\EtherpadNextcloud\Exception\EtherpadClientException;
 use OCP\IConfig;
 
 class EtherpadClient {
-	public const DEFAULT_API_VERSION = '1.3.0';
+	/**
+	 * Failsafe fallback API version, used only when auto-detection fails AND no
+	 * etherpad_api_version is stored. Deliberately kept LOW, not bumped to the
+	 * newest release: Etherpad's API version list is cumulative, so a newer
+	 * server accepts any older version while rejecting one higher than it
+	 * supports. Requesting a low version therefore maximises compatibility in
+	 * exactly the degraded path where this constant matters, and the plugin
+	 * uses no method newer than ~1.2.1 (it never passes the authorId param that
+	 * 1.3.0 added). Only raise this if we start relying on a newer-API feature.
+	 */
+	public const DEFAULT_API_VERSION = '1.2.15';
 
 	private const EXTERNAL_REQUEST_TIMEOUT_SECONDS = 15;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "etherpad-nextcloud",
-	"version": "1.0.0",
+	"version": "1.1.0-alpha.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "etherpad-nextcloud",
-			"version": "1.0.0",
+			"version": "1.1.0-alpha.2",
 			"license": "AGPL-3.0-or-later",
 			"devDependencies": {
 				"@nextcloud/vite-config": "^2.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "etherpad-nextcloud",
-	"version": "1.0.0",
+	"version": "1.1.0-alpha.2",
 	"private": true,
 	"license": "AGPL-3.0-or-later",
 	"type": "module",


### PR DESCRIPTION
## Changes
- **`appinfo/info.xml` is the single source of truth** for the app version (the release tarball script already derives the version from `<version>`). Aligned the stale `package.json` / `package-lock.json` (`1.0.0`) to info.xml's `1.1.0-alpha.2`. `package.json`'s version is `private` and not consumed by the Vite build, so this is purely metadata-consistency.
- Regenerated the `js/*.license` SPDX sidecars — the Vite license plugin embeds `package.json`'s version into them, so the bump changes those generated files (the `.mjs` bundles are unchanged). Needed for the #101 stale-js guard.
- **`EtherpadClient::DEFAULT_API_VERSION` stays at `1.2.15`** (see below) with an inline comment documenting why it is intentionally conservative.
- **New CI guard** (`lint-info-xml.yml` → `version-consistency` job): fails the build when `info.xml`, `package.json` and `package-lock.json` versions disagree, so the metadata can't silently drift again. This folds in the #119 follow-up directly.

## Why not bump the API fallback
`DEFAULT_API_VERSION` is a **failsafe**, used only when auto-detection fails *and* no `etherpad_api_version` is stored. Etherpad's API version list is cumulative: a newer server accepts any older requested version, while a request *higher* than the server supports is rejected. So a **lower** fallback maximises compatibility in exactly the degraded path where the constant matters, and the plugin uses no method newer than ~1.2.1 (it never passes the `authorId` param 1.3.0 added). Bumping the failsafe would trade a tiny compatibility loss for zero functional gain. In normal operation the detected/stored version wins anyway. Documented inline so it isn't re-bumped.

## Acceptance
- [x] Versions consistent across `package.json` / `info.xml` (both `1.1.0-alpha.2`)
- [x] `DEFAULT_API_VERSION` reviewed — intentionally kept at the conservative `1.2.15`, with rationale documented
- [x] CI guards against future version drift (#119)

## Verification
- PHPUnit 396 green; version-consistency check passes locally (`info=pkg=lock=1.1.0-alpha.2`).
- Full Playwright suite: pending a clean run (local network instability tainted the last attempts) — to be confirmed before merge.

Closes #107.
Closes #119.