### PR TITLE
Restore a pad from the trash on Nextcloud 31

### DIFF
--- a/lib/Listeners/RestoreFromTrashListener.php
+++ b/lib/Listeners/RestoreFromTrashListener.php
@@ -110,40 +110,72 @@ class RestoreFromTrashListener implements IEventListener {
 	 * Return a node whose id can be read, re-resolving it from its path if
 	 * the one handed to us cannot. The owner comes from the path rather
 	 * than the session, because `occ trashbin:restore` has no session.
+	 *
+	 * Returning null means the restore goes ahead untouched and our
+	 * bookkeeping is skipped, so every way out of here says why.
 	 */
 	private function materialize(File $node): ?File {
-		try {
-			$node->getId();
+		if ($this->hasReadableId($node)) {
 			return $node;
-		} catch (\Throwable) {
-			// Not resolvable yet — fall through and look it up by path.
 		}
 
 		try {
 			$path = $node->getPath();
-		} catch (\Throwable) {
+		} catch (\Throwable $e) {
+			$this->logSkip('the restored node has no readable path', null, $e);
 			return null;
 		}
 
 		$parts = explode('/', ltrim($path, '/'), 3);
 		if (count($parts) !== 3 || $parts[1] !== 'files' || $parts[0] === '' || $parts[2] === '') {
+			$this->logSkip('the restored node\'s path is not /<user>/files/<path>', $path);
 			return null;
 		}
 
 		try {
 			$resolved = $this->rootFolder->getUserFolder($parts[0])->get($parts[2]);
-		} catch (NotFoundException) {
+		} catch (NotFoundException $e) {
+			$this->logSkip('the restored node was not found at its own path', $path, $e);
 			return null;
 		} catch (\Throwable $e) {
-			$this->logger->warning('RestoreFromTrash listener could not resolve the restored node.', [
-				'app' => 'etherpad_nextcloud',
-				'filePath' => $path,
-				'exception' => $e,
-			]);
+			$this->logSkip('the restored node could not be resolved', $path, $e);
 			return null;
 		}
 
-		return $resolved instanceof File ? $resolved : null;
+		if (!$resolved instanceof File) {
+			$this->logSkip('the restored path does not point at a file', $path);
+			return null;
+		}
+
+		// Hold the replacement to the same standard as the node we rejected:
+		// handleRestore() reads the id on its first line, so handing on one
+		// that still throws would put the abort straight back.
+		if (!$this->hasReadableId($resolved)) {
+			$this->logSkip('the re-resolved node still has no readable id', $path);
+			return null;
+		}
+
+		return $resolved;
+	}
+
+	private function hasReadableId(File $node): bool {
+		try {
+			$node->getId();
+			return true;
+		} catch (\Throwable) {
+			return false;
+		}
+	}
+
+	private function logSkip(string $reason, ?string $path, ?\Throwable $e = null): void {
+		$context = ['app' => 'etherpad_nextcloud', 'reason' => $reason];
+		if ($path !== null) {
+			$context['filePath'] = $path;
+		}
+		if ($e !== null) {
+			$context['exception'] = $e;
+		}
+		$this->logger->warning('RestoreFromTrash listener skipped a restored node.', $context);
 	}
 
 	private function resolveUserFileByPath(string $path): ?File {

--- a/lib/Listeners/RestoreFromTrashListener.php
+++ b/lib/Listeners/RestoreFromTrashListener.php
@@ -42,6 +42,16 @@ class RestoreFromTrashListener implements IEventListener {
 			return;
 		}
 
+		// On Nextcloud 31 the event carries a node that is not resolvable
+		// yet, so anything reading its id throws and takes the whole restore
+		// down with it — a .pad then cannot be restored from the trash at
+		// all, through the web UI, WebDAV or occ alike. Re-resolve it from
+		// its path before handing it on.
+		$node = $this->materialize($node);
+		if ($node === null) {
+			return;
+		}
+
 		$this->restoreNode($node);
 	}
 
@@ -68,18 +78,72 @@ class RestoreFromTrashListener implements IEventListener {
 			if (($result['status'] ?? '') === LifecycleService::RESULT_SKIPPED) {
 				$this->logger->debug('RestoreFromTrash listener skipped lifecycle action.', [
 					'app' => 'etherpad_nextcloud',
-					'fileId' => (int)$node->getId(),
+					'fileId' => $this->loggableFileId($node),
 					'reason' => (string)($result['reason'] ?? 'unknown'),
 				]);
 			}
 		} catch (\Throwable $e) {
 			$this->logger->error('RestoreFromTrash listener aborted due to lifecycle error', [
 				'app' => 'etherpad_nextcloud',
-				'fileId' => (int)$node->getId(),
+				'fileId' => $this->loggableFileId($node),
 				'exception' => $e,
 			]);
 			throw $e;
 		}
+	}
+
+	/**
+	 * The id for a log line, or null when the node cannot supply one.
+	 * Reading it must never throw: this runs inside the catch above, where
+	 * a second exception would replace the one being reported and leave no
+	 * trace of what actually went wrong.
+	 */
+	private function loggableFileId(File $node): ?int {
+		try {
+			return (int)$node->getId();
+		} catch (\Throwable) {
+			return null;
+		}
+	}
+
+	/**
+	 * Return a node whose id can be read, re-resolving it from its path if
+	 * the one handed to us cannot. The owner comes from the path rather
+	 * than the session, because `occ trashbin:restore` has no session.
+	 */
+	private function materialize(File $node): ?File {
+		try {
+			$node->getId();
+			return $node;
+		} catch (\Throwable) {
+			// Not resolvable yet — fall through and look it up by path.
+		}
+
+		try {
+			$path = $node->getPath();
+		} catch (\Throwable) {
+			return null;
+		}
+
+		$parts = explode('/', ltrim($path, '/'), 3);
+		if (count($parts) !== 3 || $parts[1] !== 'files' || $parts[0] === '' || $parts[2] === '') {
+			return null;
+		}
+
+		try {
+			$resolved = $this->rootFolder->getUserFolder($parts[0])->get($parts[2]);
+		} catch (NotFoundException) {
+			return null;
+		} catch (\Throwable $e) {
+			$this->logger->warning('RestoreFromTrash listener could not resolve the restored node.', [
+				'app' => 'etherpad_nextcloud',
+				'filePath' => $path,
+				'exception' => $e,
+			]);
+			return null;
+		}
+
+		return $resolved instanceof File ? $resolved : null;
 	}
 
 	private function resolveUserFileByPath(string $path): ?File {

--- a/tests/phpunit/unit/RestoreFromTrashListenerTest.php
+++ b/tests/phpunit/unit/RestoreFromTrashListenerTest.php
@@ -141,21 +141,22 @@ class RestoreFromTrashListenerTest extends TestCase {
 	}
 
 	/**
-	 * The error path logs the file id, and on the node above that read
-	 * throws too. A second exception there would replace the one being
-	 * reported and leave no trace of the real cause — which is exactly what
-	 * made the Nextcloud 31 failure show up as a bare NotFoundException.
+	 * A node can go stale between being handed over and the lifecycle
+	 * failing, so the error path must survive an id it can no longer read.
+	 * Logging that threw a second time used to replace the exception being
+	 * reported, which is why the Nextcloud 31 failure showed up in the log
+	 * as a bare NotFoundException with nothing about its cause.
 	 */
 	public function testLifecycleErrorIsRethrownEvenWhenTheIdCannotBeLogged(): void {
+		$reads = 0;
 		$file = $this->createMock(File::class);
-		$file->method('getId')->willThrowException(new NotFoundException());
-		$file->method('getPath')->willReturn('/alice/files/notes.pad');
-
-		$userFolder = $this->createMock(Folder::class);
-		$userFolder->method('get')->willReturn($file);
-
-		$rootFolder = $this->createMock(IRootFolder::class);
-		$rootFolder->method('getUserFolder')->willReturn($userFolder);
+		$file->method('getId')->willReturnCallback(function () use (&$reads): int {
+			$reads++;
+			if ($reads === 1) {
+				return 42;
+			}
+			throw new NotFoundException();
+		});
 
 		$boom = new \RuntimeException('lifecycle exploded');
 		$lifecycleService = $this->createMock(LifecycleService::class);
@@ -164,12 +165,86 @@ class RestoreFromTrashListenerTest extends TestCase {
 		$listener = new RestoreFromTrashListener(
 			$lifecycleService,
 			$this->createMock(IUserSession::class),
-			$rootFolder,
+			$this->createMock(IRootFolder::class),
 			$this->createMock(LoggerInterface::class),
 		);
 
 		$this->expectExceptionObject($boom);
 		$listener->handle(new class($file) extends Event {
+			public function __construct(private File $file) {
+			}
+
+			public function getTarget(): File {
+				return $this->file;
+			}
+		});
+	}
+
+	/**
+	 * The fallback is held to the same standard as the node it replaces:
+	 * handleRestore() reads the id on its first line, so passing on one that
+	 * still throws would put the restore-aborting behaviour straight back.
+	 */
+	public function testUnresolvableFallbackIsSkippedInsteadOfPassedOn(): void {
+		$unresolvable = $this->createMock(File::class);
+		$unresolvable->method('getId')->willThrowException(new NotFoundException());
+		$unresolvable->method('getPath')->willReturn('/alice/files/notes.pad');
+
+		$stillUnresolvable = $this->createMock(File::class);
+		$stillUnresolvable->method('getId')->willThrowException(new NotFoundException());
+
+		$userFolder = $this->createMock(Folder::class);
+		$userFolder->method('get')->willReturn($stillUnresolvable);
+
+		$rootFolder = $this->createMock(IRootFolder::class);
+		$rootFolder->method('getUserFolder')->willReturn($userFolder);
+
+		$lifecycleService = $this->createMock(LifecycleService::class);
+		$lifecycleService->expects($this->never())->method('handleRestore');
+
+		$logger = $this->createMock(LoggerInterface::class);
+		$logger->expects($this->once())->method('warning');
+
+		$listener = new RestoreFromTrashListener(
+			$lifecycleService,
+			$this->createMock(IUserSession::class),
+			$rootFolder,
+			$logger,
+		);
+
+		$listener->handle(new class($unresolvable) extends Event {
+			public function __construct(private File $file) {
+			}
+
+			public function getTarget(): File {
+				return $this->file;
+			}
+		});
+	}
+
+	/** A path that is not /<user>/files/... is skipped, and says so. */
+	public function testUnexpectedPathShapeIsSkippedWithAReason(): void {
+		$node = $this->createMock(File::class);
+		$node->method('getId')->willThrowException(new NotFoundException());
+		$node->method('getPath')->willReturn('/somewhere/else.pad');
+
+		$rootFolder = $this->createMock(IRootFolder::class);
+		$rootFolder->expects($this->never())->method('getUserFolder');
+
+		$lifecycleService = $this->createMock(LifecycleService::class);
+		$lifecycleService->expects($this->never())->method('handleRestore');
+
+		$logger = $this->createMock(LoggerInterface::class);
+		$logger->expects($this->once())->method('warning');
+
+		$listener = new RestoreFromTrashListener(
+			$lifecycleService,
+			$this->createMock(IUserSession::class),
+			$rootFolder,
+			$logger,
+		);
+
+		$listener->handle(new class($node) extends Event {
 			public function __construct(private File $file) {
 			}
 

--- a/tests/phpunit/unit/RestoreFromTrashListenerTest.php
+++ b/tests/phpunit/unit/RestoreFromTrashListenerTest.php
@@ -10,6 +10,7 @@ use OCP\EventDispatcher\Event;
 use OCP\Files\File;
 use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
+use OCP\Files\NotFoundException;
 use OCP\IUser;
 use OCP\IUserSession;
 use PHPUnit\Framework\TestCase;
@@ -84,5 +85,97 @@ class RestoreFromTrashListenerTest extends TestCase {
 			'filePath' => '/G - Jacobs Test Gruppe/Neues Pad 9.pad',
 			'trashPath' => 'files_trashbin/files/Neues Pad 9.pad.d1777397341',
 		]);
+	}
+
+	/**
+	 * Nextcloud 31 hands the event a node that is not resolvable yet, so
+	 * reading its id throws. That exception used to escape the listener and
+	 * abort the restore itself — a .pad could not be brought back from the
+	 * trash at all, through the web UI, WebDAV or `occ trashbin:restore`.
+	 * The owner is taken from the path because occ has no session.
+	 */
+	public function testUnresolvableEventTargetIsLookedUpByPath(): void {
+		$unresolvable = $this->createMock(File::class);
+		$unresolvable->method('getId')->willThrowException(new NotFoundException());
+		$unresolvable->method('getPath')->willReturn('/alice/files/notes.pad');
+
+		$resolved = $this->createMock(File::class);
+		$resolved->method('getId')->willReturn(42);
+
+		$userFolder = $this->createMock(Folder::class);
+		$userFolder->expects($this->once())
+			->method('get')
+			->with('notes.pad')
+			->willReturn($resolved);
+
+		$rootFolder = $this->createMock(IRootFolder::class);
+		$rootFolder->expects($this->once())
+			->method('getUserFolder')
+			->with('alice')
+			->willReturn($userFolder);
+
+		$userSession = $this->createMock(IUserSession::class);
+		$userSession->expects($this->never())->method('getUser');
+
+		$lifecycleService = $this->createMock(LifecycleService::class);
+		$lifecycleService->expects($this->once())
+			->method('handleRestore')
+			->with($resolved)
+			->willReturn(['status' => LifecycleService::RESULT_RESTORED]);
+
+		$listener = new RestoreFromTrashListener(
+			$lifecycleService,
+			$userSession,
+			$rootFolder,
+			$this->createMock(LoggerInterface::class),
+		);
+
+		$listener->handle(new class($unresolvable) extends Event {
+			public function __construct(private File $file) {
+			}
+
+			public function getTarget(): File {
+				return $this->file;
+			}
+		});
+	}
+
+	/**
+	 * The error path logs the file id, and on the node above that read
+	 * throws too. A second exception there would replace the one being
+	 * reported and leave no trace of the real cause — which is exactly what
+	 * made the Nextcloud 31 failure show up as a bare NotFoundException.
+	 */
+	public function testLifecycleErrorIsRethrownEvenWhenTheIdCannotBeLogged(): void {
+		$file = $this->createMock(File::class);
+		$file->method('getId')->willThrowException(new NotFoundException());
+		$file->method('getPath')->willReturn('/alice/files/notes.pad');
+
+		$userFolder = $this->createMock(Folder::class);
+		$userFolder->method('get')->willReturn($file);
+
+		$rootFolder = $this->createMock(IRootFolder::class);
+		$rootFolder->method('getUserFolder')->willReturn($userFolder);
+
+		$boom = new \RuntimeException('lifecycle exploded');
+		$lifecycleService = $this->createMock(LifecycleService::class);
+		$lifecycleService->method('handleRestore')->willThrowException($boom);
+
+		$listener = new RestoreFromTrashListener(
+			$lifecycleService,
+			$this->createMock(IUserSession::class),
+			$rootFolder,
+			$this->createMock(LoggerInterface::class),
+		);
+
+		$this->expectExceptionObject($boom);
+		$listener->handle(new class($file) extends Event {
+			public function __construct(private File $file) {
+			}
+
+			public function getTarget(): File {
+				return $this->file;
+			}
+		});
 	}
 }


### PR DESCRIPTION
On Nextcloud 31 restoring a `.pad` from the trash fails. Through the web UI and WebDAV it ends in an HTTP 500; through `occ trashbin:restore` it prints a bare `Failed:` while plain files listed next to it come back fine. The file is not lost, but it cannot be brought back.

`NodeRestoredEvent` hands the listener a node that cannot be resolved yet, so reading its id throws. `LifecycleService::handleRestore()` does exactly that on its first line, the exception escapes the listener, and it aborts the restore Nextcloud is in the middle of. Nextcloud 32 and 33 pass a resolvable node, which is why this survived unnoticed — the suite only ever ran against one instance.

The listener now re-resolves the node from its path before handing it on. The owner is taken from the path rather than the session, because `occ` has none.

The error path made the diagnosis worse than the bug: it logged the file id, from that same node, inside the `catch`. That threw a second time and replaced the exception being reported, so the log showed an empty `NotFoundException` and nothing about the cause. Reading an id for a log line can no longer throw.

**Verified:** two unit tests that fail without the fix — one for the unresolvable node, one asserting the original exception survives when the id cannot be logged. Full PHPUnit 576/2193, Psalm clean. Reproduced end to end on a Nextcloud 31 container before and after: `occ trashbin:restore` goes from `Failed:` to `success`, and the `pad-trash-restore` browser spec from red to green on 31, 32 and 33.

The container stack those runs used arrives in the follow-up PR for #112.
