### PR TITLE
chore(#122): fix real Psalm type issues + enable findUnusedCode (PR B)

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -20,6 +20,9 @@ use OCP\Files\Template\FileCreatedFromTemplateEvent;
 use OCP\Files\Template\RegisterTemplateCreatorEvent;
 use OCP\Security\CSP\AddContentSecurityPolicyEvent;
 
+/**
+ * @psalm-api
+ */
 class Application extends App implements IBootstrap {
 	public const APP_ID = 'etherpad_nextcloud';
 
@@ -42,6 +45,10 @@ class Application extends App implements IBootstrap {
 		);
 
 		$context->registerEventListener(AddContentSecurityPolicyEvent::class, \OCA\EtherpadNextcloud\Listeners\CSPListener::class);
+		// LoadAdditionalScriptsEvent is provided by the Files app, not by
+		// nextcloud/ocp, so Psalm can't prove it is-a OCP\EventDispatcher\Event
+		// and rejects the generic IEventListener<Event> listener here.
+		/** @psalm-suppress InvalidArgument */
 		$context->registerEventListener(
 			LoadAdditionalScriptsEvent::class,
 			\OCA\EtherpadNextcloud\Listeners\LoadFilesScriptsListener::class,

--- a/lib/BackgroundJob/AbstractPendingDeleteRetryJob.php
+++ b/lib/BackgroundJob/AbstractPendingDeleteRetryJob.php
@@ -13,6 +13,9 @@ use OCA\EtherpadNextcloud\Service\PendingDeleteRetryService;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\TimedJob;
 
+/**
+ * @psalm-api
+ */
 abstract class AbstractPendingDeleteRetryJob extends TimedJob {
 	protected const INTERVAL_SECONDS = 24 * 60 * 60;
 	protected const MIN_AGE_SECONDS = 0;

--- a/lib/BackgroundJob/ColdPendingDeleteRetryJob.php
+++ b/lib/BackgroundJob/ColdPendingDeleteRetryJob.php
@@ -9,6 +9,9 @@ declare(strict_types=1);
 
 namespace OCA\EtherpadNextcloud\BackgroundJob;
 
+/**
+ * @psalm-api
+ */
 class ColdPendingDeleteRetryJob extends AbstractPendingDeleteRetryJob {
 	protected const INTERVAL_SECONDS = 24 * 60 * 60;
 	protected const MIN_AGE_SECONDS = 24 * 60 * 60;

--- a/lib/BackgroundJob/HotPendingDeleteRetryJob.php
+++ b/lib/BackgroundJob/HotPendingDeleteRetryJob.php
@@ -9,6 +9,9 @@ declare(strict_types=1);
 
 namespace OCA\EtherpadNextcloud\BackgroundJob;
 
+/**
+ * @psalm-api
+ */
 class HotPendingDeleteRetryJob extends AbstractPendingDeleteRetryJob {
 	protected const INTERVAL_SECONDS = 5 * 60;
 	protected const MIN_AGE_SECONDS = 0;

--- a/lib/BackgroundJob/WarmPendingDeleteRetryJob.php
+++ b/lib/BackgroundJob/WarmPendingDeleteRetryJob.php
@@ -9,6 +9,9 @@ declare(strict_types=1);
 
 namespace OCA\EtherpadNextcloud\BackgroundJob;
 
+/**
+ * @psalm-api
+ */
 class WarmPendingDeleteRetryJob extends AbstractPendingDeleteRetryJob {
 	protected const INTERVAL_SECONDS = 60 * 60;
 	protected const MIN_AGE_SECONDS = 60 * 60;

--- a/lib/Controller/AbstractPadController.php
+++ b/lib/Controller/AbstractPadController.php
@@ -32,6 +32,7 @@ use Psr\Log\LoggerInterface;
  *
  * Each concrete controller keeps its constructor narrow — it only
  * declares the services it actually uses on top of the base deps.
+ * @psalm-api
  */
 abstract class AbstractPadController extends Controller {
 	public function __construct(

--- a/lib/Controller/AdminController.php
+++ b/lib/Controller/AdminController.php
@@ -26,6 +26,9 @@ use OCP\IL10N;
 use OCP\IRequest;
 use OCP\IUserSession;
 
+/**
+ * @psalm-api
+ */
 class AdminController extends Controller {
 	private const CONSISTENCY_SAMPLE_LIMIT = 25;
 	private const PENDING_DELETE_RETRY_BATCH_SIZE = 500;
@@ -159,8 +162,7 @@ class AdminController extends Controller {
 
 	/** @return array<string,mixed> */
 	private function readJsonPayload(): array {
-		$params = $this->request->getParams();
-		return is_array($params) ? $params : [];
+		return $this->request->getParams();
 	}
 
 	private function requireAdmin(): void {

--- a/lib/Controller/EmbedController.php
+++ b/lib/Controller/EmbedController.php
@@ -22,6 +22,9 @@ use OCP\IURLGenerator;
 use OCP\IUser;
 use OCP\IUserSession;
 
+/**
+ * @psalm-api
+ */
 class EmbedController extends Controller {
 	public function __construct(
 		string $appName,

--- a/lib/Controller/PadCreateController.php
+++ b/lib/Controller/PadCreateController.php
@@ -23,6 +23,7 @@ use Psr\Log\LoggerInterface;
 /**
  * Create-side endpoints for `.pad` files. Spans empty creates, copies in
  * a parent folder, template-based creates, and external-URL imports.
+ * @psalm-api
  */
 class PadCreateController extends AbstractPadController {
 	public function __construct(

--- a/lib/Controller/PadLifecycleController.php
+++ b/lib/Controller/PadLifecycleController.php
@@ -27,6 +27,7 @@ use Psr\Log\LoggerInterface;
  * Lifecycle + sync endpoints — trash, restore, recover-from-snapshot,
  * sync state, and the find-original lookup that the copy-of-a-pad
  * recovery affordance hangs off.
+ * @psalm-api
  */
 class PadLifecycleController extends AbstractPadController {
 	public function __construct(

--- a/lib/Controller/PadSessionController.php
+++ b/lib/Controller/PadSessionController.php
@@ -29,6 +29,7 @@ use Psr\Log\LoggerInterface;
  * pad session state for a viewer: actual open flow, lazy frontmatter
  * init on first open, and the metadata + resolve readouts used by
  * embed-side surfaces.
+ * @psalm-api
  */
 class PadSessionController extends AbstractPadController {
 	public function __construct(

--- a/lib/Controller/PublicViewerController.php
+++ b/lib/Controller/PublicViewerController.php
@@ -23,6 +23,9 @@ use OCP\IRequest;
 use OCP\ISession;
 use OCP\Share\IShare;
 
+/**
+ * @psalm-api
+ */
 class PublicViewerController extends PublicShareController {
 	private ?IShare $share = null;
 

--- a/lib/Controller/PublicViewerControllerErrorMapper.php
+++ b/lib/Controller/PublicViewerControllerErrorMapper.php
@@ -50,7 +50,7 @@ class PublicViewerControllerErrorMapper {
 
 	/**
 	 * @param callable(): mixed $action
-	 * @param callable(mixed): RedirectResponse|TemplateResponse $success
+	 * @param callable(mixed): (RedirectResponse|TemplateResponse) $success
 	 */
 	public function runForTemplate(callable $action, callable $success, string $token): RedirectResponse|TemplateResponse {
 		try {

--- a/lib/Controller/ViewerController.php
+++ b/lib/Controller/ViewerController.php
@@ -23,6 +23,9 @@ use OCP\IURLGenerator;
 use OCP\IUser;
 use OCP\IUserSession;
 
+/**
+ * @psalm-api
+ */
 class ViewerController extends Controller {
 	public function __construct(
 		string $appName,

--- a/lib/Controller/ViewerControllerErrorMapper.php
+++ b/lib/Controller/ViewerControllerErrorMapper.php
@@ -32,7 +32,7 @@ class ViewerControllerErrorMapper {
 
 	/**
 	 * @param callable(): mixed $action
-	 * @param callable(mixed): RedirectResponse|TemplateResponse $success
+	 * @param callable(mixed): (RedirectResponse|TemplateResponse) $success
 	 * @param string|null $notFoundMessage context-specific message for `NotFoundException`; defaults to the open-pad wording
 	 */
 	public function runForTemplate(

--- a/lib/Hooks/TrashbinHookHandler.php
+++ b/lib/Hooks/TrashbinHookHandler.php
@@ -13,6 +13,9 @@ namespace OCA\EtherpadNextcloud\Hooks;
 use OCA\EtherpadNextcloud\Listeners\RestoreFromTrashListener;
 use Psr\Log\LoggerInterface;
 
+/**
+ * @psalm-api
+ */
 class TrashbinHookHandler {
 	/**
 	 * @param array<string,mixed> $params

--- a/lib/Listeners/CSPListener.php
+++ b/lib/Listeners/CSPListener.php
@@ -14,6 +14,10 @@ use OCP\EventDispatcher\IEventListener;
 use OCP\IConfig;
 use OCP\Security\CSP\AddContentSecurityPolicyEvent;
 
+/**
+ * @template-implements IEventListener<Event>
+ * @psalm-api
+ */
 class CSPListener implements IEventListener {
 	public function __construct(
 		private IConfig $config,

--- a/lib/Listeners/FileCreatedFromTemplateListener.php
+++ b/lib/Listeners/FileCreatedFromTemplateListener.php
@@ -37,6 +37,9 @@ use Psr\Log\LoggerInterface;
  * On any skip / failure inside the source-template branch the target is
  * reset to empty *and* re-initialised so a fresh blank pad still opens
  * cleanly on the first call.
+ *
+ * @template-implements IEventListener<Event>
+ * @psalm-api
  */
 class FileCreatedFromTemplateListener implements IEventListener {
 	public function __construct(

--- a/lib/Listeners/LoadFilesScriptsListener.php
+++ b/lib/Listeners/LoadFilesScriptsListener.php
@@ -14,6 +14,10 @@ use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\Util;
 
+/**
+ * @template-implements IEventListener<Event>
+ * @psalm-api
+ */
 class LoadFilesScriptsListener implements IEventListener {
 	public function handle(Event $event): void {
 		if (!$event instanceof LoadAdditionalScriptsEvent) {

--- a/lib/Listeners/LoadPublicShareScriptsListener.php
+++ b/lib/Listeners/LoadPublicShareScriptsListener.php
@@ -14,6 +14,10 @@ use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\Util;
 
+/**
+ * @template-implements IEventListener<Event>
+ * @psalm-api
+ */
 class LoadPublicShareScriptsListener implements IEventListener {
 	public function handle(Event $event): void {
 		if (!$event instanceof BeforeTemplateRenderedEvent) {

--- a/lib/Listeners/LoadViewerListener.php
+++ b/lib/Listeners/LoadViewerListener.php
@@ -14,6 +14,10 @@ use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\Util;
 
+/**
+ * @template-implements IEventListener<Event>
+ * @psalm-api
+ */
 class LoadViewerListener implements IEventListener {
 	public function handle(Event $event): void {
 		if (!$event instanceof LoadViewer) {

--- a/lib/Listeners/MoveToTrashListener.php
+++ b/lib/Listeners/MoveToTrashListener.php
@@ -16,6 +16,10 @@ use OCP\EventDispatcher\IEventListener;
 use OCP\Files\File;
 use Psr\Log\LoggerInterface;
 
+/**
+ * @template-implements IEventListener<Event>
+ * @psalm-api
+ */
 class MoveToTrashListener implements IEventListener {
 	public function __construct(
 		private LifecycleService $lifecycleService,

--- a/lib/Listeners/RegisterTemplateCreatorListener.php
+++ b/lib/Listeners/RegisterTemplateCreatorListener.php
@@ -15,6 +15,10 @@ use OCP\Files\Template\RegisterTemplateCreatorEvent;
 use OCP\Files\Template\TemplateFileCreator;
 use OCP\IL10N;
 
+/**
+ * @template-implements IEventListener<Event>
+ * @psalm-api
+ */
 class RegisterTemplateCreatorListener implements IEventListener {
 	public function __construct(
 		private IL10N $l10n,

--- a/lib/Listeners/RestoreFromTrashListener.php
+++ b/lib/Listeners/RestoreFromTrashListener.php
@@ -19,6 +19,10 @@ use OCP\Files\NotFoundException;
 use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
 
+/**
+ * @template-implements IEventListener<Event>
+ * @psalm-api
+ */
 class RestoreFromTrashListener implements IEventListener {
 	public function __construct(
 		private LifecycleService $lifecycleService,

--- a/lib/Migration/BackfillPadMimeType.php
+++ b/lib/Migration/BackfillPadMimeType.php
@@ -12,6 +12,9 @@ use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
 use OCP\IDBConnection;
 
+/**
+ * @psalm-api
+ */
 class BackfillPadMimeType implements IRepairStep {
 	private const MIME_PAD = 'application/x-etherpad-nextcloud';
 	private const MIME_PART = 'application';

--- a/lib/Migration/MarkApiKeySensitive.php
+++ b/lib/Migration/MarkApiKeySensitive.php
@@ -23,6 +23,7 @@ use OCP\Migration\IRepairStep;
  * {@see AdminSettingsRepository::persist()}; this only backfills the flag
  * onto the value installs stored before that change. Idempotent: writing
  * the same value with `sensitive: true` is a no-op once the flag is set.
+ * @psalm-api
  */
 class MarkApiKeySensitive implements IRepairStep {
 	public function __construct(

--- a/lib/Migration/RegisterMimeType.php
+++ b/lib/Migration/RegisterMimeType.php
@@ -14,6 +14,9 @@ use OCP\IConfig;
 use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
 
+/**
+ * @psalm-api
+ */
 class RegisterMimeType implements IRepairStep {
 	private const MIME = 'application/x-etherpad-nextcloud';
 	private const MIME_ALIAS = 'etherpad-nextcloud-pad';

--- a/lib/Migration/Version000001Date20260304222000.php
+++ b/lib/Migration/Version000001Date20260304222000.php
@@ -14,6 +14,9 @@ use OCP\DB\ISchemaWrapper;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
+/**
+ * @psalm-api
+ */
 class Version000001Date20260304222000 extends SimpleMigrationStep {
 	/**
 	 * @param Closure(): ISchemaWrapper $schemaClosure

--- a/lib/Migration/Version000002Date20260512170000.php
+++ b/lib/Migration/Version000002Date20260512170000.php
@@ -17,6 +17,9 @@ use OCP\IDBConnection;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
+/**
+ * @psalm-api
+ */
 class Version000002Date20260512170000 extends SimpleMigrationStep {
 	public function __construct(
 		private IDBConnection $db,

--- a/lib/Migration/Version000003Date20260512230000.php
+++ b/lib/Migration/Version000003Date20260512230000.php
@@ -17,6 +17,9 @@ use OCP\IDBConnection;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
+/**
+ * @psalm-api
+ */
 class Version000003Date20260512230000 extends SimpleMigrationStep {
 	public function __construct(
 		private IDBConnection $db,
@@ -24,7 +27,6 @@ class Version000003Date20260512230000 extends SimpleMigrationStep {
 	}
 
 	public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void {
-		/** @var ISchemaWrapper $schema */
 		$schema = $schemaClosure();
 		if (!$schema->hasTable(BindingService::TABLE)) {
 			return;

--- a/lib/Preview/PadPreviewProvider.php
+++ b/lib/Preview/PadPreviewProvider.php
@@ -28,6 +28,7 @@ use OCP\Preview\IProviderV2;
  * A future iteration could render the actual snapshot text into the
  * preview (similar to how the Text app previews Markdown), but that's
  * a separate feature — this exists to silence the 4xx noise.
+ * @psalm-api
  */
 class PadPreviewProvider implements IProviderV2 {
 	private const ASSET_PATH = __DIR__ . '/../../img/preview-fallback.png';
@@ -44,6 +45,13 @@ class PadPreviewProvider implements IProviderV2 {
 		return is_readable(self::ASSET_PATH);
 	}
 
+	/**
+	 * `OCP\Image` is the concrete implementation of `OCP\IImage` at runtime,
+	 * but it isn't shipped in the `nextcloud/ocp` stubs Psalm analyses against,
+	 * so Psalm can't see that it satisfies the `?IImage` return type.
+	 *
+	 * @psalm-suppress InvalidReturnType, InvalidReturnStatement
+	 */
 	public function getThumbnail(File $file, int $maxX, int $maxY): ?IImage {
 		if (!is_readable(self::ASSET_PATH)) {
 			return null;

--- a/lib/Service/ConsistencyCheckService.php
+++ b/lib/Service/ConsistencyCheckService.php
@@ -63,6 +63,6 @@ class ConsistencyCheckService {
 		$result = $qb->executeQuery();
 		$rows = $result->fetchAll();
 		$result->closeCursor();
-		return is_array($rows) ? $rows : [];
+		return $rows;
 	}
 }

--- a/lib/Service/EtherpadHealthCheckService.php
+++ b/lib/Service/EtherpadHealthCheckService.php
@@ -64,7 +64,7 @@ class EtherpadHealthCheckService {
 			$settings->etherpadApiHost,
 			$settings->etherpadApiVersion,
 			(int)($result['pad_count'] ?? 0),
-			(int)round(($this->now() - $startedAt) * 1000),
+			(int)round(($this->now() - $startedAt) * 1000.0),
 			rtrim($settings->etherpadApiHost, '/') . '/api/' . $settings->etherpadApiVersion . '/listAllPads',
 			$this->pendingDeleteRetryService->countPendingDeletes(),
 		);

--- a/lib/Service/ExternalPadExportFetcher.php
+++ b/lib/Service/ExternalPadExportFetcher.php
@@ -70,7 +70,7 @@ class ExternalPadExportFetcher {
 	}
 
 	/**
-	 * @param array{pad_url:string,host:string,port:int,resolved_ips:list<string>} $resolved
+	 * @param array{origin:string,pad_id:string,pad_url:string,host:string,port:int,resolved_ips:list<string>} $resolved
 	 */
 	private function getPublicTextFromResolvedExternalPad(array $resolved): string {
 		$url = $this->buildPublicExportUrl($resolved['pad_url'], 'txt');
@@ -156,6 +156,11 @@ class ExternalPadExportFetcher {
 			curl_close($curl);
 
 			if ($success === false) {
+				// $sizeExceeded is flipped to true inside the CURLOPT_WRITEFUNCTION
+				// closure above when the response exceeds the cap; Psalm doesn't
+				// model curl invoking that callback, so it wrongly infers the flag
+				// stays false here.
+				/** @psalm-suppress TypeDoesNotContainType */
 				if ($sizeExceeded) {
 					throw new EtherpadClientException(
 						'External public pad export exceeds maximum size (' . self::EXTERNAL_EXPORT_MAX_BYTES . ' bytes).'

--- a/lib/Service/LifecycleService.php
+++ b/lib/Service/LifecycleService.php
@@ -279,7 +279,7 @@ class LifecycleService {
 		}
 	}
 
-	/** @return array{status: string, reason?: string, file_id: int, old_pad_id?: string, new_pad_id?: string} */
+	/** @return array{status: string, reason?: string, file_id: int, pad_id?: string, old_pad_id?: string, new_pad_id?: string} */
 	public function handleRestore(File $file): array {
 		$fileId = (int)$file->getId();
 		if (!$this->isPadFile($file)) {
@@ -396,7 +396,7 @@ class LifecycleService {
 	 * caller has already verified the user owns the file, and the security
 	 * model demands we never reuse the `pad_id` from frontmatter.
 	 *
-	 * @return array{status: string, reason?: string, file_id: int, old_pad_id?: string, new_pad_id?: string}
+	 * @return array{status: string, reason?: string, file_id: int, pad_id?: string, old_pad_id?: string, new_pad_id?: string}
 	 */
 	public function recoverFromSnapshot(File $file): array {
 		$fileId = (int)$file->getId();
@@ -418,11 +418,10 @@ class LifecycleService {
 		return $result;
 	}
 
-	/** @return array{status: string, reason?: string, file_id: int, old_pad_id?: string, new_pad_id?: string} */
+	/** @return array{status: string, reason?: string, file_id: int, pad_id?: string, old_pad_id?: string, new_pad_id?: string} */
 	private function restoreWithoutBinding(File $file, int $fileId): array {
 		$oldPadId = '';
 		$newPadId = '';
-		$currentContent = '';
 		$fileContentUpdated = false;
 		$managedPadCreated = false;
 		$bindingCreated = false;
@@ -547,7 +546,7 @@ class LifecycleService {
 	private function provisionRestorePadId(string $accessMode, string $oldPadId): string {
 		if ($accessMode === BindingService::ACCESS_PROTECTED) {
 			$groupId = $this->etherpadClient->createGroup();
-			$padName = $this->buildProtectedRestorePadName($oldPadId);
+			$padName = $this->buildProtectedRestorePadName();
 			return $this->etherpadClient->createGroupPad($groupId, $padName);
 		}
 
@@ -591,7 +590,7 @@ class LifecycleService {
 		return 'r-' . trim($normalized, '-') . '-' . $suffix;
 	}
 
-	private function buildProtectedRestorePadName(string $oldPadId): string {
+	private function buildProtectedRestorePadName(): string {
 		$suffix = $this->secureRandom->generate(14, ISecureRandom::CHAR_LOWER . ISecureRandom::CHAR_DIGITS);
 		return 'restored-' . $suffix;
 	}

--- a/lib/Service/PadBootstrapService.php
+++ b/lib/Service/PadBootstrapService.php
@@ -91,8 +91,6 @@ class PadBootstrapService {
 		$binding = $this->bindingService->findByFileId($fileId);
 		$createdNewBinding = false;
 		$createdNewPad = false;
-		$padId = '';
-		$accessMode = BindingService::ACCESS_PROTECTED;
 
 		if ($binding !== null) {
 			$padId = (string)$binding['pad_id'];

--- a/lib/Service/PadCreationService.php
+++ b/lib/Service/PadCreationService.php
@@ -183,14 +183,14 @@ class PadCreationService {
 	}
 
 	/**
-	 * @return array{file:string,file_id:int,pad_id:string,access_mode:string,pad_url:string}
+	 * @return array{file:string,file_id:int,pad_id:string,access_mode:string,pad_url:string,snapshot_warning_code?:string}
 	 */
 	public function createFromUrl(string $uid, string $file, string $padUrl): array {
 		$path = $this->padPaths->normalizeCreatePath($file);
 		$fileCreated = false;
 
 		return $this->withCreateRollback(
-			function () use ($uid, $path, $padUrl, &$fileCreated): array {
+			function () use ($uid, $path, $padUrl, &$fileCreated) {
 				$fileNode = $this->padFileCreator->createUserFile($uid, $path);
 				$fileCreated = true;
 				$fileId = (int)$fileNode->getId();

--- a/lib/Service/PadFileCreator.php
+++ b/lib/Service/PadFileCreator.php
@@ -32,6 +32,10 @@ class PadFileCreator {
 
 		$parentPath = dirname($relativePath);
 		$fileName = basename($relativePath);
+		// Psalm infers basename() as non-empty-string, but it returns '' for
+		// slash-only inputs (e.g. basename('/')), so the empty-string guard is
+		// a real defensive check, not dead code.
+		/** @psalm-suppress TypeDoesNotContainType */
 		if ($fileName === '' || $fileName === '.' || $fileName === '..') {
 			throw new \RuntimeException('Invalid target filename.');
 		}

--- a/lib/Service/PadMetadataService.php
+++ b/lib/Service/PadMetadataService.php
@@ -51,7 +51,6 @@ class PadMetadataService {
 			return new PadOriginalLookup(found: false);
 		}
 
-		$padId = '';
 		try {
 			$padId = $this->padFileService->readPad((string)$node->getContent())->padId;
 		} catch (\Throwable) {

--- a/lib/Service/PadOpenService.php
+++ b/lib/Service/PadOpenService.php
@@ -120,7 +120,6 @@ class PadOpenService {
 			throw new EtherpadClientException('External pad metadata requires public access_mode.');
 		}
 
-		$effectivePadUrl = '';
 		$originalPadUrl = '';
 
 		if ($isExternal) {

--- a/lib/Service/PublicShareUrlBuilder.php
+++ b/lib/Service/PublicShareUrlBuilder.php
@@ -58,13 +58,13 @@ class PublicShareUrlBuilder {
 		}
 
 		$dir = dirname($path);
-		if ($dir === '.' || $dir === '') {
+		if ($dir === '.') {
 			$dir = '/';
 		} else {
 			$dir = '/' . $dir;
 		}
 		$fileName = basename($path);
-		if ($fileName === '' || !str_ends_with(strtolower($fileName), '.pad')) {
+		if (!str_ends_with(strtolower($fileName), '.pad')) {
 			throw new NotAPadFileException('The selected file is not a .pad document.');
 		}
 

--- a/lib/Settings/AdminSection.php
+++ b/lib/Settings/AdminSection.php
@@ -12,6 +12,9 @@ use OCP\IL10N;
 use OCP\IURLGenerator;
 use OCP\Settings\IIconSection;
 
+/**
+ * @psalm-api
+ */
 class AdminSection implements IIconSection {
 	public function __construct(
 		private IL10N $l10n,

--- a/lib/Settings/AdminSettings.php
+++ b/lib/Settings/AdminSettings.php
@@ -19,6 +19,9 @@ use OCP\IURLGenerator;
 use OCP\Settings\ISettings;
 use OCP\Util;
 
+/**
+ * @psalm-api
+ */
 class AdminSettings implements ISettings {
 	public function __construct(
 		private IConfig $config,

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,170 +1,235 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="6.16.1@f1f5de594dc76faf8784e02d3dc4716c91c6f6ac">
-  <file src="lib/AppInfo/Application.php">
-    <InvalidArgument>
-      <code><![CDATA[registerEventListener]]></code>
-    </InvalidArgument>
+  <file src="lib/Controller/AdminControllerErrorMapper.php">
+    <PossiblyUnusedMethod>
+      <code><![CDATA[__construct]]></code>
+    </PossiblyUnusedMethod>
   </file>
-  <file src="lib/Controller/AdminController.php">
-    <RedundantCondition>
-      <code><![CDATA[is_array($params)]]></code>
-    </RedundantCondition>
-    <TypeDoesNotContainType>
-      <code><![CDATA[[]]]></code>
-    </TypeDoesNotContainType>
+  <file src="lib/Controller/EmbedControllerErrorMapper.php">
+    <PossiblyUnusedMethod>
+      <code><![CDATA[__construct]]></code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="lib/Controller/PadControllerErrorMapper.php">
+    <PossiblyUnusedMethod>
+      <code><![CDATA[__construct]]></code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="lib/Controller/PublicViewerControllerErrorMapper.php">
-    <MismatchingDocblockParamType>
-      <code><![CDATA[callable(mixed): RedirectResponse|TemplateResponse]]></code>
-    </MismatchingDocblockParamType>
+    <PossiblyUnusedMethod>
+      <code><![CDATA[__construct]]></code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="lib/Controller/ViewerControllerErrorMapper.php">
-    <MismatchingDocblockParamType>
-      <code><![CDATA[callable(mixed): RedirectResponse|TemplateResponse]]></code>
-    </MismatchingDocblockParamType>
+    <PossiblyUnusedMethod>
+      <code><![CDATA[__construct]]></code>
+    </PossiblyUnusedMethod>
   </file>
-  <file src="lib/Listeners/CSPListener.php">
-    <MissingTemplateParam>
-      <code><![CDATA[IEventListener]]></code>
-    </MissingTemplateParam>
+  <file src="lib/Migration/RegisterMimeType.php">
+    <UnusedMethod>
+      <code><![CDATA[appendToJsonFile]]></code>
+      <code><![CDATA[ensureCoreFiletypeIcon]]></code>
+    </UnusedMethod>
+    <UnusedParam>
+      <code><![CDATA[$output]]></code>
+    </UnusedParam>
+    <UnusedProperty>
+      <code><![CDATA[$config]]></code>
+    </UnusedProperty>
   </file>
-  <file src="lib/Listeners/FileCreatedFromTemplateListener.php">
-    <MissingTemplateParam>
-      <code><![CDATA[IEventListener]]></code>
-    </MissingTemplateParam>
+  <file src="lib/Service/AdminConsistencyCheckResponseBuilder.php">
+    <PossiblyUnusedMethod>
+      <code><![CDATA[__construct]]></code>
+    </PossiblyUnusedMethod>
   </file>
-  <file src="lib/Listeners/LoadFilesScriptsListener.php">
-    <MissingTemplateParam>
-      <code><![CDATA[IEventListener]]></code>
-    </MissingTemplateParam>
+  <file src="lib/Service/AdminSettingsRepository.php">
+    <PossiblyUnusedMethod>
+      <code><![CDATA[__construct]]></code>
+    </PossiblyUnusedMethod>
   </file>
-  <file src="lib/Listeners/LoadPublicShareScriptsListener.php">
-    <MissingTemplateParam>
-      <code><![CDATA[IEventListener]]></code>
-    </MissingTemplateParam>
+  <file src="lib/Service/AdminSettingsValidator.php">
+    <PossiblyUnusedMethod>
+      <code><![CDATA[__construct]]></code>
+    </PossiblyUnusedMethod>
   </file>
-  <file src="lib/Listeners/LoadViewerListener.php">
-    <MissingTemplateParam>
-      <code><![CDATA[IEventListener]]></code>
-    </MissingTemplateParam>
+  <file src="lib/Service/AdminTestFaultService.php">
+    <PossiblyUnusedMethod>
+      <code><![CDATA[__construct]]></code>
+    </PossiblyUnusedMethod>
   </file>
-  <file src="lib/Listeners/MoveToTrashListener.php">
-    <MissingTemplateParam>
-      <code><![CDATA[IEventListener]]></code>
-    </MissingTemplateParam>
+  <file src="lib/Service/AllowlistNormalizer.php">
+    <PossiblyUnusedMethod>
+      <code><![CDATA[__construct]]></code>
+    </PossiblyUnusedMethod>
   </file>
-  <file src="lib/Listeners/RegisterTemplateCreatorListener.php">
-    <MissingTemplateParam>
-      <code><![CDATA[IEventListener]]></code>
-    </MissingTemplateParam>
+  <file src="lib/Service/AppConfigService.php">
+    <PossiblyUnusedMethod>
+      <code><![CDATA[__construct]]></code>
+    </PossiblyUnusedMethod>
   </file>
-  <file src="lib/Listeners/RestoreFromTrashListener.php">
-    <MissingTemplateParam>
-      <code><![CDATA[IEventListener]]></code>
-    </MissingTemplateParam>
-  </file>
-  <file src="lib/Preview/PadPreviewProvider.php">
-    <InvalidReturnStatement>
-      <code><![CDATA[$image]]></code>
-    </InvalidReturnStatement>
-    <InvalidReturnType>
-      <code><![CDATA[?IImage]]></code>
-    </InvalidReturnType>
+  <file src="lib/Service/BindingService.php">
+    <PossiblyUnusedMethod>
+      <code><![CDATA[__construct]]></code>
+      <code><![CDATA[hasFileCacheEntry]]></code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="lib/Service/ConsistencyCheckService.php">
-    <RedundantCondition>
-      <code><![CDATA[is_array($rows)]]></code>
-    </RedundantCondition>
-    <TypeDoesNotContainType>
-      <code><![CDATA[[]]]></code>
-    </TypeDoesNotContainType>
+    <PossiblyUnusedMethod>
+      <code><![CDATA[__construct]]></code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="lib/Service/EmbedResponseBuilder.php">
+    <PossiblyUnusedMethod>
+      <code><![CDATA[__construct]]></code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="lib/Service/EtherpadClient.php">
+    <PossiblyUnusedMethod>
+      <code><![CDATA[__construct]]></code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="lib/Service/EtherpadHealthCheckService.php">
-    <InvalidOperand>
-      <code><![CDATA[($this->now() - $startedAt) * 1000]]></code>
-    </InvalidOperand>
+    <PossiblyUnusedMethod>
+      <code><![CDATA[__construct]]></code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="lib/Service/ExternalPadExportFetcher.php">
-    <InvalidArgument>
-      <code><![CDATA[$resolved]]></code>
-      <code><![CDATA[$resolved]]></code>
-    </InvalidArgument>
-    <TypeDoesNotContainType>
-      <code><![CDATA[$sizeExceeded]]></code>
-      <code><![CDATA[$sizeExceeded]]></code>
-    </TypeDoesNotContainType>
+    <PossiblyUnusedMethod>
+      <code><![CDATA[__construct]]></code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="lib/Service/ExternalPadSeeder.php">
+    <PossiblyUnusedMethod>
+      <code><![CDATA[__construct]]></code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="lib/Service/LifecycleService.php">
-    <InvalidReturnStatement>
-      <code><![CDATA[$this->buildSkippedResult('binding_not_pending_delete', $fileId, $oldPadId)]]></code>
-      <code><![CDATA[$this->buildSkippedResult('binding_state_transition_conflict', $fileId, $oldPadId)]]></code>
-      <code><![CDATA[$this->buildSkippedResult('delete_on_trash_disabled', $fileId)]]></code>
-      <code><![CDATA[$this->buildSkippedResult('external_pad', $fileId, $oldPadId)]]></code>
-      <code><![CDATA[$this->buildSkippedResult('not_pad_file', $fileId)]]></code>
-    </InvalidReturnStatement>
-    <InvalidReturnType>
-      <code><![CDATA[array{status: string, reason?: string, file_id: int, old_pad_id?: string, new_pad_id?: string}]]></code>
-      <code><![CDATA[array{status: string, reason?: string, file_id: int, old_pad_id?: string, new_pad_id?: string}]]></code>
-    </InvalidReturnType>
+    <PossiblyUnusedMethod>
+      <code><![CDATA[__construct]]></code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="lib/Service/PadBootstrapService.php">
+    <PossiblyUnusedMethod>
+      <code><![CDATA[__construct]]></code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="lib/Service/PadCreateRollbackService.php">
+    <PossiblyUnusedMethod>
+      <code><![CDATA[__construct]]></code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="lib/Service/PadCreationService.php">
-    <InvalidReturnStatement>
-      <code><![CDATA[$this->withCreateRollback(
-			function () use ($uid, $path, $padUrl, &$fileCreated): array {
-				$fileNode = $this->padFileCreator->createUserFile($uid, $path);
-				$fileCreated = true;
-				$fileId = (int)$fileNode->getId();
-				if ($fileId <= 0) {
-					throw new \RuntimeException('Could not resolve new file ID.');
-				}
-
-				$seeded = $this->externalPadSeeder->seed($fileNode, $fileId, $padUrl);
-				// Preserve the historical key ordering for the external-create
-				// response: `file` is the first key so tests asserting via
-				// `assertSame` keep matching after the refactor.
-				$result = ['file' => $path] + $seeded;
-				return $result;
-			},
-			function () use ($uid, $path, &$fileCreated): void {
-				$this->rollbackService->rollbackExternalCreate($uid, $path, $fileCreated);
-			},
-			function (\Throwable $e) use ($path, $padUrl): ?array {
-				if ($e instanceof EtherpadClientException) {
-					return [
-						'message' => 'External pad URL validation failed',
-						'context' => [
-							'file' => $path,
-							'padUrl' => $padUrl,
-						],
-					];
-				}
-
-				return null;
-			},
-			function () use ($path, $padUrl): array {
-				return [
-					'message' => 'External pad create failed',
-					'context' => [
-						'file' => $path,
-						'padUrl' => $padUrl,
-					],
-				];
-			},
-		)]]></code>
-    </InvalidReturnStatement>
-    <InvalidReturnType>
-      <code><![CDATA[array{file:string,file_id:int,pad_id:string,access_mode:string,pad_url:string}]]></code>
-    </InvalidReturnType>
+    <PossiblyUnusedMethod>
+      <code><![CDATA[__construct]]></code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="lib/Service/PadFileCreator.php">
-    <TypeDoesNotContainType>
-      <code><![CDATA[$fileName === '']]></code>
-    </TypeDoesNotContainType>
+    <PossiblyUnusedMethod>
+      <code><![CDATA[__construct]]></code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="lib/Service/PadFileLockRetryService.php">
+    <PossiblyUnusedMethod>
+      <code><![CDATA[__construct]]></code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="lib/Service/PadInitializationService.php">
+    <PossiblyUnusedMethod>
+      <code><![CDATA[__construct]]></code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="lib/Service/PadLegacyMigrationService.php">
+    <PossiblyUnusedMethod>
+      <code><![CDATA[__construct]]></code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="lib/Service/PadMetadataService.php">
+    <PossiblyUnusedMethod>
+      <code><![CDATA[__construct]]></code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="lib/Service/PadOpenService.php">
+    <PossiblyUnusedMethod>
+      <code><![CDATA[__construct]]></code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="lib/Service/PadPlaceholderResolver.php">
+    <PossiblyUnusedMethod>
+      <code><![CDATA[__construct]]></code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="lib/Service/PadResponseService.php">
+    <PossiblyUnusedMethod>
+      <code><![CDATA[__construct]]></code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="lib/Service/PadSessionService.php">
+    <PossiblyUnusedMethod>
+      <code><![CDATA[__construct]]></code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="lib/Service/PadSyncService.php">
+    <PossiblyUnusedMethod>
+      <code><![CDATA[__construct]]></code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="lib/Service/ParsedPadFile.php">
+    <PossiblyUnusedProperty>
+      <code><![CDATA[$frontmatter]]></code>
+    </PossiblyUnusedProperty>
+  </file>
+  <file src="lib/Service/PendingDeleteRetryService.php">
+    <PossiblyUnusedMethod>
+      <code><![CDATA[__construct]]></code>
+    </PossiblyUnusedMethod>
+    <PossiblyUnusedReturnValue>
+      <code><![CDATA[array{
+	 *   attempted:int,
+	 *   resolved:int,
+	 *   failed:int,
+	 *   remaining:int
+	 * }]]></code>
+    </PossiblyUnusedReturnValue>
+  </file>
+  <file src="lib/Service/PublicPadContextService.php">
+    <PossiblyUnusedMethod>
+      <code><![CDATA[__construct]]></code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="lib/Service/PublicPadOpenService.php">
+    <PossiblyUnusedMethod>
+      <code><![CDATA[__construct]]></code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="lib/Service/PublicShareResolver.php">
+    <PossiblyUnusedMethod>
+      <code><![CDATA[__construct]]></code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="lib/Service/PublicShareUrlBuilder.php">
-    <TypeDoesNotContainType>
-      <code><![CDATA[$dir === '']]></code>
-      <code><![CDATA[$fileName === '']]></code>
-    </TypeDoesNotContainType>
+    <PossiblyUnusedMethod>
+      <code><![CDATA[__construct]]></code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="lib/Service/ResolvedPadShare.php">
+    <PossiblyUnusedProperty>
+      <code><![CDATA[$isFolderShare]]></code>
+      <code><![CDATA[$selectedRelativePath]]></code>
+    </PossiblyUnusedProperty>
+  </file>
+  <file src="lib/Service/SnapshotExtractor.php">
+    <PossiblyUnusedMethod>
+      <code><![CDATA[__construct]]></code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="lib/Service/TrustedEmbedOriginsNormalizer.php">
+    <PossiblyUnusedMethod>
+      <code><![CDATA[__construct]]></code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="lib/Service/UserNodeResolver.php">
+    <PossiblyUnusedMethod>
+      <code><![CDATA[__construct]]></code>
+    </PossiblyUnusedMethod>
   </file>
 </files>

--- a/psalm.xml
+++ b/psalm.xml
@@ -3,7 +3,7 @@
     errorLevel="4"
     phpVersion="8.1"
     resolveFromConfigFile="true"
-    findUnusedCode="false"
+    findUnusedCode="true"
     autoloader="tests/psalm/ocp-autoload.php"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"


### PR DESCRIPTION
PR B of the Psalm baseline burndown (#122). Companion to the already-merged PR A (#133, noise reduction). Brings the **type-issue baseline to zero** and turns on `findUnusedCode`.

## Type fixes (all 34 real findings)
- 8 listeners: `@template-implements IEventListener<Event>` (MissingTemplateParam)
- `LifecycleService` restore-result `@return` shapes reconciled (`pad_id?` added) so `buildSkippedResult` assigns cleanly
- `PadCreationService::createFromUrl`: `@return` gains `snapshot_warning_code?`; dropped the action-closure `: array` hint so `withCreateRollback`'s templated return carries the precise shape
- `ExternalPadExportFetcher::getPublicTextFromResolvedExternalPad`: `@param` widened to the full resolved shape (`origin`/`pad_id` were being rejected)
- `Viewer`/`PublicViewer` `ErrorMapper`: parenthesized the `callable(): (A|B)` return union (precedence bug)
- `EtherpadHealthCheckService`: latency math uses a float literal (strict binary operands)
- `ConsistencyCheckService` / `AdminController`: dropped redundant `is_array` guards
- `PublicShareUrlBuilder`: removed genuinely-dead `''` branches (path is already trimmed)
- Targeted `@psalm-suppress` **with rationale** where Psalm can't model runtime: `OCP\Image` (not in `nextcloud/ocp` stubs), the Files-app `LoadAdditionalScriptsEvent`, the curl write-callback mutation of `$sizeExceeded`, and `basename('/') === ''`

## findUnusedCode
- Enabled in `psalm.xml`
- Entry points (controllers, listeners, migrations, settings, jobs, hooks, preview, `Application`) annotated `@psalm-api` so Psalm roots traversal from them
- **Removed real dead code** surfaced by it: 5 unused local inits, 1 unused param (`buildProtectedRestorePadName`), 1 unnecessary `@var`
- Remaining findings are NC DI / entry-point false positives (service constructors with no literal `new`; repair-step internals reached only via `run()`). Captured in `psalm-baseline.xml` so **new** dead code is still caught.

## Verification
- `composer psalm` ✅ green (0 unbaselined issues)
- PHPUnit ✅ 409 tests, 1677 assertions
- Playwright e2e ✅ 23/23 against the Hamal test server