### PR TITLE
fix(release): exclude Playwright artefacts from the app tarball

### DIFF
--- a/scripts/build-release-tarball.sh
+++ b/scripts/build-release-tarball.sh
@@ -85,6 +85,12 @@ RSYNC_EXCLUDES=(
 	--exclude='psalm.xml'
 	--exclude='psalm-baseline.xml'
 	--exclude='dist/'
+	# Playwright e2e artefacts (gitignored, but rsync copies the working
+	# tree regardless) — must never end up in the app tarball.
+	--exclude='test-results/'
+	--exclude='playwright-report/'
+	--exclude='blob-report/'
+	--exclude='.playwright/'
 )
 
 rsync -a "${RSYNC_EXCLUDES[@]}" "$ROOT_DIR/" "$APP_STAGE/"


### PR DESCRIPTION
`scripts/build-release-tarball.sh` rsyncs the working tree with an explicit exclude list (not `git archive`). The Playwright e2e suite drops `playwright-report/`, `test-results/`, `blob-report/`, and `.playwright/` at the repo root — gitignored, but rsync copies them regardless. They leaked into the locally-built v1.1.0-alpha.3 tarball and more than doubled its size (516K vs the expected ~290K).

Added the four artefact dirs to `RSYNC_EXCLUDES`. Rebuilt locally: 516K → 289K (in line with alpha.1/alpha.2 at 230K/238K), no `playwright-report`/`test-results` entries in the archive.

The published v1.1.0-alpha.3 release asset was already replaced with a correctly-built (clean) tarball; this just prevents the regression for future releases.