### PR TITLE
Allow creating a pad directly in the user's root folder

### DIFF
--- a/lib/Service/UserNodeResolver.php
+++ b/lib/Service/UserNodeResolver.php
@@ -38,16 +38,24 @@ class UserNodeResolver {
 	}
 
 	/**
+	 * The user's own root counts as one of their folders. Its path is
+	 * `/<uid>/files` with no trailing slash, so a prefix test alone rejects
+	 * it — and create-by-parent then cannot create a pad directly in "All
+	 * files", which is where someone is most likely to start.
+	 *
 	 * @throws NotFoundException
 	 */
 	public function resolveUserFolderNodeById(string $uid, int $folderId): Folder {
 		$nodes = $this->rootFolder->getById($folderId);
-		$prefix = '/' . $uid . '/files/';
+		$root = '/' . $uid . '/files';
 		foreach ($nodes as $node) {
 			if (!$node instanceof Folder) {
 				continue;
 			}
-			if (str_starts_with((string)$node->getPath(), $prefix)) {
+			$path = rtrim((string)$node->getPath(), '/');
+			// The separator stays in the prefix test so a sibling that merely
+			// starts the same way — /<uid>/files_versions — is still refused.
+			if ($path === $root || str_starts_with($path, $root . '/')) {
 				return $node;
 			}
 		}

--- a/tests/phpunit/unit/UserNodeResolverTest.php
+++ b/tests/phpunit/unit/UserNodeResolverTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * Copyright (c) 2026 Jacob Bühler
+ */
+
+namespace OCA\EtherpadNextcloud\Tests\Unit;
+
+use OCA\EtherpadNextcloud\Service\UserNodeResolver;
+use OCP\Files\File;
+use OCP\Files\Folder;
+use OCP\Files\IRootFolder;
+use OCP\Files\NotFoundException;
+use PHPUnit\Framework\TestCase;
+
+class UserNodeResolverTest extends TestCase {
+	private function resolverFor(array $nodes): UserNodeResolver {
+		$rootFolder = $this->createMock(IRootFolder::class);
+		$rootFolder->method('getById')->willReturn($nodes);
+		return new UserNodeResolver($rootFolder);
+	}
+
+	private function folderAt(string $path): Folder {
+		$folder = $this->createMock(Folder::class);
+		$folder->method('getPath')->willReturn($path);
+		return $folder;
+	}
+
+	public function testResolvesAFolderBelowTheUserRoot(): void {
+		$folder = $this->folderAt('/alice/files/Projects');
+		$resolver = $this->resolverFor([$folder]);
+
+		$this->assertSame($folder, $resolver->resolveUserFolderNodeById('alice', 42));
+	}
+
+	/**
+	 * The user's own root has the path `/<uid>/files`, without a trailing
+	 * slash, so a prefix check against `/<uid>/files/` rejects it — and
+	 * create-by-parent cannot create a pad directly in "All files".
+	 */
+	public function testResolvesTheUserRootItself(): void {
+		$root = $this->folderAt('/alice/files');
+		$resolver = $this->resolverFor([$root]);
+
+		$this->assertSame($root, $resolver->resolveUserFolderNodeById('alice', 42));
+	}
+
+	public function testRejectsAFolderBelongingToAnotherUser(): void {
+		$resolver = $this->resolverFor([$this->folderAt('/bob/files/Projects')]);
+
+		$this->expectException(NotFoundException::class);
+		$resolver->resolveUserFolderNodeById('alice', 42);
+	}
+
+	/** A sibling directory that merely starts the same way is not the root. */
+	public function testRejectsALookalikeSiblingOfTheUserRoot(): void {
+		$resolver = $this->resolverFor([$this->folderAt('/alice/files_versions/Projects')]);
+
+		$this->expectException(NotFoundException::class);
+		$resolver->resolveUserFolderNodeById('alice', 42);
+	}
+
+	public function testRejectsAFileWhenAFolderWasAskedFor(): void {
+		$file = $this->createMock(File::class);
+		$file->method('getPath')->willReturn('/alice/files/notes.pad');
+		$resolver = $this->resolverFor([$file]);
+
+		$this->expectException(NotFoundException::class);
+		$resolver->resolveUserFolderNodeById('alice', 42);
+	}
+
+	public function testResolvesAFileBelowTheUserRoot(): void {
+		$file = $this->createMock(File::class);
+		$file->method('getPath')->willReturn('/alice/files/notes.pad');
+		$resolver = $this->resolverFor([$file]);
+
+		$this->assertSame($file, $resolver->resolveUserFileNodeById('alice', 42));
+	}
+
+	public function testRejectsAnotherUsersFile(): void {
+		$file = $this->createMock(File::class);
+		$file->method('getPath')->willReturn('/bob/files/notes.pad');
+		$resolver = $this->resolverFor([$file]);
+
+		$this->expectException(NotFoundException::class);
+		$resolver->resolveUserFileNodeById('alice', 42);
+	}
+}


### PR DESCRIPTION
`create-by-parent` answers `404 Cannot resolve selected parent folder` for the user's own root — the one folder someone is most likely to start in.

`UserNodeResolver::resolveUserFolderNodeById` tested the folder's path against the prefix `/<uid>/files/`. The user's root is `/<uid>/files`, without the trailing slash, so it never matched. Every folder below it worked, which is why this went unnoticed.

Reproduced against a containerised Nextcloud before and after the change: the same request goes from `404` to a created pad.

The separator stays in the prefix test, so a sibling directory that merely starts the same way — `/<uid>/files_versions` — is still refused. That case now has a test, along with the root itself, another user's folder, and a file offered where a folder was asked for: the resolver had no tests at all, and it decides which node a request is allowed to reach.

**Verified:** PHPUnit 585/2205, Psalm clean, and the browser suite green against the container stack.
