### PR TITLE
chore(psalm): reduce baseline noise — suppress + stubs + redundant casts (#122)

### DIFF
--- a/lib/Exception/PadFileLockRetryExhaustedException.php
+++ b/lib/Exception/PadFileLockRetryExhaustedException.php
@@ -16,7 +16,7 @@ class PadFileLockRetryExhaustedException extends \RuntimeException {
 		private int $retryAttempts,
 		private LockedException $lockedException,
 	) {
-		parent::__construct($lockedException->getMessage(), (int)$lockedException->getCode(), $lockedException);
+		parent::__construct($lockedException->getMessage(), $lockedException->getCode(), $lockedException);
 	}
 
 	public function getRetryAttempts(): int {

--- a/lib/Listeners/CSPListener.php
+++ b/lib/Listeners/CSPListener.php
@@ -86,9 +86,9 @@ class CSPListener implements IEventListener {
 			if (!is_array($parts)) {
 				return null;
 			}
-			$scheme = strtolower((string)($parts['scheme'] ?? ''));
-			$host = strtolower((string)($parts['host'] ?? ''));
-			$port = isset($parts['port']) ? (int)$parts['port'] : 443;
+			$scheme = strtolower($parts['scheme'] ?? '');
+			$host = strtolower($parts['host'] ?? '');
+			$port = isset($parts['port']) ? $parts['port'] : 443;
 			if ($scheme !== 'https' || $host === '' || $port <= 0 || $port > 65535) {
 				return null;
 			}

--- a/lib/Service/AdminSettingsValidator.php
+++ b/lib/Service/AdminSettingsValidator.php
@@ -124,7 +124,7 @@ class AdminSettingsValidator {
 			throw new AdminValidationException('etherpad_api_host', $this->l10n->t('Etherpad API URL must not include query or fragment.'));
 		}
 
-		$scheme = strtolower((string)$parts['scheme']);
+		$scheme = strtolower($parts['scheme']);
 		if (!in_array($scheme, ['http', 'https'], true)) {
 			throw new AdminValidationException('etherpad_api_host', $this->l10n->t('Etherpad API URL must use http or https.'));
 		}

--- a/lib/Service/AllowlistNormalizer.php
+++ b/lib/Service/AllowlistNormalizer.php
@@ -47,10 +47,10 @@ class AllowlistNormalizer {
 			);
 		}
 
-		$scheme = strtolower((string)($parts['scheme'] ?? ''));
-		$host = strtolower((string)($parts['host'] ?? ''));
-		$port = isset($parts['port']) ? (int)$parts['port'] : 443;
-		$path = (string)($parts['path'] ?? '');
+		$scheme = strtolower($parts['scheme'] ?? '');
+		$host = strtolower($parts['host'] ?? '');
+		$port = isset($parts['port']) ? $parts['port'] : 443;
+		$path = $parts['path'] ?? '';
 
 		if ($scheme !== 'https' || $host === '' || $port <= 0 || $port > 65535 || ($path !== '' && $path !== '/')
 			|| isset($parts['user']) || isset($parts['pass']) || isset($parts['query']) || isset($parts['fragment'])

--- a/lib/Service/EtherpadClient.php
+++ b/lib/Service/EtherpadClient.php
@@ -270,9 +270,9 @@ class EtherpadClient {
 		if ($parts === false || empty($parts['scheme']) || empty($parts['host'])) {
 			return '';
 		}
-		$scheme = strtolower((string)$parts['scheme']);
-		$host = strtolower((string)$parts['host']);
-		$port = isset($parts['port']) ? (int)$parts['port'] : null;
+		$scheme = strtolower($parts['scheme']);
+		$host = strtolower($parts['host']);
+		$port = isset($parts['port']) ? $parts['port'] : null;
 		$isDefaultPort = ($scheme === 'https' && $port === 443) || ($scheme === 'http' && $port === 80);
 		if ($port === null || $isDefaultPort) {
 			return $scheme . '://' . $host;

--- a/lib/Service/EtherpadHealthCheckService.php
+++ b/lib/Service/EtherpadHealthCheckService.php
@@ -51,7 +51,7 @@ class EtherpadHealthCheckService {
 			// path leaks the literal '{detail}' through to consumers in
 			// some catalog setups. Doing the substitution here removes that
 			// surface area.
-			$template = (string)$this->l10n->t('Etherpad connection test failed: {detail}');
+			$template = $this->l10n->t('Etherpad connection test failed: {detail}');
 			throw new AdminHealthCheckException(
 				str_replace('{detail}', $detail, $template),
 				0,

--- a/lib/Service/ExternalPadExportFetcher.php
+++ b/lib/Service/ExternalPadExportFetcher.php
@@ -284,9 +284,9 @@ class ExternalPadExportFetcher {
 		if (!is_array($parts)) {
 			return '';
 		}
-		$scheme = strtolower((string)($parts['scheme'] ?? ''));
-		$host = strtolower((string)($parts['host'] ?? ''));
-		$port = isset($parts['port']) ? (int)$parts['port'] : 443;
+		$scheme = strtolower($parts['scheme'] ?? '');
+		$host = strtolower($parts['host'] ?? '');
+		$port = isset($parts['port']) ? $parts['port'] : 443;
 		if ($scheme !== 'https' || $host === '' || $port <= 0 || $port > 65535) {
 			return '';
 		}
@@ -308,10 +308,10 @@ class ExternalPadExportFetcher {
 			throw new EtherpadClientException('Public pad URL must not contain credentials.');
 		}
 
-		$scheme = strtolower((string)($parts['scheme'] ?? ''));
-		$host = strtolower((string)($parts['host'] ?? ''));
-		$port = isset($parts['port']) ? (int)$parts['port'] : 443;
-		$path = (string)($parts['path'] ?? '');
+		$scheme = strtolower($parts['scheme'] ?? '');
+		$host = strtolower($parts['host'] ?? '');
+		$port = isset($parts['port']) ? $parts['port'] : 443;
+		$path = $parts['path'] ?? '';
 		// `+` is literal in URL path segments — only query/form bodies treat
 		// it as a space. Using urldecode here turned `/p/team+pad` into
 		// pad-id `team pad`, then re-encoded to `/p/team%20pad` at fetch
@@ -325,8 +325,8 @@ class ExternalPadExportFetcher {
 			throw new EtherpadClientException('Public pad URL must match /p/{padId}.');
 		}
 
-		$basePath = rtrim((string)$matches[1], '/');
-		$padId = trim((string)$matches[2]);
+		$basePath = rtrim($matches[1], '/');
+		$padId = trim($matches[2]);
 		if ($padId === '') {
 			throw new EtherpadClientException('Invalid public pad URL.');
 		}

--- a/lib/Service/LifecycleService.php
+++ b/lib/Service/LifecycleService.php
@@ -202,7 +202,7 @@ class LifecycleService {
 						if ($this->isTestFaultActive(self::TEST_FAULT_TRASH_WRITE_FAIL)) {
 							throw new \RuntimeException('Injected test fault: trash_write_fail');
 						}
-						$file->putContent((string)$updatedContent);
+						$file->putContent($updatedContent);
 						$snapshotPersisted = true;
 					} catch (LockedException $e) {
 						// Trash operation can hold a lock on the file node; do not block state transition/deletion.

--- a/lib/Service/PadFileService.php
+++ b/lib/Service/PadFileService.php
@@ -102,7 +102,7 @@ class PadFileService {
 			return null;
 		}
 
-		$url = trim((string)$matches[1]);
+		$url = trim($matches[1]);
 		if ($url === '' || preg_match('#^https?://#i', $url) !== 1) {
 			return null;
 		}
@@ -118,7 +118,7 @@ class PadFileService {
 		if (preg_match('~/p/([^/?#]+)$~', $decodedPath, $padMatches) !== 1) {
 			return null;
 		}
-		$padId = trim((string)$padMatches[1]);
+		$padId = trim($padMatches[1]);
 		if ($padId === '') {
 			return null;
 		}

--- a/lib/Service/PadOpenService.php
+++ b/lib/Service/PadOpenService.php
@@ -69,13 +69,13 @@ class PadOpenService {
 				throw new \RuntimeException('Could not resolve file ID.');
 			}
 
-			$pad = $this->padFileService->readPad((string)$content);
+			$pad = $this->padFileService->readPad($content);
 			$padId = $pad->padId;
 			$accessMode = $pad->accessMode;
 			$padUrl = $pad->padUrl;
 			$isExternal = $pad->isExternal;
 			$snapshot = $isExternal
-				? $this->snapshotExtractor->extract((string)$content)
+				? $this->snapshotExtractor->extract($content)
 				: new SnapshotPayload('', '');
 			if (!$isExternal) {
 				$this->bindingService->assertConsistentMapping($fileId, $padId, $accessMode);

--- a/lib/Service/TrustedEmbedOriginsNormalizer.php
+++ b/lib/Service/TrustedEmbedOriginsNormalizer.php
@@ -50,25 +50,25 @@ class TrustedEmbedOriginsNormalizer {
 		if (!is_array($parts) || !isset($parts['scheme'], $parts['host'])) {
 			return $this->invalid($throwOnInvalid, 'Trusted embed origins must be absolute origins: {origin}', $entry);
 		}
-		if (isset($parts['path']) && trim((string)$parts['path'], '/') !== '') {
+		if (isset($parts['path']) && trim($parts['path'], '/') !== '') {
 			return $this->invalid($throwOnInvalid, 'Trusted embed origins must not include a path: {origin}', $entry);
 		}
 		if (isset($parts['query']) || isset($parts['fragment']) || isset($parts['user']) || isset($parts['pass'])) {
 			return $this->invalid($throwOnInvalid, 'Trusted embed origins must not include credentials, query, or fragment: {origin}', $entry);
 		}
 
-		$scheme = strtolower((string)$parts['scheme']);
+		$scheme = strtolower($parts['scheme']);
 		if ($scheme !== 'https') {
 			return $this->invalid($throwOnInvalid, 'Trusted embed origins must use https: {origin}', $entry);
 		}
 
-		$host = strtolower((string)$parts['host']);
+		$host = strtolower($parts['host']);
 		if (str_contains($host, ':') && !str_starts_with($host, '[')) {
 			$host = '[' . $host . ']';
 		}
 		$origin = $scheme . '://' . $host;
 		if (isset($parts['port'])) {
-			$port = (int)$parts['port'];
+			$port = $parts['port'];
 			if ($port < 1 || $port > 65535) {
 				return $this->invalid($throwOnInvalid, 'Trusted embed origins must use a valid TCP port: {origin}', $entry);
 			}

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,18 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="6.16.1@f1f5de594dc76faf8784e02d3dc4716c91c6f6ac">
   <file src="lib/AppInfo/Application.php">
-    <MissingOverrideAttribute>
-      <code><![CDATA[public function boot(IBootContext $context): void {]]></code>
-      <code><![CDATA[public function register(IRegistrationContext $context): void {]]></code>
-    </MissingOverrideAttribute>
-    <UndefinedClass>
-      <code><![CDATA[LoadAdditionalScriptsEvent]]></code>
-    </UndefinedClass>
-  </file>
-  <file src="lib/BackgroundJob/AbstractPendingDeleteRetryJob.php">
-    <MissingOverrideAttribute>
-      <code><![CDATA[protected function run($argument): void {]]></code>
-    </MissingOverrideAttribute>
+    <InvalidArgument>
+      <code><![CDATA[registerEventListener]]></code>
+    </InvalidArgument>
   </file>
   <file src="lib/Controller/AdminController.php">
     <RedundantCondition>
@@ -21,13 +12,6 @@
     <TypeDoesNotContainType>
       <code><![CDATA[[]]]></code>
     </TypeDoesNotContainType>
-  </file>
-  <file src="lib/Controller/PublicViewerController.php">
-    <MissingOverrideAttribute>
-      <code><![CDATA[protected function getPasswordHash(): ?string {]]></code>
-      <code><![CDATA[protected function isPasswordProtected(): bool {]]></code>
-      <code><![CDATA[public function isValidToken(): bool {]]></code>
-    </MissingOverrideAttribute>
   </file>
   <file src="lib/Controller/PublicViewerControllerErrorMapper.php">
     <MismatchingDocblockParamType>
@@ -39,171 +23,53 @@
       <code><![CDATA[callable(mixed): RedirectResponse|TemplateResponse]]></code>
     </MismatchingDocblockParamType>
   </file>
-  <file src="lib/Exception/PadFileLockRetryExhaustedException.php">
-    <RedundantCast>
-      <code><![CDATA[(int)$lockedException->getCode()]]></code>
-    </RedundantCast>
-  </file>
   <file src="lib/Listeners/CSPListener.php">
-    <MissingOverrideAttribute>
-      <code><![CDATA[public function handle(Event $event): void {]]></code>
-    </MissingOverrideAttribute>
     <MissingTemplateParam>
       <code><![CDATA[IEventListener]]></code>
     </MissingTemplateParam>
-    <RedundantCast>
-      <code><![CDATA[(int)$parts['port']]]></code>
-      <code><![CDATA[(string)($parts['host'] ?? '')]]></code>
-      <code><![CDATA[(string)($parts['scheme'] ?? '')]]></code>
-    </RedundantCast>
   </file>
   <file src="lib/Listeners/FileCreatedFromTemplateListener.php">
-    <MissingOverrideAttribute>
-      <code><![CDATA[public function handle(Event $event): void {]]></code>
-    </MissingOverrideAttribute>
     <MissingTemplateParam>
       <code><![CDATA[IEventListener]]></code>
     </MissingTemplateParam>
   </file>
   <file src="lib/Listeners/LoadFilesScriptsListener.php">
-    <MissingOverrideAttribute>
-      <code><![CDATA[public function handle(Event $event): void {]]></code>
-    </MissingOverrideAttribute>
     <MissingTemplateParam>
       <code><![CDATA[IEventListener]]></code>
     </MissingTemplateParam>
-    <UndefinedClass>
-      <code><![CDATA[LoadAdditionalScriptsEvent]]></code>
-    </UndefinedClass>
   </file>
   <file src="lib/Listeners/LoadPublicShareScriptsListener.php">
-    <MissingOverrideAttribute>
-      <code><![CDATA[public function handle(Event $event): void {]]></code>
-    </MissingOverrideAttribute>
     <MissingTemplateParam>
       <code><![CDATA[IEventListener]]></code>
     </MissingTemplateParam>
-    <UndefinedClass>
-      <code><![CDATA[BeforeTemplateRenderedEvent]]></code>
-    </UndefinedClass>
   </file>
   <file src="lib/Listeners/LoadViewerListener.php">
-    <MissingOverrideAttribute>
-      <code><![CDATA[public function handle(Event $event): void {]]></code>
-    </MissingOverrideAttribute>
     <MissingTemplateParam>
       <code><![CDATA[IEventListener]]></code>
     </MissingTemplateParam>
-    <UndefinedClass>
-      <code><![CDATA[LoadViewer]]></code>
-    </UndefinedClass>
   </file>
   <file src="lib/Listeners/MoveToTrashListener.php">
-    <MissingOverrideAttribute>
-      <code><![CDATA[public function handle(Event $event): void {]]></code>
-    </MissingOverrideAttribute>
     <MissingTemplateParam>
       <code><![CDATA[IEventListener]]></code>
     </MissingTemplateParam>
   </file>
   <file src="lib/Listeners/RegisterTemplateCreatorListener.php">
-    <MissingOverrideAttribute>
-      <code><![CDATA[public function handle(Event $event): void {]]></code>
-    </MissingOverrideAttribute>
     <MissingTemplateParam>
       <code><![CDATA[IEventListener]]></code>
     </MissingTemplateParam>
   </file>
   <file src="lib/Listeners/RestoreFromTrashListener.php">
-    <MissingOverrideAttribute>
-      <code><![CDATA[public function handle(Event $event): void {]]></code>
-    </MissingOverrideAttribute>
     <MissingTemplateParam>
       <code><![CDATA[IEventListener]]></code>
     </MissingTemplateParam>
-    <UndefinedClass>
-      <code><![CDATA[$this->rootFolder]]></code>
-      <code><![CDATA[private]]></code>
-    </UndefinedClass>
-  </file>
-  <file src="lib/Migration/BackfillPadMimeType.php">
-    <MissingOverrideAttribute>
-      <code><![CDATA[public function getName(): string {]]></code>
-      <code><![CDATA[public function run(IOutput $output): void {]]></code>
-    </MissingOverrideAttribute>
-  </file>
-  <file src="lib/Migration/MarkApiKeySensitive.php">
-    <MissingOverrideAttribute>
-      <code><![CDATA[public function getName(): string {]]></code>
-      <code><![CDATA[public function run(IOutput $output): void {]]></code>
-    </MissingOverrideAttribute>
-  </file>
-  <file src="lib/Migration/RegisterMimeType.php">
-    <MissingOverrideAttribute>
-      <code><![CDATA[public function getName(): string {]]></code>
-      <code><![CDATA[public function run(IOutput $output): void {]]></code>
-    </MissingOverrideAttribute>
-    <UndefinedClass>
-      <code><![CDATA[\OC]]></code>
-      <code><![CDATA[\OC]]></code>
-      <code><![CDATA[\OC]]></code>
-      <code><![CDATA[\OC]]></code>
-      <code><![CDATA[\OC]]></code>
-      <code><![CDATA[\OC]]></code>
-    </UndefinedClass>
-  </file>
-  <file src="lib/Migration/Version000001Date20260304222000.php">
-    <MissingOverrideAttribute>
-      <code><![CDATA[public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {]]></code>
-    </MissingOverrideAttribute>
-    <UndefinedDocblockClass>
-      <code><![CDATA[$schema->createTable('ep_pad_bindings')]]></code>
-      <code><![CDATA[$table]]></code>
-      <code><![CDATA[$table]]></code>
-      <code><![CDATA[$table]]></code>
-      <code><![CDATA[$table]]></code>
-      <code><![CDATA[$table]]></code>
-      <code><![CDATA[$table]]></code>
-      <code><![CDATA[$table]]></code>
-      <code><![CDATA[$table]]></code>
-      <code><![CDATA[$table]]></code>
-      <code><![CDATA[$table]]></code>
-      <code><![CDATA[$table]]></code>
-      <code><![CDATA[$table]]></code>
-    </UndefinedDocblockClass>
-  </file>
-  <file src="lib/Migration/Version000002Date20260512170000.php">
-    <MissingOverrideAttribute>
-      <code><![CDATA[public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void {]]></code>
-    </MissingOverrideAttribute>
-  </file>
-  <file src="lib/Migration/Version000003Date20260512230000.php">
-    <MissingOverrideAttribute>
-      <code><![CDATA[public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void {]]></code>
-    </MissingOverrideAttribute>
   </file>
   <file src="lib/Preview/PadPreviewProvider.php">
-    <MissingOverrideAttribute>
-      <code><![CDATA[public function getMimeType(): string {]]></code>
-      <code><![CDATA[public function getThumbnail(File $file, int $maxX, int $maxY): ?IImage {]]></code>
-      <code><![CDATA[public function isAvailable(FileInfo $file): bool {]]></code>
-    </MissingOverrideAttribute>
-    <UndefinedClass>
-      <code><![CDATA[\OCP\Image]]></code>
-    </UndefinedClass>
-  </file>
-  <file src="lib/Service/AdminSettingsValidator.php">
-    <RedundantCast>
-      <code><![CDATA[(string)$parts['scheme']]]></code>
-    </RedundantCast>
-  </file>
-  <file src="lib/Service/AllowlistNormalizer.php">
-    <RedundantCast>
-      <code><![CDATA[(int)$parts['port']]]></code>
-      <code><![CDATA[(string)($parts['host'] ?? '')]]></code>
-      <code><![CDATA[(string)($parts['path'] ?? '')]]></code>
-      <code><![CDATA[(string)($parts['scheme'] ?? '')]]></code>
-    </RedundantCast>
+    <InvalidReturnStatement>
+      <code><![CDATA[$image]]></code>
+    </InvalidReturnStatement>
+    <InvalidReturnType>
+      <code><![CDATA[?IImage]]></code>
+    </InvalidReturnType>
   </file>
   <file src="lib/Service/ConsistencyCheckService.php">
     <RedundantCondition>
@@ -213,43 +79,16 @@
       <code><![CDATA[[]]]></code>
     </TypeDoesNotContainType>
   </file>
-  <file src="lib/Service/EmbedResponseBuilder.php">
-    <UndefinedClass>
-      <code><![CDATA[$this->csrfTokenManager]]></code>
-      <code><![CDATA[private]]></code>
-    </UndefinedClass>
-  </file>
-  <file src="lib/Service/EtherpadClient.php">
-    <RedundantCast>
-      <code><![CDATA[(int)$parts['port']]]></code>
-      <code><![CDATA[(string)$parts['host']]]></code>
-      <code><![CDATA[(string)$parts['scheme']]]></code>
-    </RedundantCast>
-  </file>
   <file src="lib/Service/EtherpadHealthCheckService.php">
     <InvalidOperand>
       <code><![CDATA[($this->now() - $startedAt) * 1000]]></code>
     </InvalidOperand>
-    <RedundantCast>
-      <code><![CDATA[(string)$this->l10n->t('Etherpad connection test failed: {detail}')]]></code>
-    </RedundantCast>
   </file>
   <file src="lib/Service/ExternalPadExportFetcher.php">
     <InvalidArgument>
       <code><![CDATA[$resolved]]></code>
       <code><![CDATA[$resolved]]></code>
     </InvalidArgument>
-    <RedundantCast>
-      <code><![CDATA[(int)$parts['port']]]></code>
-      <code><![CDATA[(int)$parts['port']]]></code>
-      <code><![CDATA[(string)$matches[1]]]></code>
-      <code><![CDATA[(string)$matches[2]]]></code>
-      <code><![CDATA[(string)($parts['host'] ?? '')]]></code>
-      <code><![CDATA[(string)($parts['host'] ?? '')]]></code>
-      <code><![CDATA[(string)($parts['path'] ?? '')]]></code>
-      <code><![CDATA[(string)($parts['scheme'] ?? '')]]></code>
-      <code><![CDATA[(string)($parts['scheme'] ?? '')]]></code>
-    </RedundantCast>
     <TypeDoesNotContainType>
       <code><![CDATA[$sizeExceeded]]></code>
       <code><![CDATA[$sizeExceeded]]></code>
@@ -267,15 +106,6 @@
       <code><![CDATA[array{status: string, reason?: string, file_id: int, old_pad_id?: string, new_pad_id?: string}]]></code>
       <code><![CDATA[array{status: string, reason?: string, file_id: int, old_pad_id?: string, new_pad_id?: string}]]></code>
     </InvalidReturnType>
-    <RedundantCast>
-      <code><![CDATA[(string)$updatedContent]]></code>
-    </RedundantCast>
-  </file>
-  <file src="lib/Service/PadCreateRollbackService.php">
-    <UndefinedClass>
-      <code><![CDATA[$this->rootFolder]]></code>
-      <code><![CDATA[private]]></code>
-    </UndefinedClass>
   </file>
   <file src="lib/Service/PadCreationService.php">
     <InvalidReturnStatement>
@@ -330,58 +160,11 @@
     <TypeDoesNotContainType>
       <code><![CDATA[$fileName === '']]></code>
     </TypeDoesNotContainType>
-    <UndefinedClass>
-      <code><![CDATA[$this->rootFolder]]></code>
-      <code><![CDATA[private]]></code>
-    </UndefinedClass>
-  </file>
-  <file src="lib/Service/PadFileService.php">
-    <RedundantCast>
-      <code><![CDATA[(string)$matches[1]]]></code>
-      <code><![CDATA[(string)$padMatches[1]]]></code>
-    </RedundantCast>
-  </file>
-  <file src="lib/Service/PadOpenService.php">
-    <RedundantCast>
-      <code><![CDATA[(string)$content]]></code>
-      <code><![CDATA[(string)$content]]></code>
-    </RedundantCast>
   </file>
   <file src="lib/Service/PublicShareUrlBuilder.php">
     <TypeDoesNotContainType>
       <code><![CDATA[$dir === '']]></code>
       <code><![CDATA[$fileName === '']]></code>
     </TypeDoesNotContainType>
-  </file>
-  <file src="lib/Service/TrustedEmbedOriginsNormalizer.php">
-    <RedundantCast>
-      <code><![CDATA[(int)$parts['port']]]></code>
-      <code><![CDATA[(string)$parts['host']]]></code>
-      <code><![CDATA[(string)$parts['path']]]></code>
-      <code><![CDATA[(string)$parts['scheme']]]></code>
-    </RedundantCast>
-  </file>
-  <file src="lib/Service/UserNodeResolver.php">
-    <UndefinedClass>
-      <code><![CDATA[$this->rootFolder]]></code>
-      <code><![CDATA[$this->rootFolder]]></code>
-      <code><![CDATA[$this->rootFolder]]></code>
-      <code><![CDATA[private]]></code>
-    </UndefinedClass>
-  </file>
-  <file src="lib/Settings/AdminSection.php">
-    <MissingOverrideAttribute>
-      <code><![CDATA[public function getID(): string {]]></code>
-      <code><![CDATA[public function getIcon(): string {]]></code>
-      <code><![CDATA[public function getName(): string {]]></code>
-      <code><![CDATA[public function getPriority(): int {]]></code>
-    </MissingOverrideAttribute>
-  </file>
-  <file src="lib/Settings/AdminSettings.php">
-    <MissingOverrideAttribute>
-      <code><![CDATA[public function getForm(): TemplateResponse {]]></code>
-      <code><![CDATA[public function getPriority(): int {]]></code>
-      <code><![CDATA[public function getSection(): string {]]></code>
-    </MissingOverrideAttribute>
   </file>
 </files>

--- a/psalm.xml
+++ b/psalm.xml
@@ -16,4 +16,30 @@
             <directory name="vendor" />
         </ignoreFiles>
     </projectFiles>
+    <issueHandlers>
+        <!-- The #[\Override] attribute is PHP 8.3+, but the app supports PHP
+             8.1+ (see appinfo/info.xml), so requiring it project-wide isn't
+             appropriate. -->
+        <MissingOverrideAttribute errorLevel="suppress" />
+        <!-- Classes that exist at runtime but aren't shipped in nextcloud/ocp
+             (and can't be cleanly stubbed because we call their API, or they
+             pull in further unshipped internals). IRootFolder & friends DO
+             resolve, via tests/psalm/missing-class-stubs.php. -->
+        <UndefinedClass>
+            <errorLevel type="suppress">
+                <referencedClass name="OCP\Image" />
+                <referencedClass name="OC" />
+                <referencedClass name="OC\Security\CSRF\CsrfTokenManager" />
+                <referencedClass name="Doctrine\DBAL\Schema\Table" />
+                <referencedClass name="OCA\Files\Event\LoadAdditionalScriptsEvent" />
+                <referencedClass name="OCA\Files_Sharing\Event\BeforeTemplateRenderedEvent" />
+                <referencedClass name="OCA\Viewer\Event\LoadViewer" />
+            </errorLevel>
+        </UndefinedClass>
+        <UndefinedDocblockClass>
+            <errorLevel type="suppress">
+                <referencedClass name="Doctrine\DBAL\Schema\Table" />
+            </errorLevel>
+        </UndefinedDocblockClass>
+    </issueHandlers>
 </psalm>

--- a/tests/psalm/missing-class-stubs.php
+++ b/tests/psalm/missing-class-stubs.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Minimal class stubs for Psalm analysis only.
+ *
+ * Some `nextcloud/ocp` public type files reference Nextcloud-internal `OC\…`
+ * classes the package does not ship — e.g. `OCP\Files\IRootFolder implements
+ * OC\Hooks\Emitter`. When Psalm's autoloader requires such an OCP file, the
+ * missing internal makes it fatal, so the OCP interface (and everything
+ * depending on it) shows up as `UndefinedClass`. Defining empty placeholders
+ * for those two internals lets the real OCP type files load, so Psalm gets the
+ * actual OCP API instead of treating it as undefined.
+ *
+ * Genuinely-external classes that can't be loaded this way (the Doctrine DBAL
+ * schema type, the `\OC` accessor, `OCP\Image`'s concrete internal base, and a
+ * few other apps' events) are handled by targeted suppressions in psalm.xml
+ * instead.
+ *
+ * Runtime/PHPUnit is unaffected — this file is loaded only by the Psalm
+ * autoloader (tests/psalm/ocp-autoload.php), never by the app.
+ */
+
+namespace OC\Hooks {
+	if (!interface_exists(Emitter::class)) {
+		interface Emitter {
+		}
+	}
+}
+
+namespace OC\User {
+	if (!class_exists(NoUserException::class)) {
+		class NoUserException extends \Exception {
+		}
+	}
+}

--- a/tests/psalm/ocp-autoload.php
+++ b/tests/psalm/ocp-autoload.php
@@ -11,6 +11,11 @@ declare(strict_types=1);
  * Psalm can find and scan the OCP/NCU definitions for type information, without
  * touching the runtime/PHPUnit autoloader (which uses its own local stubs).
  */
+
+// Define the internal/external classes the OCP type files reference but that
+// nextcloud/ocp does not ship, so autoloading those OCP files won't fatal.
+require_once __DIR__ . '/missing-class-stubs.php';
+
 spl_autoload_register(static function (string $class): void {
 	foreach (['OCP', 'NCU'] as $top) {
 		if ($class === $top || str_starts_with($class, $top . '\\')) {


### PR DESCRIPTION
Part 1 of the Psalm baseline burn-down (#122). Clears the trivial / OCP-resolution-artifact findings so the baseline reflects only **real type issues** — from **131 → 34**.

## Changes
- **MissingOverrideAttribute (33) → suppressed project-wide.** `#[\Override]` is PHP 8.3+, but the app supports PHP 8.1+ (`info.xml`), so requiring it isn't appropriate.
- **OCP-resolution artifacts (36) → resolved.**
  - `tests/psalm/missing-class-stubs.php` defines the two unshipped `OC\` internals (`OC\Hooks\Emitter`, `OC\User\NoUserException`) that `nextcloud/ocp`'s `OCP\Files\IRootFolder` references. With those present the real OCP type files load, so Psalm gets the **actual API** (not `UndefinedClass`).
  - Targeted `<referencedClass>` suppressions for genuinely-external classes that aren't in `nextcloud/ocp` and can't be cleanly stubbed: `Doctrine\DBAL\Schema\Table`, `\OC`, `OC\Security\CSRF\CsrfTokenManager`, the Files/Files_Sharing/Viewer events, and `OCP\Image` (its concrete internal base would need all 25 `IImage` methods).
- **RedundantCast (31) → removed** across 11 services (casts on `parse_url()` / `preg_match()` results Psalm already types). Behaviour-neutral — careful not to touch the *non-redundant* `(string)`/`(int)` coercions on `mixed` (e.g. `AdminSettingsValidator::normalizeHostUrl`).

## Verification
- PHPUnit **409** green (cast removals broke nothing), Psalm green (baseline now **34**).
- Full Playwright **23 passed, 0 flaky** on NC 33 (CSP, external-pad import, pad open all exercise the touched URL-parsing paths).

## Follow-up (part 2)
The remaining **34** baseline entries are the real type issues (`TypeDoesNotContainType`, `InvalidReturnStatement/Type`, `MismatchingDocblockParamType`, `MissingTemplateParam`, …) — fixed in a separate PR, along with enabling `findUnusedCode`.

Part of #122.