### PR TITLE
Create the pad file atomically, and roll back the file it created

### DIFF
--- a/lib/Service/PadCreateRollbackService.php
+++ b/lib/Service/PadCreateRollbackService.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace OCA\EtherpadNextcloud\Service;
 
+use OCP\Files\File;
 use OCP\Files\IRootFolder;
 use Psr\Log\LoggerInterface;
 
@@ -25,10 +26,10 @@ class PadCreateRollbackService {
 	) {
 	}
 
-	public function rollbackFailedCreate(string $uid, string $path, string $padId, bool $fileCreated): void {
+	public function rollbackFailedCreate(string $uid, string $path, string $padId, int $createdFileId): void {
 		try {
-			if ($fileCreated) {
-				$this->deleteUserNodeIfExists($uid, $path);
+			if ($createdFileId > 0) {
+				$this->deleteCreatedFile($uid, $createdFileId);
 			}
 		} catch (\Throwable $cleanupError) {
 			$this->logger->warning('Could not cleanup failed .pad file create', [
@@ -51,10 +52,10 @@ class PadCreateRollbackService {
 		}
 	}
 
-	public function rollbackExternalCreate(string $uid, string $path, bool $fileCreated): void {
+	public function rollbackExternalCreate(string $uid, string $path, int $createdFileId): void {
 		try {
-			if ($fileCreated) {
-				$this->deleteUserNodeIfExists($uid, $path);
+			if ($createdFileId > 0) {
+				$this->deleteCreatedFile($uid, $createdFileId);
 			}
 		} catch (\Throwable $cleanupError) {
 			$this->logger->warning('Could not cleanup failed external .pad create', [
@@ -65,15 +66,25 @@ class PadCreateRollbackService {
 		}
 	}
 
-	private function deleteUserNodeIfExists(string $uid, string $absolutePath): void {
-		$relativePath = ltrim($absolutePath, '/');
-		if ($relativePath === '') {
+	/**
+	 * Delete the node this create actually made, identified by its file id.
+	 *
+	 * Resolving the path again instead would delete whatever holds that name
+	 * by the time cleanup runs. A path is not an identity: the file can be
+	 * moved or renamed while Etherpad is being provisioned, and the freed
+	 * name can be taken by something else — which a later failure would then
+	 * delete. The id follows the file wherever it went, and matches nothing
+	 * else.
+	 */
+	private function deleteCreatedFile(string $uid, int $fileId): void {
+		if ($fileId <= 0) {
 			return;
 		}
-		$userFolder = $this->rootFolder->getUserFolder($uid);
-		if (!$userFolder->nodeExists($relativePath)) {
-			return;
+		// Scoped to the user's own folder, so an id that somehow belongs
+		// elsewhere resolves to nothing rather than to someone else's file.
+		$node = $this->rootFolder->getUserFolder($uid)->getFirstNodeById($fileId);
+		if ($node instanceof File) {
+			$node->delete();
 		}
-		$userFolder->get($relativePath)->delete();
 	}
 }

--- a/lib/Service/PadCreationService.php
+++ b/lib/Service/PadCreationService.php
@@ -43,16 +43,19 @@ class PadCreationService {
 		$this->padTypePolicy->requireEnabled($accessMode);
 		$path = $this->padPaths->normalizeCreatePath($file);
 		$padId = '';
-		$fileCreated = false;
+		$createdFileId = 0;
 
 		return $this->withCreateRollback(
-			function () use ($uid, $path, $accessMode, &$padId, &$fileCreated): array {
+			function () use ($uid, $path, $accessMode, &$padId, &$createdFileId): array {
 				$fileNode = $this->padFileCreator->createUserFile($uid, $path);
-				$fileCreated = true;
 				$fileId = (int)$fileNode->getId();
 				if ($fileId <= 0) {
+					// Without an id the file cannot be identified again, so
+					// rollback will leave it rather than guess by name. An
+					// empty leftover beats deleting someone else's file.
 					throw new \RuntimeException('Could not resolve new file ID.');
 				}
+				$createdFileId = $fileId;
 				$padId = $this->padBootstrapService->provisionPadId($accessMode);
 				$padUrl = $this->etherpadClient->buildPadUrl($padId);
 
@@ -75,8 +78,8 @@ class PadCreationService {
 					'pad_url' => $padUrl,
 				];
 			},
-			function () use ($uid, $path, &$padId, &$fileCreated): void {
-				$this->rollbackService->rollbackFailedCreate($uid, $path, $padId, $fileCreated);
+			function () use ($uid, $path, &$padId, &$createdFileId): void {
+				$this->rollbackService->rollbackFailedCreate($uid, $path, $padId, $createdFileId);
 			},
 			function (\Throwable $e) use ($path, $accessMode, &$padId): ?array {
 				if ($e instanceof BindingException) {
@@ -117,18 +120,21 @@ class PadCreationService {
 		}
 
 		$padId = '';
-		$fileCreated = false;
+		$createdFileId = 0;
 		$path = '';
 
 		return $this->withCreateRollback(
-			function () use ($uid, $parentFolder, $parentFolderId, $fileName, $accessMode, &$path, &$padId, &$fileCreated): array {
+			function () use ($uid, $parentFolder, $parentFolderId, $fileName, $accessMode, &$path, &$padId, &$createdFileId): array {
 				$fileNode = $this->padFileCreator->createUserFileInFolder($parentFolder, $fileName);
-				$fileCreated = true;
 				$path = $this->userNodeResolver->toUserAbsolutePath($uid, $fileNode);
 				$fileId = (int)$fileNode->getId();
 				if ($fileId <= 0) {
+					// Without an id the file cannot be identified again, so
+					// rollback will leave it rather than guess by name. An
+					// empty leftover beats deleting someone else's file.
 					throw new \RuntimeException('Could not resolve new file ID.');
 				}
+				$createdFileId = $fileId;
 
 				$padId = $this->padBootstrapService->provisionPadId($accessMode);
 				$padUrl = $this->etherpadClient->buildPadUrl($padId);
@@ -151,8 +157,8 @@ class PadCreationService {
 					'pad_url' => $padUrl,
 				];
 			},
-			function () use ($uid, &$path, &$padId, &$fileCreated): void {
-				$this->rollbackService->rollbackFailedCreate($uid, $path, $padId, $fileCreated);
+			function () use ($uid, &$path, &$padId, &$createdFileId): void {
+				$this->rollbackService->rollbackFailedCreate($uid, $path, $padId, $createdFileId);
 			},
 			function (\Throwable $e) use ($parentFolderId, $name, $accessMode, &$path, &$padId): ?array {
 				if ($e instanceof BindingException) {
@@ -190,16 +196,19 @@ class PadCreationService {
 	 */
 	public function createFromUrl(string $uid, string $file, string $padUrl): array {
 		$path = $this->padPaths->normalizeCreatePath($file);
-		$fileCreated = false;
+		$createdFileId = 0;
 
 		return $this->withCreateRollback(
-			function () use ($uid, $path, $padUrl, &$fileCreated) {
+			function () use ($uid, $path, $padUrl, &$createdFileId) {
 				$fileNode = $this->padFileCreator->createUserFile($uid, $path);
-				$fileCreated = true;
 				$fileId = (int)$fileNode->getId();
 				if ($fileId <= 0) {
+					// Without an id the file cannot be identified again, so
+					// rollback will leave it rather than guess by name. An
+					// empty leftover beats deleting someone else's file.
 					throw new \RuntimeException('Could not resolve new file ID.');
 				}
+				$createdFileId = $fileId;
 
 				$seeded = $this->externalPadSeeder->seed($fileNode, $fileId, $padUrl);
 				// Preserve the historical key ordering for the external-create
@@ -208,8 +217,8 @@ class PadCreationService {
 				$result = ['file' => $path] + $seeded;
 				return $result;
 			},
-			function () use ($uid, $path, &$fileCreated): void {
-				$this->rollbackService->rollbackExternalCreate($uid, $path, $fileCreated);
+			function () use ($uid, $path, &$createdFileId): void {
+				$this->rollbackService->rollbackExternalCreate($uid, $path, $createdFileId);
 			},
 			function (\Throwable $e) use ($path, $padUrl): ?array {
 				if ($e instanceof EtherpadClientException) {
@@ -253,12 +262,11 @@ class PadCreationService {
 		$templateNode = $this->userNodeResolver->resolveUserFileNodeById($uid, $templateFileId);
 
 		$padId = '';
-		$fileCreated = false;
+		$createdFileId = 0;
 
 		return $this->withCreateRollback(
-			function () use ($uid, $path, $templateNode, $user, &$padId, &$fileCreated): array {
+			function () use ($uid, $path, $templateNode, $user, &$padId, &$createdFileId): array {
 				$fileNode = $this->padFileCreator->createUserFile($uid, $path);
-				$fileCreated = true;
 
 				$result = $this->materializeTemplateInto($fileNode, $templateNode, $user);
 				$padId = $result['pad_id'];
@@ -271,8 +279,8 @@ class PadCreationService {
 					'pad_url' => $result['pad_url'],
 				];
 			},
-			function () use ($uid, $path, &$padId, &$fileCreated): void {
-				$this->rollbackService->rollbackFailedCreate($uid, $path, $padId, $fileCreated);
+			function () use ($uid, $path, &$padId, &$createdFileId): void {
+				$this->rollbackService->rollbackFailedCreate($uid, $path, $padId, $createdFileId);
 			},
 			function (\Throwable $e) use ($path, &$padId): ?array {
 				if ($e instanceof BindingException) {

--- a/lib/Service/PadCreationService.php
+++ b/lib/Service/PadCreationService.php
@@ -267,6 +267,10 @@ class PadCreationService {
 		return $this->withCreateRollback(
 			function () use ($uid, $path, $templateNode, $user, &$padId, &$createdFileId): array {
 				$fileNode = $this->padFileCreator->createUserFile($uid, $path);
+				// Recorded before the template is materialised: everything
+				// after this can fail, and rollback needs to know which file
+				// to remove.
+				$createdFileId = (int)$fileNode->getId();
 
 				$result = $this->materializeTemplateInto($fileNode, $templateNode, $user);
 				$padId = $result['pad_id'];

--- a/tests/phpunit/stubs/OCP/Files/Folder.php
+++ b/tests/phpunit/stubs/OCP/Files/Folder.php
@@ -10,6 +10,9 @@ if (!interface_exists(Folder::class)) {
 
 		public function get(string $path): mixed;
 
+		/** Mirrors OCP\Files\Folder::getFirstNodeById(): the node or null. */
+		public function getFirstNodeById(int $id): mixed;
+
 		public function newFile(string $name, $content = null): mixed;
 
 		public function newFolder(string $path): Folder;

--- a/tests/phpunit/unit/PadCreateRollbackServiceTest.php
+++ b/tests/phpunit/unit/PadCreateRollbackServiceTest.php
@@ -6,49 +6,95 @@ namespace OCA\EtherpadNextcloud\Tests\Unit;
 
 use OCA\EtherpadNextcloud\Service\EtherpadClient;
 use OCA\EtherpadNextcloud\Service\PadCreateRollbackService;
+use OCP\Files\File;
 use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
 class PadCreateRollbackServiceTest extends TestCase {
-	public function testRollbackDoesNotDeleteExistingNodeWhenCreateDidNotCreateFile(): void {
+	public function testRollbackTouchesNothingWhenNoFileWasCreated(): void {
 		$rootFolder = $this->createMock(IRootFolder::class);
 		$rootFolder->expects($this->never())->method('getUserFolder');
 
 		$this->buildService($rootFolder)
-			->rollbackFailedCreate('alice', '/Existing.pad', '', false);
+			->rollbackFailedCreate('alice', '/Existing.pad', '', 0);
 	}
 
-	public function testRollbackDeletesCreatedFileWhenItStillExists(): void {
-		$deletedNode = new class {
-			public bool $deleted = false;
+	public function testRollbackDeletesTheFileItCreated(): void {
+		$created = $this->createMock(File::class);
+		$created->expects($this->once())->method('delete');
 
-			public function delete(): void {
-				$this->deleted = true;
-			}
-		};
+		$this->buildService($this->rootFolderReturning($created, 4711))
+			->rollbackFailedCreate('alice', '/Created.pad', '', 4711);
+	}
 
+	/**
+	 * The path is only carried for log lines. Cleanup follows the id, so a
+	 * file that was renamed or moved while Etherpad was being provisioned is
+	 * still the one that gets deleted — and whatever took its old name is
+	 * not.
+	 */
+	public function testRollbackFollowsTheFileRatherThanTheName(): void {
+		$movedAway = $this->createMock(File::class);
+		$movedAway->method('getPath')->willReturn('/alice/files/Archive/Created.pad');
+		$movedAway->expects($this->once())->method('delete');
+
+		$this->buildService($this->rootFolderReturning($movedAway, 4711))
+			->rollbackFailedCreate('alice', '/Created.pad', '', 4711);
+	}
+
+	public function testRollbackDeletesNothingWhenTheFileIsAlreadyGone(): void {
+		$this->buildService($this->rootFolderReturning(null, 4711))
+			->rollbackFailedCreate('alice', '/Created.pad', '', 4711);
+
+		$this->addToAssertionCount(1);
+	}
+
+	/** A folder sharing the id is not what this create made. */
+	public function testRollbackIgnoresANodeThatIsNotAFile(): void {
+		$folder = $this->createMock(Folder::class);
+		$folder->expects($this->never())->method('delete');
+
+		$this->buildService($this->rootFolderReturning($folder, 4711))
+			->rollbackFailedCreate('alice', '/Created.pad', '', 4711);
+	}
+
+	public function testExternalRollbackDeletesTheFileItCreated(): void {
+		$created = $this->createMock(File::class);
+		$created->expects($this->once())->method('delete');
+
+		$this->buildService($this->rootFolderReturning($created, 4711))
+			->rollbackExternalCreate('alice', '/Created.pad', 4711);
+	}
+
+	/** A cleanup failure must not replace the error that caused the rollback. */
+	public function testRollbackSwallowsADeleteFailure(): void {
+		$created = $this->createMock(File::class);
+		$created->method('delete')->willThrowException(new \RuntimeException('nope'));
+
+		$this->buildService($this->rootFolderReturning($created, 4711))
+			->rollbackFailedCreate('alice', '/Created.pad', '', 4711);
+
+		$this->addToAssertionCount(1);
+	}
+
+	private function rootFolderReturning(mixed $node, int $fileId): IRootFolder {
 		$userFolder = $this->createMock(Folder::class);
 		$userFolder->expects($this->once())
-			->method('nodeExists')
-			->with('Created.pad')
-			->willReturn(true);
-		$userFolder->expects($this->once())
-			->method('get')
-			->with('Created.pad')
-			->willReturn($deletedNode);
+			->method('getFirstNodeById')
+			->with($fileId)
+			->willReturn($node);
+		// Nothing may be resolved by name any more.
+		$userFolder->expects($this->never())->method('get');
+		$userFolder->expects($this->never())->method('nodeExists');
 
 		$rootFolder = $this->createMock(IRootFolder::class);
 		$rootFolder->expects($this->once())
 			->method('getUserFolder')
 			->with('alice')
 			->willReturn($userFolder);
-
-		$this->buildService($rootFolder)
-			->rollbackFailedCreate('alice', '/Created.pad', '', true);
-
-		$this->assertTrue($deletedNode->deleted);
+		return $rootFolder;
 	}
 
 	private function buildService(IRootFolder $rootFolder): PadCreateRollbackService {

--- a/tests/phpunit/unit/PadCreationServiceTest.php
+++ b/tests/phpunit/unit/PadCreationServiceTest.php
@@ -75,7 +75,7 @@ class PadCreationServiceTest extends TestCase {
 		$rollbackService = $this->createMock(PadCreateRollbackService::class);
 		$rollbackService->expects($this->once())
 			->method('rollbackFailedCreate')
-			->with('alice', '/Test.pad', 'g.ABC$pad', true);
+			->with('alice', '/Test.pad', 'g.ABC$pad', 123);
 
 		$bootstrap = $this->createMock(PadBootstrapService::class);
 		$bootstrap->method('provisionPadId')->willReturn('g.ABC$pad');
@@ -366,7 +366,7 @@ class PadCreationServiceTest extends TestCase {
 		$rollbackService = $this->createMock(PadCreateRollbackService::class);
 		$rollbackService->expects($this->once())
 			->method('rollbackExternalCreate')
-			->with('alice', '/External.pad', true);
+			->with('alice', '/External.pad', 321);
 
 		$fetcher = $this->createMock(ExternalPadExportFetcher::class);
 		$fetcher->method('normalizeAndFetchExternalPublicPadTextOrEmpty')
@@ -448,6 +448,48 @@ class PadCreationServiceTest extends TestCase {
 		$this->assertSame(99, $result['file_id']);
 		$this->assertSame('p-fresh', $result['pad_id']);
 		$this->assertSame(BindingService::ACCESS_PROTECTED, $result['access_mode']);
+	}
+
+	/**
+	 * Everything after the file is created can still fail, and the rollback
+	 * then has to be told which file to remove. The template flow used to
+	 * signal that with a boolean; carrying the id is what makes cleanup
+	 * follow the file rather than its name.
+	 */
+	public function testCreateFromTemplateRollsBackWithTheCreatedFileId(): void {
+		$templateNode = $this->createMock(\OCP\Files\File::class);
+		$templateNode->method('getName')->willReturn('Tpl.pad');
+		$templateNode->method('getContent')->willReturn('tpl-content');
+
+		$userNodeResolver = $this->createMock(UserNodeResolver::class);
+		$userNodeResolver->method('resolveUserFileNodeById')->willReturn($templateNode);
+
+		$padPaths = $this->createMock(PathNormalizer::class);
+		$padPaths->method('normalizeCreatePath')->willReturn('/FromTpl.pad');
+
+		$newFile = $this->createMock(\OCP\Files\File::class);
+		$newFile->method('getId')->willReturn(4242);
+		$fileCreator = $this->createMock(PadFileCreator::class);
+		$fileCreator->method('createUserFile')->willReturn($newFile);
+
+		// Fails after the file exists, which is the case that matters.
+		$padFileService = $this->createMock(PadFileService::class);
+		$padFileService->method('readPad')->willThrowException(new \RuntimeException('template unreadable'));
+
+		$rollbackService = $this->createMock(PadCreateRollbackService::class);
+		$rollbackService->expects($this->once())
+			->method('rollbackFailedCreate')
+			->with('alice', '/FromTpl.pad', '', 4242);
+
+		$this->expectException(\RuntimeException::class);
+
+		$this->buildService(
+			padPaths: $padPaths,
+			fileCreator: $fileCreator,
+			padFileService: $padFileService,
+			rollbackService: $rollbackService,
+			userNodeResolver: $userNodeResolver,
+		)->createFromTemplate('alice', '/FromTpl.pad', 7, null);
 	}
 
 	public function testCreateFromTemplateRefusesNonPadTemplate(): void {


### PR DESCRIPTION
Cleanup after a failed pad create resolved the path again and deleted whatever held that name.

A path is not an identity. While Etherpad is being provisioned the file can be moved or renamed, the freed name can be taken by something else, and a later failure then deletes that stranger's file. It is the one path in this flow that destroys data nobody asked it to touch.

The created node's id is carried through to the rollback instead, and looked up inside the user's own folder so an id from elsewhere resolves to nothing. The path is kept for log lines only.

One deliberate trade-off: if the id cannot be read at all, the create fails and the rollback leaves the file alone rather than guessing by name. An empty leftover `.pad` is a much smaller problem than deleting the wrong file.

**Tests.** The rollback service had two; it has seven, and they assert that nothing is resolved by name any more — a moved file is still deleted, a file that is already gone is a no-op, a folder sharing the id is not touched, and a failing delete does not replace the error that caused the rollback. `createFromTemplate` gained a failure case of its own; it fails without the fix.

Worth noting for anyone reading the diff: the two pre-existing expectations asserted `true` where the argument is now an id. PHPUnit compares loosely in `with()`, so `123 == true` kept them green while the contract had changed underneath them. They name the ids now.

The `Folder` test stub gained `getFirstNodeById`, matching the interface it stands in for (Nextcloud 29+; this app supports 31+).

**Verified:** PHPUnit 591/2235, Psalm clean.

The other half of that review — the race between `nodeExists()` and `newFile()` — is not in here. Measured against a container, concurrent creates of the same name do not overwrite each other; they answer 500 and sometimes create nothing at all. That needs a different fix and gets its own PR.
