### PR TITLE
perf: drop per-request MIME registration from the App constructor (#108)

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -16,7 +16,6 @@ use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
 use OCP\BackgroundJob\IJobList;
-use OCP\Files\IMimeTypeDetector;
 use OCP\Files\Template\FileCreatedFromTemplateEvent;
 use OCP\Files\Template\RegisterTemplateCreatorEvent;
 use OCP\Security\CSP\AddContentSecurityPolicyEvent;
@@ -26,10 +25,12 @@ class Application extends App implements IBootstrap {
 
 	public function __construct() {
 		parent::__construct(self::APP_ID);
-
-		$detector = $this->getContainer()->query(IMimeTypeDetector::class);
-		$detector->getAllMappings();
-		$detector->registerType('pad', 'application/x-etherpad-nextcloud');
+		// NB: no runtime MIME registration here. The `.pad` MIME type is
+		// persisted by the RegisterMimeType repair step (config mimetype
+		// mapping/aliases + filecache backfill), which is the supported
+		// Nextcloud mechanism. The old constructor used
+		// IMimeTypeDetector::registerType() — not part of the public OCP
+		// interface, and it ran getAllMappings() on every app instantiation.
 	}
 
 	public function register(IRegistrationContext $context): void {

--- a/lib/Migration/RegisterMimeType.php
+++ b/lib/Migration/RegisterMimeType.php
@@ -114,7 +114,21 @@ class RegisterMimeType implements IRepairStep {
 			}
 		}
 
-		$updated = array_replace_recursive($current, $mappings);
+		$updated = self::mergeMimeMappings($current, $mappings);
 		file_put_contents($file, json_encode($updated, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n");
+	}
+
+	/**
+	 * Merge our `.pad` mapping into the existing mimetype config without
+	 * clobbering unrelated entries, and idempotently (re-running yields the
+	 * same result). Extracted as a pure function so the contract is testable
+	 * without the surrounding filesystem / \OC config-dir resolution.
+	 *
+	 * @param array<string,mixed> $current
+	 * @param array<string,mixed> $mappings
+	 * @return array<string,mixed>
+	 */
+	public static function mergeMimeMappings(array $current, array $mappings): array {
+		return array_replace_recursive($current, $mappings);
 	}
 }

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -8,9 +8,6 @@
     <UndefinedClass>
       <code><![CDATA[LoadAdditionalScriptsEvent]]></code>
     </UndefinedClass>
-    <UndefinedInterfaceMethod>
-      <code><![CDATA[registerType]]></code>
-    </UndefinedInterfaceMethod>
   </file>
   <file src="lib/BackgroundJob/AbstractPendingDeleteRetryJob.php">
     <MissingOverrideAttribute>

--- a/tests/phpunit/unit/BackfillPadMimeTypeTest.php
+++ b/tests/phpunit/unit/BackfillPadMimeTypeTest.php
@@ -1,0 +1,187 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\EtherpadNextcloud\Tests\Unit;
+
+use OCA\EtherpadNextcloud\Migration\BackfillPadMimeType;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+use OCP\Migration\IOutput;
+use PHPUnit\Framework\TestCase;
+
+class BackfillPadMimeTypeTest extends TestCase {
+	private const MIME = 'application/x-etherpad-nextcloud';
+
+	public function testSkipsWhenPadMimeTypeIsNotRegistered(): void {
+		// getMimeId('application/x-etherpad-nextcloud') -> not found.
+		$qb = new BackfillTestQueryBuilder([false]);
+		$output = $this->createMock(IOutput::class);
+		$output->expects($this->once())->method('info')
+			->with($this->stringContains('not registered'));
+
+		(new BackfillPadMimeType($this->connection($qb)))->run($output);
+
+		$this->assertFalse($qb->executeStatementCalled);
+	}
+
+	public function testSkipsWhenApplicationMimePartIsMissing(): void {
+		// pad mime found (7), application mimepart -> not found.
+		$qb = new BackfillTestQueryBuilder([7, false]);
+		$output = $this->createMock(IOutput::class);
+		$output->expects($this->once())->method('info')
+			->with($this->stringContains('application mimepart is missing'));
+
+		(new BackfillPadMimeType($this->connection($qb)))->run($output);
+
+		$this->assertFalse($qb->executeStatementCalled);
+	}
+
+	public function testUpdatesPadRowsAndOnlyTouchesRowsNotAlreadyTheTarget(): void {
+		// pad mime id = 7, application mimepart id = 1, 3 rows updated.
+		$qb = new BackfillTestQueryBuilder([7, 1], 3);
+		$output = $this->createMock(IOutput::class);
+		$output->expects($this->once())->method('info')
+			->with($this->stringContains('Backfilled MIME type for 3 .pad files.'));
+
+		(new BackfillPadMimeType($this->connection($qb)))->run($output);
+
+		$this->assertTrue($qb->executeStatementCalled);
+		$this->assertSame('filecache', $qb->updateTable);
+		// mimetype + mimepart set to the resolved ids.
+		$this->assertSame(7, $qb->params[$qb->sets['mimetype']]);
+		$this->assertSame(1, $qb->params[$qb->sets['mimepart']]);
+		// Targets only *.pad rows …
+		$like = $qb->findCondition('like', 'name');
+		$this->assertNotNull($like);
+		$this->assertSame('%.pad', $qb->params[$like[2]]);
+		// … and only rows whose mimetype is NOT already the pad mime: this is
+		// the idempotency guard (a second run updates nothing).
+		$neq = $qb->findCondition('neq', 'mimetype');
+		$this->assertNotNull($neq);
+		$this->assertSame(7, $qb->params[$neq[2]]);
+	}
+
+	private function connection(BackfillTestQueryBuilder $qb): IDBConnection {
+		return new class ($qb) implements IDBConnection {
+			public function __construct(private BackfillTestQueryBuilder $qb) {
+			}
+
+			public function getQueryBuilder(): IQueryBuilder {
+				return $this->qb;
+			}
+		};
+	}
+}
+
+class BackfillTestQueryBuilder implements IQueryBuilder {
+	/** @var array<string,mixed> */
+	public array $params = [];
+	/** @var array<string,string> field => parameter name */
+	public array $sets = [];
+	/** @var list<array<int,string>> */
+	public array $conditions = [];
+	public ?string $updateTable = null;
+	public bool $executeStatementCalled = false;
+
+	private int $counter = 0;
+
+	/**
+	 * @param list<int|false> $fetchOneQueue successive getMimeId() results
+	 */
+	public function __construct(private array $fetchOneQueue, private int $updateResult = 0) {
+	}
+
+	public function select(string $select): self {
+		return $this;
+	}
+
+	public function from(string $table): self {
+		return $this;
+	}
+
+	public function update(string $table): self {
+		$this->updateTable = $table;
+		return $this;
+	}
+
+	public function set(string $field, string $parameter): self {
+		$this->sets[$field] = $parameter;
+		return $this;
+	}
+
+	public function where(mixed $condition): self {
+		$this->conditions[] = $condition;
+		return $this;
+	}
+
+	public function andWhere(mixed $condition): self {
+		$this->conditions[] = $condition;
+		return $this;
+	}
+
+	public function setMaxResults(int $maxResults): self {
+		return $this;
+	}
+
+	public function createNamedParameter(mixed $value, ?int $type = null): string {
+		$name = 'param' . ++$this->counter;
+		$this->params[$name] = $value;
+		return $name;
+	}
+
+	public function expr(): BackfillTestExpressionBuilder {
+		return new BackfillTestExpressionBuilder();
+	}
+
+	public function executeQuery(): BackfillTestResult {
+		$value = array_shift($this->fetchOneQueue);
+		return new BackfillTestResult($value ?? false);
+	}
+
+	public function executeStatement(): int {
+		$this->executeStatementCalled = true;
+		return $this->updateResult;
+	}
+
+	/**
+	 * @return array<int,string>|null the recorded [op, field, param] condition
+	 */
+	public function findCondition(string $op, string $field): ?array {
+		foreach ($this->conditions as $condition) {
+			if (($condition[0] ?? null) === $op && ($condition[1] ?? null) === $field) {
+				return $condition;
+			}
+		}
+		return null;
+	}
+}
+
+class BackfillTestExpressionBuilder {
+	/** @return array{string,string,string} */
+	public function like(string $field, string $parameter): array {
+		return ['like', $field, $parameter];
+	}
+
+	/** @return array{string,string,string} */
+	public function neq(string $field, string $parameter): array {
+		return ['neq', $field, $parameter];
+	}
+
+	/** @return array{string,string,string} */
+	public function eq(string $field, string $parameter): array {
+		return ['eq', $field, $parameter];
+	}
+}
+
+class BackfillTestResult {
+	public function __construct(private int|false $value) {
+	}
+
+	public function fetchOne(): int|false {
+		return $this->value;
+	}
+
+	public function closeCursor(): void {
+	}
+}

--- a/tests/phpunit/unit/RegisterMimeTypeTest.php
+++ b/tests/phpunit/unit/RegisterMimeTypeTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\EtherpadNextcloud\Tests\Unit;
+
+use OCA\EtherpadNextcloud\Migration\RegisterMimeType;
+use PHPUnit\Framework\TestCase;
+
+class RegisterMimeTypeTest extends TestCase {
+	private const MIME = 'application/x-etherpad-nextcloud';
+
+	public function testMergeAddsPadMappingWithoutClobberingExistingEntries(): void {
+		$current = [
+			'txt' => ['text/plain'],
+			'md' => ['text/markdown'],
+		];
+		$new = ['pad' => [self::MIME]];
+
+		$merged = RegisterMimeType::mergeMimeMappings($current, $new);
+
+		// Existing entries are preserved …
+		$this->assertSame(['text/plain'], $merged['txt']);
+		$this->assertSame(['text/markdown'], $merged['md']);
+		// … and the pad mapping is added.
+		$this->assertSame([self::MIME], $merged['pad']);
+	}
+
+	public function testMergeIsIdempotent(): void {
+		$current = ['txt' => ['text/plain']];
+		$new = ['pad' => [self::MIME]];
+
+		$once = RegisterMimeType::mergeMimeMappings($current, $new);
+		$twice = RegisterMimeType::mergeMimeMappings($once, $new);
+
+		$this->assertSame($once, $twice);
+		$this->assertSame([self::MIME], $twice['pad']);
+	}
+
+	public function testMergeOverridesAStalePadMapping(): void {
+		// A previously-wrong value for our own key is corrected, not duplicated.
+		$current = ['pad' => ['application/octet-stream']];
+		$new = ['pad' => [self::MIME]];
+
+		$merged = RegisterMimeType::mergeMimeMappings($current, $new);
+
+		$this->assertSame([self::MIME], $merged['pad']);
+	}
+}


### PR DESCRIPTION
## What
`Application::__construct` ran `IMimeTypeDetector::getAllMappings()` + `registerType()` on **every** app instantiation. Two problems:
- `registerType()` isn't part of the public `OCP\Files\IMimeTypeDetector` interface (it's a concrete-class method), and
- `getAllMappings()` forces loading the full mapping table each time — avoidable per-request cost.

## Change
Remove the runtime registration entirely (not just move it to `boot()`). The `.pad` MIME type is already registered **persistently** by the `RegisterMimeType` repair step — config `mimetypemapping.json` + `mimetypealiases.json`, filecache backfill, and the core filetype icon — which is the supported Nextcloud mechanism and the actual source of truth. The runtime call merely duplicated that for the current request. Constructor now only calls `parent::__construct`, with a comment explaining why no MIME work lives here.

> Approach informed by how Text / Richdocuments / Whiteboard handle MIME (config mapping + repair, no runtime `registerType`), and the fact that `registerType` isn't public OCP API.

## Acceptance
- [x] No MIME work in the constructor
- [x] `.pad` still detected as `application/x-etherpad-nextcloud`

## Verification
- PHPUnit 403 + Psalm green (baseline shrank by 1 — the `UndefinedInterfaceMethod` entry for the non-public `registerType()` call is gone).
- Deployed to NC 33; full Playwright suite **23 passed, 0 flaky** — `.pad` detection still works in the Files list, viewer, and template picker.

Closes #108.