### PR TITLE
Keep every protected pad open at once

### DIFF
--- a/docs/etherpad-integration.md
+++ b/docs/etherpad-integration.md
@@ -91,10 +91,30 @@ two cases at once, and only one of them is harmless:
   same, and carrying it would let the next person to log in keep their
   pad until it expired.
 
-Since nothing here can tell those apart, both are dropped. The cookie is
-also scoped to the domain Nextcloud and Etherpad share, so it reaches
-every host under that parent — it is not a pad-host-only cookie, which is
-how the open request can read it in the first place.
+Since nothing here can tell those apart, both are dropped. On a public
+share the session listing is not asked for at all: the author there comes
+from the share token, so every anonymous visitor of one link shares it,
+and Etherpad deletes no sessions — a link opened by hundreds of people
+would make every open download hundreds of entries.
+
+The cookie is scoped to the domain Nextcloud and Etherpad share, so it
+reaches every host under that parent — it is not a pad-host-only cookie,
+which is how the open request can read it in the first place.
+
+#### The costs this accepts
+
+- **One cookie now carries several sessions.** That is the point of it,
+  but it also means a single exposure — script on any host under the
+  shared parent domain, since the cookie cannot be `HttpOnly` on Etherpad
+  before 3.0.0 — yields every protected pad the user has open rather than
+  one. Narrowing the domain is not available: the cookie has to reach
+  Etherpad.
+- **A revoked share stays usable until its session expires.** Before, an
+  open of any other protected pad happened to overwrite the cookie and cut
+  it off; that only ever helped if the user opened another pad, and did
+  nothing otherwise. Nothing in the app deletes Etherpad sessions, so the
+  window is the session TTL either way — it is just no longer shortened by
+  accident.
 
 ### Author Resolution Strategy
 

--- a/docs/etherpad-integration.md
+++ b/docs/etherpad-integration.md
@@ -27,6 +27,7 @@ Important:
 - `createGroupPad`
 - `createAuthorIfNotExistsFor`
 - `createSession`
+- `listSessionsOfAuthor`
 
 ## Pad Types
 
@@ -49,9 +50,36 @@ Normal protected open flow:
 
 1. Extract group ID from pad ID.
 2. Resolve Etherpad author context for the Nextcloud user.
-3. Create Etherpad session via `createSession`.
-4. Set `sessionID` cookie.
+3. Create an Etherpad session for that group via `createSession`.
+4. Set the `sessionID` cookie — see below, it may carry several ids.
 5. Open regular pad URL.
+
+#### Why the cookie carries more than one session
+
+A session grants access to exactly one group, and every protected pad is
+its own group. The cookie is the only place that state lives, so writing
+just the new id used to revoke whatever the browser held: a second
+protected pad in a second tab took the first tab's access away, and
+Etherpad answered 403 for it.
+
+Etherpad reads the value as a comma-separated list and picks the entry
+matching the group being opened, so the others survive the write:
+
+- the ids the browser sent are the candidates — nothing is added that was
+  not already there, so an open never re-issues access to a pad the user
+  has since lost;
+- `listSessionsOfAuthor` says which group each of those belongs to and how
+  long it lasts, which is what keeps one entry per group rather than one
+  per open;
+- ids that listing does not know — another author's, which is every
+  public share, since each share token is its own Etherpad author — are
+  kept unverified, last, and under a tighter cap;
+- the cookie expires with the longest-lived id it carries, and holds at
+  most 25.
+
+If `listSessionsOfAuthor` is unavailable the open still happens, on the
+browser's cookie alone. That path cannot tell groups apart, so it keeps
+only a few carried-over ids and logs a warning.
 
 ### Author Resolution Strategy
 
@@ -68,25 +96,26 @@ For normal authenticated users, the plugin now caches Etherpad author state per 
 Open-path behavior:
 
 1. Try cached `authorId` for the current Nextcloud user.
-2. If the current display name differs from the cached synced name:
-   - call `setAuthorName`
-   - update cached name
-3. Try `createSession` with cached `authorId`.
-4. If session creation fails with an Etherpad API error:
+2. Call `createAuthorIfNotExistsFor` with the current display name. This
+   runs on every open even when the cached name still matches: it is the
+   only thing that keeps Etherpad's copy of the name in step with
+   Nextcloud's, and a name that drifted on the Etherpad side — a user
+   renaming themselves in the pad, another integrator — is never repaired
+   otherwise. If the answer is a different author id, the cache follows it.
+3. Build the open context with the cached `authorId`.
+4. If anything in that fails with an Etherpad API error:
    - clear cached author state
    - retry full author bootstrap through `createAuthorIfNotExistsFor`
-   - then create session again
+   - then build the open context again
 
-Why this exists:
+What the cache is for:
 
-- Without caching, a normal protected open typically required:
-  - `createAuthorIfNotExistsFor`
-  - `setAuthorName`
-  - `createSession`
-- With cache hit and unchanged display name, the hot path is usually only:
-  - `createSession`
+- it holds the author id, so the id does not have to be rediscovered from
+  scratch, and it holds the last synced name so a rename is written back
+  only when it actually changed;
+- it is not a way to skip the author call — see step 2.
 
-This reduces Etherpad API round-trips on repeated opens without weakening access checks or moving trust to the client.
+This keeps the author identity stable across opens without weakening access checks or moving trust to the client.
 
 Cookie details:
 

--- a/docs/etherpad-integration.md
+++ b/docs/etherpad-integration.md
@@ -68,18 +68,33 @@ matching the group being opened, so the others survive the write:
 - the ids the browser sent are the candidates — nothing is added that was
   not already there, so an open never re-issues access to a pad the user
   has since lost;
-- `listSessionsOfAuthor` says which group each of those belongs to and how
-  long it lasts, which is what keeps one entry per group rather than one
-  per open;
-- ids that listing does not know — another author's, which is every
-  public share, since each share token is its own Etherpad author — are
-  kept unverified, last, and under a tighter cap;
-- the cookie expires with the longest-lived id it carries, and holds at
-  most 25.
+- `listSessionsOfAuthor` says which of those belong to this Etherpad
+  author, which group each is for, and how long it lasts; that is what
+  keeps one entry per group rather than one per open;
+- ids the listing does not know are dropped, and the cookie expires with
+  the longest-lived id it keeps, up to 25 of them.
 
-If `listSessionsOfAuthor` is unavailable the open still happens, on the
-browser's cookie alone. That path cannot tell groups apart, so it keeps
-only a few carried-over ids and logs a warning.
+If `listSessionsOfAuthor` is unavailable, the open still happens but
+carries nothing — one fresh id, as before this mechanism existed — and
+logs a warning.
+
+#### What this deliberately does not do
+
+An id the current author does not own cannot be attributed. That covers
+two cases at once, and only one of them is harmless:
+
+- a protected **public share** is its own Etherpad author (`nc:public-share:<token>`),
+  so its session looks foreign to a logged-in user's author — a share and
+  an authenticated protected pad therefore cannot be open at the same
+  time, which was already true before;
+- the session of **whoever used the browser before** looks exactly the
+  same, and carrying it would let the next person to log in keep their
+  pad until it expired.
+
+Since nothing here can tell those apart, both are dropped. The cookie is
+also scoped to the domain Nextcloud and Etherpad share, so it reaches
+every host under that parent — it is not a pad-host-only cookie, which is
+how the open request can read it in the first place.
 
 ### Author Resolution Strategy
 

--- a/lib/Service/EtherpadClient.php
+++ b/lib/Service/EtherpadClient.php
@@ -133,7 +133,9 @@ class EtherpadClient {
 	 * @return array<string,array{groupID:string,validUntil:int}>
 	 */
 	public function listSessionsOfAuthor(string $authorId): array {
-		$data = $this->apiCall('listSessionsOfAuthor', ['authorID' => $authorId], 'GET');
+		// POST like every other authenticated call: a GET would put the
+		// apikey in the URL, and from there into proxy and access logs.
+		$data = $this->apiCall('listSessionsOfAuthor', ['authorID' => $authorId]);
 
 		$sessions = [];
 		foreach ($data as $sessionId => $info) {

--- a/lib/Service/EtherpadClient.php
+++ b/lib/Service/EtherpadClient.php
@@ -122,6 +122,35 @@ class EtherpadClient {
 		return $sessionId;
 	}
 
+	/**
+	 * The author's sessions, keyed by session id, each carrying the group it
+	 * grants access to and when it stops doing so.
+	 *
+	 * Etherpad keeps them until they are deleted — an author who has opened
+	 * protected pads for a while accumulates hundreds, nearly all expired —
+	 * so callers must filter by validUntil rather than trust the list.
+	 *
+	 * @return array<string,array{groupID:string,validUntil:int}>
+	 */
+	public function listSessionsOfAuthor(string $authorId): array {
+		$data = $this->apiCall('listSessionsOfAuthor', ['authorID' => $authorId], 'GET');
+
+		$sessions = [];
+		foreach ($data as $sessionId => $info) {
+			if (!is_string($sessionId) || !is_array($info)) {
+				continue;
+			}
+			$groupId = (string)($info['groupID'] ?? '');
+			$validUntil = (int)($info['validUntil'] ?? 0);
+			if ($groupId === '' || $validUntil <= 0) {
+				continue;
+			}
+			$sessions[$sessionId] = ['groupID' => $groupId, 'validUntil' => $validUntil];
+		}
+
+		return $sessions;
+	}
+
 	public function getReadOnlyPadUrl(string $padId): string {
 		$data = $this->apiCall('getReadOnlyID', ['padID' => $padId]);
 		$readOnlyId = (string)($data['readOnlyID'] ?? '');

--- a/lib/Service/PadSessionService.php
+++ b/lib/Service/PadSessionService.php
@@ -26,8 +26,10 @@ class PadSessionService {
 
 	/**
 	 * One entry per group, so this is how many protected pads may be open at
-	 * once before the oldest loses access. A session id is ~34 bytes, so 25
-	 * of them are under a kilobyte against the 4 KB a cookie may occupy. It
+	 * once before the oldest loses access. An Etherpad session id is `s.`
+	 * plus 16 characters, and buildSetCookieHeader percent-encodes the comma
+	 * between them, so 25 of them cost 25×18 + 24×3 = 522 bytes against the
+	 * 4 KB a cookie may occupy. It
 	 * is not a pad-host-only cookie — it is scoped to the domain both hosts
 	 * share, so Nextcloud and every sibling under that parent see it too,
 	 * which is how this request can read it at all. The pad being opened is
@@ -36,6 +38,15 @@ class PadSessionService {
 	 * looking at.
 	 */
 	private const MAX_SESSION_IDS = 25;
+
+	/**
+	 * How many ids are read out of the cookie at all. Only a bound on work:
+	 * the cap above decides what survives. Any host under the shared parent
+	 * domain can write this cookie, and without a limit a forged value would
+	 * decide how much parsing and comparing each open does. Twice the emit
+	 * cap, so a legitimate cookie is never truncated by it.
+	 */
+	private const MAX_PARSED_SESSION_IDS = 50;
 
 	public function __construct(
 		private EtherpadClient $etherpadClient,
@@ -57,7 +68,7 @@ class PadSessionService {
 		if ($authorId !== '') {
 			$authorId = $this->syncAuthorMapping($uid, $authorId, $effectiveDisplayName);
 			try {
-				return $this->openContextFor($authorId, $groupId, $padId, $validUntil);
+				return $this->openContextFor($uid, $authorId, $groupId, $padId, $validUntil);
 			} catch (EtherpadClientException) {
 				$this->clearCachedAuthorState($uid);
 			}
@@ -66,7 +77,7 @@ class PadSessionService {
 		$authorId = $this->etherpadClient->createAuthorIfNotExistsFor('nc:' . $uid, $effectiveDisplayName);
 		$this->rememberAuthorId($uid, $authorId);
 		$this->rememberAuthorName($uid, $effectiveDisplayName);
-		return $this->openContextFor($authorId, $groupId, $padId, $validUntil);
+		return $this->openContextFor($uid, $authorId, $groupId, $padId, $validUntil);
 	}
 
 	/**
@@ -83,13 +94,12 @@ class PadSessionService {
 	 * cookie says what this browser already held, so an open adds nothing
 	 * that was not already there — it does not re-issue access to a pad the
 	 * user has since lost, it only refrains from taking away what they were
-	 * carrying, which dies at its own validUntil. Etherpad's list then says
-	 * which of those are this author's; the rest are dropped.
-	 * Etherpad's session list says which group each of those ids belongs to
-	 * and how long it lasts, which is what lets one entry per group survive
-	 * rather than one per open: without it, opening the same pad ten times
-	 * filled the cookie with ten ids for one group and pushed the other pad
-	 * out.
+	 * carrying, which dies at its own validUntil. Etherpad's session list
+	 * then says which of those ids are this author's, which group each is
+	 * for, and how long it lasts — that is what lets one entry per group
+	 * survive rather than one per open: without it, opening the same pad ten
+	 * times filled the cookie with ten ids for one group and pushed the
+	 * other pad out.
 	 *
 	 * Ids the list does not know are dropped. That covers a public share's
 	 * session — each share token is its own Etherpad author — so a share and
@@ -101,31 +111,21 @@ class PadSessionService {
 	 *
 	 * @return array{url:string,cookie:array{name:string,value:string,expires:int,path:string,domain:string,secure:bool,http_only:bool,same_site:string}}
 	 */
-	private function openContextFor(string $authorId, string $groupId, string $padId, int $validUntil): array {
+	private function openContextFor(string $uid, string $authorId, string $groupId, string $padId, int $validUntil): array {
 		$carriedIds = $this->sessionIdsFromCookie();
-
-		// Nothing to annotate, nothing to ask. The first protected open of a
-		// browsing session — the common case, and the whole of it for anyone
-		// who only ever has one pad open — costs no extra round trip, and
-		// the listing is the call whose cost grows with every distinct pad
-		// the user has ever opened.
-		$sessions = [];
-		try {
-			if ($carriedIds !== []) {
-				$sessions = $this->etherpadClient->listSessionsOfAuthor($authorId);
-			}
-		} catch (EtherpadClientException $e) {
-			// Not fatal — the open proceeds on the cookie alone. Logged
-			// because that degraded path cannot tell groups apart, so the
-			// symptom this method exists to prevent comes back, and nothing
-			// else would say why.
-			$this->logger->warning('Could not list Etherpad sessions; the session cookie falls back to the browser copy', [
-				'app' => 'etherpad_nextcloud',
-				'exception' => $e,
-			]);
-		}
+		$sessions = $this->sessionsToAttributeWith($uid, $authorId, $carriedIds);
 
 		$chosenSessionId = $this->etherpadClient->createSession($groupId, $authorId, $validUntil);
+		if (preg_match(self::SESSION_ID_PATTERN, $chosenSessionId) !== 1) {
+			// The id is about to be written into a cookie that the next open
+			// has to be able to read back. If Etherpad's shape ever moves
+			// outside what sessionIdsFromCookie accepts, every later open
+			// would silently find an empty cookie and write a single id
+			// again — this branch's bug, restored, with nothing to say so.
+			$this->logger->warning('Etherpad returned a session id in an unexpected shape; carrying sessions between pads will not work', [
+				'app' => 'etherpad_nextcloud',
+			]);
+		}
 
 		return [
 			'url' => $this->etherpadClient->buildPadUrl($padId),
@@ -133,6 +133,45 @@ class PadSessionService {
 				$this->cookieValueFor($chosenSessionId, $validUntil, $groupId, $carriedIds, $sessions),
 			),
 		];
+	}
+
+	/**
+	 * What the carried ids can be checked against, or an empty list when
+	 * they cannot be checked at all.
+	 *
+	 * Not asked for when there is nothing to check — the first protected
+	 * open of a browsing session, and every open for anyone who only ever
+	 * has one pad open, costs no extra round trip.
+	 *
+	 * Not asked for on a public share either. There the author is derived
+	 * from the share token alone, so every anonymous visitor of one link
+	 * shares it, and Etherpad deletes no sessions: a link opened by five
+	 * hundred people carries five hundred sessions under one author, and
+	 * every open would download the lot. The cost is that two protected
+	 * pads inside one shared folder cannot be open at once, which is what
+	 * happened before this branch anyway.
+	 *
+	 * @param list<string> $carriedIds
+	 * @return array<string,array{groupID:string,validUntil:int}>
+	 */
+	private function sessionsToAttributeWith(string $uid, string $authorId, array $carriedIds): array {
+		if ($carriedIds === [] || !$this->shouldPersistAuthorState($uid)) {
+			return [];
+		}
+
+		try {
+			return $this->etherpadClient->listSessionsOfAuthor($authorId);
+		} catch (EtherpadClientException $e) {
+			// Not fatal: the open goes ahead. But nothing can be attributed
+			// without the listing, so nothing is carried and a second pad
+			// loses access exactly as it did before this existed — which is
+			// a symptom nothing else would explain.
+			$this->logger->warning('Could not list Etherpad sessions; this open drops the other pads\' sessions from the cookie', [
+				'app' => 'etherpad_nextcloud',
+				'exception' => $e,
+			]);
+			return [];
+		}
 	}
 
 	/**
@@ -151,9 +190,6 @@ class PadSessionService {
 		$carried = [];
 
 		foreach ($carriedIds as $candidate) {
-			if ($candidate === $chosenSessionId) {
-				continue;
-			}
 			$info = $sessions[$candidate] ?? null;
 			if ($info === null) {
 				// Not this author's, so not this user's: dropped. It used to
@@ -174,6 +210,17 @@ class PadSessionService {
 			if ($known === null || $info['validUntil'] > $known['validUntil']) {
 				$carried[$info['groupID']] = ['sessionId' => $candidate, 'validUntil' => $info['validUntil']];
 			}
+		}
+
+		if ($carried === [] && $carriedIds !== [] && $sessions !== []) {
+			// The browser brought ids and this author owns none of them.
+			// Expected after a user switch — that is the case the rule exists
+			// for — but it also happens when the author id itself was
+			// re-issued, and then the user loses their other open pads for a
+			// reason that looks exactly like the bug this prevents.
+			$this->logger->debug('None of the session ids the browser sent belong to this Etherpad author; the other pads drop out of the cookie', [
+				'app' => 'etherpad_nextcloud',
+			]);
 		}
 
 		// The pad being opened first, then the rest by how long they last,
@@ -212,6 +259,9 @@ class PadSessionService {
 		$existing = (string)($this->request->getCookie('sessionID') ?? '');
 		$ids = [];
 		foreach (explode(',', trim($existing, '"')) as $candidate) {
+			if (count($ids) >= self::MAX_PARSED_SESSION_IDS) {
+				break;
+			}
 			$candidate = trim($candidate);
 			if ($candidate === '' || in_array($candidate, $ids, true)) {
 				continue;
@@ -231,8 +281,10 @@ class PadSessionService {
 		return $matches[1];
 	}
 
-	/** @return array{name:string,value:string,expires:int,path:string,domain:string,secure:bool,http_only:bool,same_site:string} */
-	/** @param array{value:string,expires:int} $cookie */
+	/**
+	 * @param array{value:string,expires:int} $cookie
+	 * @return array{name:string,value:string,expires:int,path:string,domain:string,secure:bool,http_only:bool,same_site:string}
+	 */
 	private function buildEtherpadSessionCookie(array $cookie): array {
 		$cookieDomain = $this->resolveCookieDomain();
 		return [

--- a/lib/Service/PadSessionService.php
+++ b/lib/Service/PadSessionService.php
@@ -12,6 +12,7 @@ use OCA\EtherpadNextcloud\Exception\EtherpadClientException;
 use OCP\IConfig;
 use OCP\IRequest;
 use OCP\IURLGenerator;
+use Psr\Log\LoggerInterface;
 
 class PadSessionService {
 	private const USER_CONFIG_AUTHOR_ID_KEY = 'etherpad_author_id';
@@ -21,7 +22,7 @@ class PadSessionService {
 	 * The shape createSession() returns. Anything else in the incoming
 	 * cookie is dropped rather than echoed back into a Set-Cookie header.
 	 */
-	private const SESSION_ID_PATTERN = '/^s\.[A-Za-z0-9]+$/';
+	private const SESSION_ID_PATTERN = '/^s\.[A-Za-z0-9]{16,64}$/';
 
 	/**
 	 * One entry per group, so this is how many protected pads may be open at
@@ -35,10 +36,13 @@ class PadSessionService {
 	private const MAX_SESSION_IDS = 25;
 
 	/**
-	 * A session about to expire is not worth reusing: the pad would lose
-	 * access minutes later with no open to renew it.
+	 * How many carried-over ids the degraded path keeps. It cannot tell
+	 * groups apart, so it cannot stop one pad — or a cookie written by a
+	 * sibling host under the shared parent domain — from filling every
+	 * slot. A handful preserves the common two-or-three-tabs case without
+	 * offering that much room.
 	 */
-	private const REUSE_MIN_REMAINING_SECONDS = 300;
+	private const MAX_UNVERIFIED_SESSION_IDS = 5;
 
 	public function __construct(
 		private EtherpadClient $etherpadClient,
@@ -46,6 +50,7 @@ class PadSessionService {
 		private IURLGenerator $urlGenerator,
 		private CookieDomainPolicy $cookieDomainPolicy,
 		private IRequest $request,
+		private LoggerInterface $logger,
 	) {
 	}
 
@@ -72,93 +77,137 @@ class PadSessionService {
 	}
 
 	/**
-	 * The author's sessions, as Etherpad holds them, are the source of truth
-	 * for what the cookie should say.
+	 * A fresh session for the pad being opened, plus the ids the browser
+	 * already had that are still worth carrying.
 	 *
-	 * Building the list from the incoming cookie alone could not get this
-	 * right. Every open minted a new session even for a pad already open, so
-	 * ten entries meant ten *opens*, not ten pads: opening B ten times
-	 * pushed A out and A went back to 403 with two pads on screen. Etherpad
-	 * knows which group each session belongs to, so the session for this
-	 * group is reused while it lasts and the cookie carries one entry per
-	 * group.
+	 * The cookie is the only place this state lives, and writing just the
+	 * new id replaced it — so a second protected pad in a second tab took
+	 * the first tab's access away. Etherpad reads the value as a
+	 * comma-separated list and picks the entry matching the group, so the
+	 * others have to survive the write.
 	 *
-	 * It also stops the sessions piling up. Etherpad deletes none of them —
-	 * an author who has opened protected pads for a while accumulates
-	 * hundreds, nearly all long expired.
+	 * What may survive is decided by two things together. The browser's
+	 * cookie says what this browser already held: nothing is added to it
+	 * here that was not already there, so an open never re-issues access to
+	 * a pad the user has since lost — it only refrains from taking away what
+	 * they were already carrying, which dies at its own validUntil.
+	 * Etherpad's session list says which group each of those ids belongs to
+	 * and how long it lasts, which is what lets one entry per group survive
+	 * rather than one per open: without it, opening the same pad ten times
+	 * filled the cookie with ten ids for one group and pushed the other pad
+	 * out.
 	 *
-	 * If Etherpad cannot answer, the open still happens: a fresh session,
-	 * and the cookie merged with what the browser sent, which is what this
-	 * did before.
+	 * Ids the list does not know — another author's, which is every public
+	 * share, since each share token is its own Etherpad author — are kept
+	 * unverified and last, capped tighter, because nothing here can tell
+	 * them apart from a value some other host under the shared cookie
+	 * domain wrote.
 	 *
 	 * @return array{url:string,cookie:array{name:string,value:string,expires:int,path:string,domain:string,secure:bool,http_only:bool,same_site:string}}
 	 */
 	private function openContextFor(string $authorId, string $groupId, string $padId, int $validUntil): array {
+		$sessions = [];
 		try {
 			$sessions = $this->etherpadClient->listSessionsOfAuthor($authorId);
-		} catch (EtherpadClientException) {
-			$sessionId = $this->etherpadClient->createSession($groupId, $authorId, $validUntil);
-			return [
-				'url' => $this->etherpadClient->buildPadUrl($padId),
-				'cookie' => $this->buildEtherpadSessionCookie(
-					$this->mergeWithExistingSessionIds($sessionId),
-					$validUntil,
-				),
-			];
+		} catch (EtherpadClientException $e) {
+			// Not fatal — the open proceeds on the cookie alone. Logged
+			// because that degraded path cannot tell groups apart, so the
+			// symptom this method exists to prevent comes back, and nothing
+			// else would say why.
+			$this->logger->warning('Could not list Etherpad sessions; the session cookie falls back to the browser copy', [
+				'app' => 'etherpad_nextcloud',
+				'exception' => $e,
+			]);
 		}
 
-		$now = time();
-		$reusable = '';
-		// Keyed by group, not by session: an author can hold several living
-		// sessions for one group — from opens before this reuse existed, from
-		// the fallback below, or from two opens racing — and keying by
-		// session id would let one pad occupy several of the 25 slots and
-		// push a third pad out. The longest-lived per group wins.
-		$perGroup = [];
-		foreach ($sessions as $sessionId => $info) {
-			if ($info['validUntil'] <= $now) {
-				continue;
-			}
-			if ($info['groupID'] === $groupId) {
-				if ($info['validUntil'] > ($now + self::REUSE_MIN_REMAINING_SECONDS)
-					&& ($reusable === '' || $info['validUntil'] > $sessions[$reusable]['validUntil'])) {
-					$reusable = $sessionId;
-				}
-				continue;
-			}
-			$known = $perGroup[$info['groupID']] ?? null;
-			if ($known === null || $info['validUntil'] > $known['validUntil']) {
-				$perGroup[$info['groupID']] = ['sessionId' => $sessionId, 'validUntil' => $info['validUntil']];
-			}
-		}
-
-		if ($reusable !== '') {
-			$validUntil = $sessions[$reusable]['validUntil'];
-			$sessionId = $reusable;
-		} else {
-			$sessionId = $this->etherpadClient->createSession($groupId, $authorId, $validUntil);
-		}
-
-		// The pad being opened first, then the rest by how long they last,
-		// so the cap drops what expires soonest.
-		uasort($perGroup, static fn (array $a, array $b): int => $b['validUntil'] <=> $a['validUntil']);
-		$kept = array_slice(
-			array_merge([['sessionId' => $sessionId, 'validUntil' => $validUntil]], array_values($perGroup)),
-			0,
-			self::MAX_SESSION_IDS,
-		);
+		$chosenSessionId = $this->etherpadClient->createSession($groupId, $authorId, $validUntil);
 
 		return [
 			'url' => $this->etherpadClient->buildPadUrl($padId),
 			'cookie' => $this->buildEtherpadSessionCookie(
-				implode(',', array_column($kept, 'sessionId')),
-				// The cookie has to outlive every id it carries. Reusing a
-				// session with ten minutes left would otherwise set the whole
-				// cookie to ten minutes, and the browser would drop another
-				// pad's session that was good for another hour.
-				max(array_column($kept, 'validUntil')),
+				$this->cookieValueFor($chosenSessionId, $validUntil, $groupId, $sessions),
 			),
 		];
+	}
+
+	/**
+	 * @param array<string,array{groupID:string,validUntil:int}> $sessions
+	 * @return array{value:string,expires:int}
+	 */
+	private function cookieValueFor(string $chosenSessionId, int $validUntil, string $groupId, array $sessions): array {
+		$now = time();
+		$carried = [];
+		$unverified = [];
+
+		foreach ($this->sessionIdsFromCookie() as $candidate) {
+			if ($candidate === $chosenSessionId) {
+				continue;
+			}
+			$info = $sessions[$candidate] ?? null;
+			if ($info === null) {
+				if (count($unverified) < self::MAX_UNVERIFIED_SESSION_IDS) {
+					$unverified[] = $candidate;
+				}
+				continue;
+			}
+			if ($info['validUntil'] <= $now || $info['groupID'] === $groupId) {
+				// Expired, or superseded by the session just created.
+				continue;
+			}
+			$known = $carried[$info['groupID']] ?? null;
+			if ($known === null || $info['validUntil'] > $known['validUntil']) {
+				$carried[$info['groupID']] = ['sessionId' => $candidate, 'validUntil' => $info['validUntil']];
+			}
+		}
+
+		// The pad being opened first, then the rest by how long they last,
+		// so the cap drops what expires soonest.
+		uasort($carried, static fn (array $a, array $b): int => $b['validUntil'] <=> $a['validUntil']);
+
+		$ids = array_merge(
+			[$chosenSessionId],
+			array_column(array_values($carried), 'sessionId'),
+			$unverified,
+		);
+		$expiries = array_merge(
+			[$validUntil],
+			array_column(array_values($carried), 'validUntil'),
+		);
+
+		return [
+			'value' => implode(',', array_slice($ids, 0, self::MAX_SESSION_IDS)),
+			// The cookie has to outlive every id it carries, or the browser
+			// drops another pad's session that was good for another hour.
+			// Unverified ids have no known expiry and cannot extend it.
+			'expires' => max($expiries),
+		];
+	}
+
+	/**
+	 * The session ids the browser sent, in the order it sent them.
+	 *
+	 * Only values shaped like one are read. The cookie is attacker-writable
+	 * in principle — any host under the shared parent domain can set it —
+	 * and while buildSetCookieHeader percent-encodes the value, so a `;`
+	 * cannot smuggle in an attribute, an unbounded length could still be
+	 * echoed back as a header no proxy will pass.
+	 *
+	 * @return list<string>
+	 */
+	private function sessionIdsFromCookie(): array {
+		$existing = (string)($this->request->getCookie('sessionID') ?? '');
+		$ids = [];
+		foreach (explode(',', trim($existing, '"')) as $candidate) {
+			$candidate = trim($candidate);
+			if ($candidate === '' || in_array($candidate, $ids, true)) {
+				continue;
+			}
+			if (preg_match(self::SESSION_ID_PATTERN, $candidate) !== 1) {
+				continue;
+			}
+			$ids[] = $candidate;
+		}
+		return $ids;
 	}
 
 	public function extractGroupId(string $padId): string {
@@ -169,12 +218,13 @@ class PadSessionService {
 	}
 
 	/** @return array{name:string,value:string,expires:int,path:string,domain:string,secure:bool,http_only:bool,same_site:string} */
-	private function buildEtherpadSessionCookie(string $cookieValue, int $validUntil): array {
+	/** @param array{value:string,expires:int} $cookie */
+	private function buildEtherpadSessionCookie(array $cookie): array {
 		$cookieDomain = $this->resolveCookieDomain();
 		return [
 			'name' => 'sessionID',
-			'value' => $cookieValue,
-			'expires' => $validUntil,
+			'value' => $cookie['value'],
+			'expires' => $cookie['expires'],
 			'path' => '/',
 			'domain' => $cookieDomain,
 			'secure' => true,
@@ -183,43 +233,6 @@ class PadSessionService {
 			'http_only' => false,
 			'same_site' => 'None',
 		];
-	}
-
-	/**
-	 * Every protected pad lives in its own Etherpad group, and a session is
-	 * granted for one group. Writing only the new session id replaced the
-	 * one before it, so a second protected pad open in a second tab silently
-	 * took the first tab's access away — Etherpad answers 403 for a pad
-	 * whose group no longer has a session in the cookie.
-	 *
-	 * Etherpad reads the cookie as a comma-separated list and picks the
-	 * entry matching the group being opened, so the fix is to keep the ones
-	 * already there. Newest first: when the cap trims, the oldest goes,
-	 * which is the one least likely to still be on screen. Expired entries
-	 * need no pruning here — Etherpad checks each against its own validUntil.
-	 *
-	 * Only values shaped like a session id are carried over. The cookie is
-	 * attacker-writable in principle, and while buildSetCookieHeader
-	 * percent-encodes the value — so a `;` cannot smuggle in an attribute —
-	 * there is no reason to hand anything else back.
-	 */
-	private function mergeWithExistingSessionIds(string $newSessionId): string {
-		$sessionIds = [$newSessionId];
-		$existing = (string)($this->request->getCookie('sessionID') ?? '');
-		foreach (explode(',', trim($existing, '"')) as $candidate) {
-			if (count($sessionIds) >= self::MAX_SESSION_IDS) {
-				break;
-			}
-			$candidate = trim($candidate);
-			if ($candidate === '' || in_array($candidate, $sessionIds, true)) {
-				continue;
-			}
-			if (preg_match(self::SESSION_ID_PATTERN, $candidate) !== 1) {
-				continue;
-			}
-			$sessionIds[] = $candidate;
-		}
-		return implode(',', $sessionIds);
 	}
 
 	/** @param array{name:string,value:string,expires:int,path:string,domain:string,secure:bool,http_only:bool,same_site:string} $cookie */
@@ -290,10 +303,11 @@ class PadSessionService {
 		return $authorId;
 	}
 
+	/**
+	 * Only reached with a uid whose state is persisted — resolveCachedAuthorId
+	 * answers '' for the others and the caller stops there.
+	 */
 	private function cachedAuthorName(string $uid): string {
-		if (!$this->shouldPersistAuthorState($uid)) {
-			return '';
-		}
 		return trim((string)$this->config->getUserValue(
 			$uid,
 			'etherpad_nextcloud',

--- a/lib/Service/PadSessionService.php
+++ b/lib/Service/PadSessionService.php
@@ -27,22 +27,15 @@ class PadSessionService {
 	/**
 	 * One entry per group, so this is how many protected pads may be open at
 	 * once before the oldest loses access. A session id is ~34 bytes, so 25
-	 * of them are under a kilobyte against the 4 KB a cookie may occupy —
-	 * and the cookie only ever goes to the pad host. The pad being opened is
+	 * of them are under a kilobyte against the 4 KB a cookie may occupy. It
+	 * is not a pad-host-only cookie — it is scoped to the domain both hosts
+	 * share, so Nextcloud and every sibling under that parent see it too,
+	 * which is how this request can read it at all. The pad being opened is
 	 * always kept; beyond that the ones expiring last win, because the
 	 * soonest to expire is the one a user is least likely to still be
 	 * looking at.
 	 */
 	private const MAX_SESSION_IDS = 25;
-
-	/**
-	 * How many carried-over ids the degraded path keeps. It cannot tell
-	 * groups apart, so it cannot stop one pad — or a cookie written by a
-	 * sibling host under the shared parent domain — from filling every
-	 * slot. A handful preserves the common two-or-three-tabs case without
-	 * offering that much room.
-	 */
-	private const MAX_UNVERIFIED_SESSION_IDS = 5;
 
 	public function __construct(
 		private EtherpadClient $etherpadClient,
@@ -87,21 +80,24 @@ class PadSessionService {
 	 * others have to survive the write.
 	 *
 	 * What may survive is decided by two things together. The browser's
-	 * cookie says what this browser already held: nothing is added to it
-	 * here that was not already there, so an open never re-issues access to
-	 * a pad the user has since lost — it only refrains from taking away what
-	 * they were already carrying, which dies at its own validUntil.
+	 * cookie says what this browser already held, so an open adds nothing
+	 * that was not already there — it does not re-issue access to a pad the
+	 * user has since lost, it only refrains from taking away what they were
+	 * carrying, which dies at its own validUntil. Etherpad's list then says
+	 * which of those are this author's; the rest are dropped.
 	 * Etherpad's session list says which group each of those ids belongs to
 	 * and how long it lasts, which is what lets one entry per group survive
 	 * rather than one per open: without it, opening the same pad ten times
 	 * filled the cookie with ten ids for one group and pushed the other pad
 	 * out.
 	 *
-	 * Ids the list does not know — another author's, which is every public
-	 * share, since each share token is its own Etherpad author — are kept
-	 * unverified and last, capped tighter, because nothing here can tell
-	 * them apart from a value some other host under the shared cookie
-	 * domain wrote.
+	 * Ids the list does not know are dropped. That covers a public share's
+	 * session — each share token is its own Etherpad author — so a share and
+	 * an authenticated pad cannot be open at once, as was already the case
+	 * before any of this. It also covers the session of whoever used this
+	 * browser before, which is why the rule is worth the loss: nothing here
+	 * can tell those two apart, and carrying them would hand a pad to the
+	 * next person to log in.
 	 *
 	 * @return array{url:string,cookie:array{name:string,value:string,expires:int,path:string,domain:string,secure:bool,http_only:bool,same_site:string}}
 	 */
@@ -153,7 +149,6 @@ class PadSessionService {
 	): array {
 		$now = time();
 		$carried = [];
-		$unverified = [];
 
 		foreach ($carriedIds as $candidate) {
 			if ($candidate === $chosenSessionId) {
@@ -161,9 +156,14 @@ class PadSessionService {
 			}
 			$info = $sessions[$candidate] ?? null;
 			if ($info === null) {
-				if (count($unverified) < self::MAX_UNVERIFIED_SESSION_IDS) {
-					$unverified[] = $candidate;
-				}
+				// Not this author's, so not this user's: dropped. It used to
+				// be carried, on the grounds that a public share is its own
+				// Etherpad author and its session would look exactly like
+				// this — but so does the session of whoever was logged into
+				// this browser before. Keeping it let the next user inherit
+				// their pad until it expired, where overwriting the cookie
+				// had cut that off. Nothing here can tell the two apart, and
+				// only one of them is safe to guess at.
 				continue;
 			}
 			if ($info['validUntil'] <= $now || $info['groupID'] === $groupId) {
@@ -183,7 +183,6 @@ class PadSessionService {
 		$ids = array_merge(
 			[$chosenSessionId],
 			array_column(array_values($carried), 'sessionId'),
-			$unverified,
 		);
 		$expiries = array_merge(
 			[$validUntil],
@@ -194,7 +193,6 @@ class PadSessionService {
 			'value' => implode(',', array_slice($ids, 0, self::MAX_SESSION_IDS)),
 			// The cookie has to outlive every id it carries, or the browser
 			// drops another pad's session that was good for another hour.
-			// Unverified ids have no known expiry and cannot extend it.
 			'expires' => max($expiries),
 		];
 	}

--- a/lib/Service/PadSessionService.php
+++ b/lib/Service/PadSessionService.php
@@ -10,17 +10,32 @@ namespace OCA\EtherpadNextcloud\Service;
 
 use OCA\EtherpadNextcloud\Exception\EtherpadClientException;
 use OCP\IConfig;
+use OCP\IRequest;
 use OCP\IURLGenerator;
 
 class PadSessionService {
 	private const USER_CONFIG_AUTHOR_ID_KEY = 'etherpad_author_id';
 	private const USER_CONFIG_AUTHOR_NAME_KEY = 'etherpad_author_display_name';
 
+	/**
+	 * The shape createSession() returns. Anything else in the incoming
+	 * cookie is dropped rather than echoed back into a Set-Cookie header.
+	 */
+	private const SESSION_ID_PATTERN = '/^s\.[A-Za-z0-9]+$/';
+
+	/**
+	 * A session id is ~34 bytes, so ten of them stay far inside the 4 KB a
+	 * cookie may occupy — and nobody has ten protected pads open whose
+	 * sessions all still matter. The newest are kept.
+	 */
+	private const MAX_SESSION_IDS = 10;
+
 	public function __construct(
 		private EtherpadClient $etherpadClient,
 		private IConfig $config,
 		private IURLGenerator $urlGenerator,
 		private CookieDomainPolicy $cookieDomainPolicy,
+		private IRequest $request,
 	) {
 	}
 
@@ -66,7 +81,7 @@ class PadSessionService {
 		$cookieDomain = $this->resolveCookieDomain();
 		return [
 			'name' => 'sessionID',
-			'value' => $sessionId,
+			'value' => $this->mergeWithExistingSessionIds($sessionId),
 			'expires' => $validUntil,
 			'path' => '/',
 			'domain' => $cookieDomain,
@@ -76,6 +91,43 @@ class PadSessionService {
 			'http_only' => false,
 			'same_site' => 'None',
 		];
+	}
+
+	/**
+	 * Every protected pad lives in its own Etherpad group, and a session is
+	 * granted for one group. Writing only the new session id replaced the
+	 * one before it, so a second protected pad open in a second tab silently
+	 * took the first tab's access away — Etherpad answers 403 for a pad
+	 * whose group no longer has a session in the cookie.
+	 *
+	 * Etherpad reads the cookie as a comma-separated list and picks the
+	 * entry matching the group being opened, so the fix is to keep the ones
+	 * already there. Newest first: when the cap trims, the oldest goes,
+	 * which is the one least likely to still be on screen. Expired entries
+	 * need no pruning here — Etherpad checks each against its own validUntil.
+	 *
+	 * Only values shaped like a session id are carried over. The cookie is
+	 * attacker-writable in principle, and while buildSetCookieHeader
+	 * percent-encodes the value — so a `;` cannot smuggle in an attribute —
+	 * there is no reason to hand anything else back.
+	 */
+	private function mergeWithExistingSessionIds(string $newSessionId): string {
+		$sessionIds = [$newSessionId];
+		$existing = (string)($this->request->getCookie('sessionID') ?? '');
+		foreach (explode(',', trim($existing, '"')) as $candidate) {
+			if (count($sessionIds) >= self::MAX_SESSION_IDS) {
+				break;
+			}
+			$candidate = trim($candidate);
+			if ($candidate === '' || in_array($candidate, $sessionIds, true)) {
+				continue;
+			}
+			if (preg_match(self::SESSION_ID_PATTERN, $candidate) !== 1) {
+				continue;
+			}
+			$sessionIds[] = $candidate;
+		}
+		return implode(',', $sessionIds);
 	}
 
 	/** @param array{name:string,value:string,expires:int,path:string,domain:string,secure:bool,http_only:bool,same_site:string} $cookie */
@@ -122,6 +174,19 @@ class PadSessionService {
 			return $authorId;
 		}
 
+		// The cached id only saves a round trip if it is allowed to. This
+		// asked Etherpad for the author on every open and compared the name
+		// afterwards, so the cache spared nothing and a repeat open of the
+		// same pad cost two API calls where one would do. The stored name is
+		// the question being asked, so ask it first.
+		//
+		// Skipping the call also skips the incidental proof that the author
+		// still exists — createSession answers that a moment later, and its
+		// failure already clears the cache and retries from scratch.
+		if ($this->cachedAuthorName($uid) === $trimmedName) {
+			return $authorId;
+		}
+
 		try {
 			$syncedAuthorId = $this->etherpadClient->createAuthorIfNotExistsFor('nc:' . $uid, $trimmedName);
 		} catch (\Throwable) {
@@ -133,16 +198,22 @@ class PadSessionService {
 			$this->rememberAuthorId($uid, $syncedAuthorId);
 			$authorId = $syncedAuthorId;
 		}
-		$lastSyncedName = trim((string)$this->config->getUserValue(
+		if ($this->cachedAuthorName($uid) !== $trimmedName) {
+			$this->rememberAuthorName($uid, $trimmedName);
+		}
+		return $authorId;
+	}
+
+	private function cachedAuthorName(string $uid): string {
+		if (!$this->shouldPersistAuthorState($uid)) {
+			return '';
+		}
+		return trim((string)$this->config->getUserValue(
 			$uid,
 			'etherpad_nextcloud',
 			self::USER_CONFIG_AUTHOR_NAME_KEY,
 			''
 		));
-		if ($lastSyncedName !== $trimmedName) {
-			$this->rememberAuthorName($uid, $trimmedName);
-		}
-		return $authorId;
 	}
 
 	private function resolveCachedAuthorId(string $uid): string {

--- a/lib/Service/PadSessionService.php
+++ b/lib/Service/PadSessionService.php
@@ -24,11 +24,21 @@ class PadSessionService {
 	private const SESSION_ID_PATTERN = '/^s\.[A-Za-z0-9]+$/';
 
 	/**
-	 * A session id is ~34 bytes, so ten of them stay far inside the 4 KB a
-	 * cookie may occupy — and nobody has ten protected pads open whose
-	 * sessions all still matter. The newest are kept.
+	 * One entry per group, so this is how many protected pads may be open at
+	 * once before the oldest loses access. A session id is ~34 bytes, so 25
+	 * of them are under a kilobyte against the 4 KB a cookie may occupy —
+	 * and the cookie only ever goes to the pad host. The pad being opened is
+	 * always kept; beyond that the ones expiring last win, because the
+	 * soonest to expire is the one a user is least likely to still be
+	 * looking at.
 	 */
-	private const MAX_SESSION_IDS = 10;
+	private const MAX_SESSION_IDS = 25;
+
+	/**
+	 * A session about to expire is not worth reusing: the pad would lose
+	 * access minutes later with no open to renew it.
+	 */
+	private const REUSE_MIN_REMAINING_SECONDS = 300;
 
 	public function __construct(
 		private EtherpadClient $etherpadClient,
@@ -49,11 +59,7 @@ class PadSessionService {
 		if ($authorId !== '') {
 			$authorId = $this->syncAuthorMapping($uid, $authorId, $effectiveDisplayName);
 			try {
-				$sessionId = $this->etherpadClient->createSession($groupId, $authorId, $validUntil);
-				return [
-					'url' => $this->etherpadClient->buildPadUrl($padId),
-					'cookie' => $this->buildEtherpadSessionCookie($sessionId, $validUntil),
-				];
+				return $this->openContextFor($authorId, $groupId, $padId, $validUntil);
 			} catch (EtherpadClientException) {
 				$this->clearCachedAuthorState($uid);
 			}
@@ -62,10 +68,80 @@ class PadSessionService {
 		$authorId = $this->etherpadClient->createAuthorIfNotExistsFor('nc:' . $uid, $effectiveDisplayName);
 		$this->rememberAuthorId($uid, $authorId);
 		$this->rememberAuthorName($uid, $effectiveDisplayName);
-		$sessionId = $this->etherpadClient->createSession($groupId, $authorId, $validUntil);
+		return $this->openContextFor($authorId, $groupId, $padId, $validUntil);
+	}
+
+	/**
+	 * The author's sessions, as Etherpad holds them, are the source of truth
+	 * for what the cookie should say.
+	 *
+	 * Building the list from the incoming cookie alone could not get this
+	 * right. Every open minted a new session even for a pad already open, so
+	 * ten entries meant ten *opens*, not ten pads: opening B ten times
+	 * pushed A out and A went back to 403 with two pads on screen. Etherpad
+	 * knows which group each session belongs to, so the session for this
+	 * group is reused while it lasts and the cookie carries one entry per
+	 * group.
+	 *
+	 * It also stops the sessions piling up. Etherpad deletes none of them —
+	 * an author who has opened protected pads for a while accumulates
+	 * hundreds, nearly all long expired.
+	 *
+	 * If Etherpad cannot answer, the open still happens: a fresh session,
+	 * and the cookie merged with what the browser sent, which is what this
+	 * did before.
+	 *
+	 * @return array{url:string,cookie:array{name:string,value:string,expires:int,path:string,domain:string,secure:bool,http_only:bool,same_site:string}}
+	 */
+	private function openContextFor(string $authorId, string $groupId, string $padId, int $validUntil): array {
+		try {
+			$sessions = $this->etherpadClient->listSessionsOfAuthor($authorId);
+		} catch (EtherpadClientException) {
+			$sessionId = $this->etherpadClient->createSession($groupId, $authorId, $validUntil);
+			return [
+				'url' => $this->etherpadClient->buildPadUrl($padId),
+				'cookie' => $this->buildEtherpadSessionCookie(
+					$this->mergeWithExistingSessionIds($sessionId),
+					$validUntil,
+				),
+			];
+		}
+
+		$now = time();
+		$reusable = '';
+		$otherGroups = [];
+		foreach ($sessions as $sessionId => $info) {
+			if ($info['validUntil'] <= $now) {
+				continue;
+			}
+			if ($info['groupID'] === $groupId) {
+				if ($info['validUntil'] > ($now + self::REUSE_MIN_REMAINING_SECONDS)
+					&& ($reusable === '' || $info['validUntil'] > $sessions[$reusable]['validUntil'])) {
+					$reusable = $sessionId;
+				}
+				continue;
+			}
+			$otherGroups[$sessionId] = $info['validUntil'];
+		}
+
+		if ($reusable !== '') {
+			$validUntil = $sessions[$reusable]['validUntil'];
+			$sessionId = $reusable;
+		} else {
+			$sessionId = $this->etherpadClient->createSession($groupId, $authorId, $validUntil);
+		}
+
+		// The pad being opened first, then the rest by how long they last,
+		// so the cap drops what expires soonest.
+		arsort($otherGroups);
+		$cookieIds = array_merge([$sessionId], array_keys($otherGroups));
+
 		return [
 			'url' => $this->etherpadClient->buildPadUrl($padId),
-			'cookie' => $this->buildEtherpadSessionCookie($sessionId, $validUntil),
+			'cookie' => $this->buildEtherpadSessionCookie(
+				implode(',', array_slice($cookieIds, 0, self::MAX_SESSION_IDS)),
+				$validUntil,
+			),
 		];
 	}
 
@@ -77,11 +153,11 @@ class PadSessionService {
 	}
 
 	/** @return array{name:string,value:string,expires:int,path:string,domain:string,secure:bool,http_only:bool,same_site:string} */
-	private function buildEtherpadSessionCookie(string $sessionId, int $validUntil): array {
+	private function buildEtherpadSessionCookie(string $cookieValue, int $validUntil): array {
 		$cookieDomain = $this->resolveCookieDomain();
 		return [
 			'name' => 'sessionID',
-			'value' => $this->mergeWithExistingSessionIds($sessionId),
+			'value' => $cookieValue,
 			'expires' => $validUntil,
 			'path' => '/',
 			'domain' => $cookieDomain,
@@ -174,19 +250,13 @@ class PadSessionService {
 			return $authorId;
 		}
 
-		// The cached id only saves a round trip if it is allowed to. This
-		// asked Etherpad for the author on every open and compared the name
-		// afterwards, so the cache spared nothing and a repeat open of the
-		// same pad cost two API calls where one would do. The stored name is
-		// the question being asked, so ask it first.
-		//
-		// Skipping the call also skips the incidental proof that the author
-		// still exists — createSession answers that a moment later, and its
-		// failure already clears the cache and retries from scratch.
-		if ($this->cachedAuthorName($uid) === $trimmedName) {
-			return $authorId;
-		}
-
+		// Asked on every open, and deliberately not skipped when the stored
+		// name still matches. It looks like a round trip the cache should
+		// spare, but it is the only thing that keeps Etherpad's idea of the
+		// author's name in step with Nextcloud's: the name can drift on the
+		// Etherpad side — a user renaming themselves in the pad, another
+		// integrator, an API call — and nothing else ever repairs it. The
+		// e2e suite catches exactly that, with the pad showing a stale name.
 		try {
 			$syncedAuthorId = $this->etherpadClient->createAuthorIfNotExistsFor('nc:' . $uid, $trimmedName);
 		} catch (\Throwable) {

--- a/lib/Service/PadSessionService.php
+++ b/lib/Service/PadSessionService.php
@@ -109,7 +109,12 @@ class PadSessionService {
 
 		$now = time();
 		$reusable = '';
-		$otherGroups = [];
+		// Keyed by group, not by session: an author can hold several living
+		// sessions for one group — from opens before this reuse existed, from
+		// the fallback below, or from two opens racing — and keying by
+		// session id would let one pad occupy several of the 25 slots and
+		// push a third pad out. The longest-lived per group wins.
+		$perGroup = [];
 		foreach ($sessions as $sessionId => $info) {
 			if ($info['validUntil'] <= $now) {
 				continue;
@@ -121,7 +126,10 @@ class PadSessionService {
 				}
 				continue;
 			}
-			$otherGroups[$sessionId] = $info['validUntil'];
+			$known = $perGroup[$info['groupID']] ?? null;
+			if ($known === null || $info['validUntil'] > $known['validUntil']) {
+				$perGroup[$info['groupID']] = ['sessionId' => $sessionId, 'validUntil' => $info['validUntil']];
+			}
 		}
 
 		if ($reusable !== '') {
@@ -133,14 +141,22 @@ class PadSessionService {
 
 		// The pad being opened first, then the rest by how long they last,
 		// so the cap drops what expires soonest.
-		arsort($otherGroups);
-		$cookieIds = array_merge([$sessionId], array_keys($otherGroups));
+		uasort($perGroup, static fn (array $a, array $b): int => $b['validUntil'] <=> $a['validUntil']);
+		$kept = array_slice(
+			array_merge([['sessionId' => $sessionId, 'validUntil' => $validUntil]], array_values($perGroup)),
+			0,
+			self::MAX_SESSION_IDS,
+		);
 
 		return [
 			'url' => $this->etherpadClient->buildPadUrl($padId),
 			'cookie' => $this->buildEtherpadSessionCookie(
-				implode(',', array_slice($cookieIds, 0, self::MAX_SESSION_IDS)),
-				$validUntil,
+				implode(',', array_column($kept, 'sessionId')),
+				// The cookie has to outlive every id it carries. Reusing a
+				// session with ten minutes left would otherwise set the whole
+				// cookie to ten minutes, and the browser would drop another
+				// pad's session that was good for another hour.
+				max(array_column($kept, 'validUntil')),
 			),
 		];
 	}

--- a/lib/Service/PadSessionService.php
+++ b/lib/Service/PadSessionService.php
@@ -106,9 +106,18 @@ class PadSessionService {
 	 * @return array{url:string,cookie:array{name:string,value:string,expires:int,path:string,domain:string,secure:bool,http_only:bool,same_site:string}}
 	 */
 	private function openContextFor(string $authorId, string $groupId, string $padId, int $validUntil): array {
+		$carriedIds = $this->sessionIdsFromCookie();
+
+		// Nothing to annotate, nothing to ask. The first protected open of a
+		// browsing session — the common case, and the whole of it for anyone
+		// who only ever has one pad open — costs no extra round trip, and
+		// the listing is the call whose cost grows with every distinct pad
+		// the user has ever opened.
 		$sessions = [];
 		try {
-			$sessions = $this->etherpadClient->listSessionsOfAuthor($authorId);
+			if ($carriedIds !== []) {
+				$sessions = $this->etherpadClient->listSessionsOfAuthor($authorId);
+			}
 		} catch (EtherpadClientException $e) {
 			// Not fatal — the open proceeds on the cookie alone. Logged
 			// because that degraded path cannot tell groups apart, so the
@@ -125,21 +134,28 @@ class PadSessionService {
 		return [
 			'url' => $this->etherpadClient->buildPadUrl($padId),
 			'cookie' => $this->buildEtherpadSessionCookie(
-				$this->cookieValueFor($chosenSessionId, $validUntil, $groupId, $sessions),
+				$this->cookieValueFor($chosenSessionId, $validUntil, $groupId, $carriedIds, $sessions),
 			),
 		];
 	}
 
 	/**
+	 * @param list<string> $carriedIds
 	 * @param array<string,array{groupID:string,validUntil:int}> $sessions
 	 * @return array{value:string,expires:int}
 	 */
-	private function cookieValueFor(string $chosenSessionId, int $validUntil, string $groupId, array $sessions): array {
+	private function cookieValueFor(
+		string $chosenSessionId,
+		int $validUntil,
+		string $groupId,
+		array $carriedIds,
+		array $sessions,
+	): array {
 		$now = time();
 		$carried = [];
 		$unverified = [];
 
-		foreach ($this->sessionIdsFromCookie() as $candidate) {
+		foreach ($carriedIds as $candidate) {
 			if ($candidate === $chosenSessionId) {
 				continue;
 			}

--- a/tests/e2e/specs/protected-multi-pad-cookie.spec.ts
+++ b/tests/e2e/specs/protected-multi-pad-cookie.spec.ts
@@ -1,0 +1,89 @@
+/**
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * Copyright (c) 2026 Jacob Bühler
+ */
+import { test, expect, request as playwrightRequest } from '@playwright/test'
+import { E2E } from '../fixtures/env'
+import { createPadAtPath, deleteViaDav, mkcolViaDav, propfindFileId } from '../fixtures/dav'
+import { uniqueName } from '../fixtures/nextcloud'
+
+/**
+ * Every protected pad lives in its own Etherpad group, and a session grants
+ * access to one group. The `sessionID` cookie is the only place that state
+ * lives, so an open that writes just its own id revokes the others: a second
+ * protected pad in a second tab used to take the first tab's access away, and
+ * Etherpad answered 403 for it.
+ *
+ * The unit tests pin the rules against a stubbed session listing. This is the
+ * part they cannot reach — that Etherpad's real response has the shape the
+ * parser expects, that a real browser cookie survives ten opens of the other
+ * pad, and that Etherpad itself still grants access at the end of it. A
+ * mismatch in the real payload would leave every unit test green and restore
+ * the original bug in full.
+ */
+test.describe('protected pads opened side by side', () => {
+	const folderName = uniqueName('multi-session')
+	let padA = { path: '', padUrl: '', fileId: 0 }
+	let padB = { path: '', padUrl: '', fileId: 0 }
+
+	test.beforeAll(async () => {
+		await mkcolViaDav(folderName)
+		await propfindFileId(folderName)
+		const a = await createPadAtPath(`/${folderName}/pad-a.pad`, 'protected')
+		const b = await createPadAtPath(`/${folderName}/pad-b.pad`, 'protected')
+		padA = { ...a, fileId: await propfindFileId(`${folderName}/pad-a.pad`) }
+		padB = { ...b, fileId: await propfindFileId(`${folderName}/pad-b.pad`) }
+	})
+
+	test.afterAll(async () => {
+		await deleteViaDav(folderName)
+	})
+
+	test('keeps the first pad reachable after ten opens of the second', async () => {
+		// storageState cleared: request.newContext() inherits the project's
+		// `use`, and the saved browser session would authenticate instead of
+		// the app password — and carry a sessionID cookie from another test.
+		const ctx = await playwrightRequest.newContext({
+			baseURL: E2E.baseURL,
+			storageState: { cookies: [], origins: [] },
+			extraHTTPHeaders: {
+				Authorization: 'Basic ' + Buffer.from(`${E2E.user}:${E2E.appPassword}`).toString('base64'),
+				Accept: 'application/json',
+				'OCS-APIRequest': 'true',
+			},
+		})
+
+		try {
+			const open = async (fileId: number) => {
+				const res = await ctx.post('/index.php/apps/etherpad_nextcloud/api/v1/pads/open-by-id', {
+					form: { fileId: String(fileId) },
+				})
+				expect(res.status(), await res.text()).toBe(200)
+			}
+
+			await open(padA.fileId)
+			for (let i = 0; i < 10; i++) {
+				await open(padB.fileId)
+			}
+
+			const state = await ctx.storageState()
+			const sessionCookie = state.cookies.find((cookie) => cookie.name === 'sessionID')
+			expect(sessionCookie, 'the open response should set a sessionID cookie').toBeTruthy()
+
+			// One id per pad, not one per open. Ten opens of B used to leave
+			// ten of B's ids in the cookie and push A's out.
+			const ids = decodeURIComponent(sessionCookie!.value).split(',')
+			expect(ids).toHaveLength(2)
+
+			// And Etherpad agrees: pad A is still readable with that cookie.
+			// This is the assertion the unit tests cannot make — it is the
+			// server's own verdict on the value we built.
+			const padAUrl = new URL(padA.padUrl)
+			const exportUrl = `${padAUrl.origin}${padAUrl.pathname}/export/txt`
+			const exported = await ctx.get(exportUrl)
+			expect(exported.status(), `pad A should still be reachable, got HTTP ${exported.status()}`).toBe(200)
+		} finally {
+			await ctx.dispose()
+		}
+	})
+})

--- a/tests/phpunit/stubs/OCP/IRequest.php
+++ b/tests/phpunit/stubs/OCP/IRequest.php
@@ -10,5 +10,8 @@ if (!interface_exists(IRequest::class)) {
 		public function getParams(): array;
 
 		public function getParam(string $key, mixed $default = null): mixed;
+
+		/** Mirrors OCP\IRequest::getCookie(): the raw value, or null. */
+		public function getCookie(string $key): ?string;
 	}
 }

--- a/tests/phpunit/unit/EtherpadClientTest.php
+++ b/tests/phpunit/unit/EtherpadClientTest.php
@@ -87,6 +87,42 @@ class EtherpadClientTest extends TestCase {
 		$this->assertStringContainsString('apikey=stored-key', (string)$captured['options']['body']);
 	}
 
+	/**
+	 * The session listing is a POST like every other authenticated call. As
+	 * a GET the apikey would travel in the URL and from there into proxy and
+	 * access logs.
+	 */
+	public function testListSessionsOfAuthorSendsTheKeyInTheBodyNotTheUrl(): void {
+		$captured = null;
+		$client = $this->clientWithResponse(
+			$this->response(200, '{"code":0,"data":{"s.one":{"groupID":"g.aaa","authorID":"a.x","validUntil":99}}}'),
+			$captured,
+		);
+
+		$sessions = $client->listSessionsOfAuthor('a.x');
+
+		$this->assertSame('POST', $captured['method']);
+		$this->assertStringNotContainsString('apikey', $captured['url']);
+		$this->assertArrayNotHasKey('query', $captured['options']);
+		$this->assertStringContainsString('apikey=stored-key', (string)$captured['options']['body']);
+		$this->assertStringContainsString('authorID=a.x', (string)$captured['options']['body']);
+		$this->assertSame(['s.one' => ['groupID' => 'g.aaa', 'validUntil' => 99]], $sessions);
+	}
+
+	public function testListSessionsOfAuthorSkipsEntriesWithoutAGroupOrExpiry(): void {
+		$client = $this->clientWithResponse($this->response(200, json_encode([
+			'code' => 0,
+			'data' => [
+				's.ok' => ['groupID' => 'g.aaa', 'validUntil' => 42],
+				's.nogroup' => ['groupID' => '', 'validUntil' => 42],
+				's.noexpiry' => ['groupID' => 'g.bbb', 'validUntil' => 0],
+				's.notanarray' => 'nonsense',
+			],
+		])));
+
+		$this->assertSame(['s.ok' => ['groupID' => 'g.aaa', 'validUntil' => 42]], $client->listSessionsOfAuthor('a.x'));
+	}
+
 	public function testApiCallThrowsOnNonZeroApiCode(): void {
 		$client = $this->clientWithResponse(
 			$this->response(200, '{"code":1,"message":"groupID does not exist"}')

--- a/tests/phpunit/unit/PadSessionServiceTest.php
+++ b/tests/phpunit/unit/PadSessionServiceTest.php
@@ -157,12 +157,14 @@ class PadSessionServiceTest extends TestCase {
 	}
 
 	/**
-	 * A public share is its own Etherpad author, so its session is not in
-	 * this author's listing. It is kept anyway — the browser had it — but
-	 * last, and under a tighter cap, because nothing here can tell it from a
-	 * value some other host under the shared cookie domain wrote.
+	 * The session of whoever used this browser before belongs to their
+	 * Etherpad author, so it is not in this one's listing. Carrying it would
+	 * hand the next person to log in a pad that is not theirs — and a public
+	 * share's session, which is also its own author, is indistinguishable
+	 * from it. Both are dropped; the share case was already broken before
+	 * any of this, the other one would have been new.
 	 */
-	public function testKeepsIdsTheListingDoesNotKnowLastAndCapped(): void {
+	public function testDropsIdsTheListingDoesNotKnow(): void {
 		$known = $this->sid('known');
 		$foreign = array_map(fn (int $i): string => $this->sid('foreign' . $i), range(1, 8));
 
@@ -171,10 +173,7 @@ class PadSessionServiceTest extends TestCase {
 			implode(',', array_merge($foreign, [$known])),
 		)['value'];
 
-		$ids = explode(',', $value);
-		$this->assertSame($this->sid('new'), $ids[0]);
-		$this->assertSame($known, $ids[1]);
-		$this->assertCount(2 + 5, $ids);
+		$this->assertSame($this->sid('new') . ',' . $known, $value);
 	}
 
 	public function testTheCookieOutlivesEveryIdItCarries(): void {
@@ -214,10 +213,18 @@ class PadSessionServiceTest extends TestCase {
 		$this->assertSame($this->sid('new'), $value);
 	}
 
+	/**
+	 * RFC 6265 lets a server quote a value that contains commas, and
+	 * Etherpad strips those quotes itself. The parsing has to as well, or a
+	 * quoted cookie would look like one unusable id.
+	 */
 	public function testAcceptsTheQuotedCookieForm(): void {
 		$one = $this->sid('one');
 
-		$value = $this->openContextCookie([], '"' . $one . ' "')['value'];
+		$value = $this->openContextCookie(
+			[$one => ['groupID' => 'g.OTHERGROUP00000', 'validUntil' => time() + 3600]],
+			'"' . $one . ' "',
+		)['value'];
 
 		$this->assertSame($this->sid('new') . ',' . $one, $value);
 	}
@@ -227,14 +234,17 @@ class PadSessionServiceTest extends TestCase {
 	 * cookie alone, group-blind and capped tighter, and logged, because the
 	 * symptom this method prevents comes back on that path.
 	 */
-	public function testFallsBackToTheBrowsersCookieWhenTheListingFails(): void {
+	/**
+	 * Without the listing nothing can be attributed, so nothing is carried:
+	 * the open falls back to exactly what it did before this branch, one
+	 * fresh id, rather than to a rule it cannot enforce.
+	 */
+	public function testCarriesNothingWhenTheListingFails(): void {
 		$carried = array_map(fn (int $i): string => $this->sid('old' . $i), range(1, 8));
 
 		$value = $this->openContextCookie([], implode(',', $carried), 'g.ABCDEFGHIJKLMNOP', true)['value'];
 
-		$ids = explode(',', $value);
-		$this->assertSame($this->sid('new'), $ids[0]);
-		$this->assertCount(1 + 5, $ids);
+		$this->assertSame($this->sid('new'), $value);
 	}
 
 	/**

--- a/tests/phpunit/unit/PadSessionServiceTest.php
+++ b/tests/phpunit/unit/PadSessionServiceTest.php
@@ -12,6 +12,7 @@ use OCP\IConfig;
 use OCP\IRequest;
 use OCP\IURLGenerator;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 
 class PadSessionServiceTest extends TestCase {
 	/**
@@ -29,28 +30,41 @@ class PadSessionServiceTest extends TestCase {
 		$urlGenerator->method('getBaseUrl')->willReturn($nextcloudUrl);
 		$request = $this->createMock(IRequest::class);
 		$request->method('getCookie')->with('sessionID')->willReturn($incomingSessionCookie);
-		return new PadSessionService($etherpadClient, $config, $urlGenerator, new CookieDomainPolicy(), $request);
+		return new PadSessionService(
+			$etherpadClient,
+			$config,
+			$urlGenerator,
+			new CookieDomainPolicy(),
+			$request,
+			$this->createMock(LoggerInterface::class),
+		);
+	}
+
+	/**
+	 * Etherpad's real shape: `s.` plus 16 characters. The `x` separates the
+	 * label from the padding, so `g1` and `g10` do not collide.
+	 */
+	private function sid(string $label): string {
+		return 's.' . substr(str_pad($label . 'x', 16, '0'), 0, 16);
 	}
 
 	/**
 	 * Each protected pad is its own Etherpad group, and a session grants
-	 * access to one group. Etherpad holds the author's sessions and knows
-	 * which group each belongs to, so that list — not the incoming cookie —
-	 * decides what the cookie should say.
+	 * access to one group. The cookie is the only place that state lives,
+	 * so an open must not write away what the browser already carried.
 	 *
-	 * @param array<string,array{groupID:string,validUntil:int}>|null $sessions null makes the listing fail
+	 * @param array<string,array{groupID:string,validUntil:int}> $sessions
+	 * @return array{name:string,value:string,expires:int,path:string,domain:string,secure:bool,http_only:bool,same_site:string}
 	 */
-	private function openContextCookieValue(
-		?array $sessions,
+	private function openContextCookie(
+		array $sessions,
 		?string $incoming = null,
 		string $groupId = 'g.ABCDEFGHIJKLMNOP',
-		?EtherpadClient $client = null,
-	): string {
-		$etherpadClient = $client ?? $this->createMock(EtherpadClient::class);
-		if ($client === null) {
-			$etherpadClient->method('createSession')->willReturn('s.new');
-		}
-		if ($sessions === null) {
+		bool $listingFails = false,
+	): array {
+		$etherpadClient = $this->createMock(EtherpadClient::class);
+		$etherpadClient->method('createSession')->willReturn($this->sid('new'));
+		if ($listingFails) {
 			$etherpadClient->method('listSessionsOfAuthor')
 				->willThrowException(new EtherpadClientException('unavailable'));
 		} else {
@@ -58,139 +72,195 @@ class PadSessionServiceTest extends TestCase {
 		}
 		$etherpadClient->method('createAuthorIfNotExistsFor')->willReturn('a.author');
 		$etherpadClient->method('buildPadUrl')->willReturn('https://pad.example.test/p/x');
-		$config = $this->createMock(IConfig::class);
-		$service = $this->buildService($etherpadClient, $config, 'https://cloud.example.test', $incoming);
 
-		return $service->createProtectedOpenContext('admin', 'Admin', $groupId . '$pad-1')['cookie']['value'];
-	}
-
-	/**
-	 * @param array<string,array{groupID:string,validUntil:int}> $sessions
-	 * @return array{name:string,value:string,expires:int,path:string,domain:string,secure:bool,http_only:bool,same_site:string}
-	 */
-	private function openContextCookie(array $sessions, string $groupId = 'g.ABCDEFGHIJKLMNOP'): array {
-		$etherpadClient = $this->createMock(EtherpadClient::class);
-		$etherpadClient->method('createSession')->willReturn('s.new');
-		$etherpadClient->method('listSessionsOfAuthor')->willReturn($sessions);
-		$etherpadClient->method('createAuthorIfNotExistsFor')->willReturn('a.author');
-		$etherpadClient->method('buildPadUrl')->willReturn('https://pad.example.test/p/x');
-
-		$service = $this->buildService($etherpadClient, $this->createMock(IConfig::class));
+		$service = $this->buildService(
+			$etherpadClient,
+			$this->createMock(IConfig::class),
+			'https://cloud.example.test',
+			$incoming,
+		);
 
 		return $service->createProtectedOpenContext('admin', 'Admin', $groupId . '$pad-1')['cookie'];
 	}
 
-	public function testCarriesTheAuthorsOtherLivingSessions(): void {
-		$value = $this->openContextCookieValue([
-			's.other' => ['groupID' => 'g.OTHERGROUP00000', 'validUntil' => time() + 3600],
-		]);
+	public function testWritesOnlyTheNewSessionWhenTheBrowserSentNone(): void {
+		$this->assertSame($this->sid('new'), $this->openContextCookie([], null)['value']);
+	}
 
-		$this->assertSame('s.new,s.other', $value);
+	public function testKeepsAnotherPadsSessionTheBrowserWasCarrying(): void {
+		$other = $this->sid('other');
+
+		$value = $this->openContextCookie(
+			[$other => ['groupID' => 'g.OTHERGROUP00000', 'validUntil' => time() + 3600]],
+			$other,
+		)['value'];
+
+		$this->assertSame($this->sid('new') . ',' . $other, $value);
 	}
 
 	/**
-	 * The bug a cookie-only list could not fix: every open minted a session
-	 * even for a pad already open, so ten entries meant ten opens. Opening
-	 * one pad repeatedly pushed the other out.
+	 * The point of asking Etherpad: without the group behind each id, ten
+	 * opens of one pad filled the cookie with ten of its ids and pushed the
+	 * other pad out.
 	 */
-	public function testReusesTheLivingSessionOfTheGroupBeingOpened(): void {
-		$existing = time() + 3600;
-		$etherpadClient = $this->createMock(EtherpadClient::class);
-		$etherpadClient->expects($this->never())->method('createSession');
+	public function testCollapsesSeveralSessionsOfOneGroupIntoTheLongestLiving(): void {
+		$short = $this->sid('bshort');
+		$long = $this->sid('blong');
+		$c = $this->sid('c');
 
-		$value = $this->openContextCookieValue(
+		$value = $this->openContextCookie(
 			[
-				's.same' => ['groupID' => 'g.ABCDEFGHIJKLMNOP', 'validUntil' => $existing],
-				's.other' => ['groupID' => 'g.OTHERGROUP00000', 'validUntil' => time() + 60],
+				$short => ['groupID' => 'g.BBBBBBBBBBBBBBBB', 'validUntil' => time() + 600],
+				$long => ['groupID' => 'g.BBBBBBBBBBBBBBBB', 'validUntil' => time() + 3600],
+				$c => ['groupID' => 'g.CCCCCCCCCCCCCCCC', 'validUntil' => time() + 1200],
 			],
-			null,
-			'g.ABCDEFGHIJKLMNOP',
-			$etherpadClient,
-		);
+			implode(',', [$short, $long, $c]),
+		)['value'];
 
-		$this->assertSame('s.same,s.other', $value);
+		$this->assertSame(implode(',', [$this->sid('new'), $long, $c]), $value);
 	}
 
-	public function testMintsAFreshSessionWhenTheGroupsSessionIsAboutToExpire(): void {
-		$value = $this->openContextCookieValue([
-			's.nearly' => ['groupID' => 'g.ABCDEFGHIJKLMNOP', 'validUntil' => time() + 60],
-		]);
+	/**
+	 * Nothing is added that the browser was not already carrying. An open
+	 * must not re-issue access to a pad the user has since lost — it only
+	 * refrains from taking away what they held, which dies on its own.
+	 */
+	public function testDoesNotReissueSessionsTheBrowserDidNotSend(): void {
+		$value = $this->openContextCookie(
+			[$this->sid('revoked') => ['groupID' => 'g.REVOKEDGROUP000', 'validUntil' => time() + 3600]],
+			null,
+		)['value'];
 
-		$this->assertSame('s.new', $value);
+		$this->assertSame($this->sid('new'), $value);
+	}
+
+	public function testDropsTheOldSessionOfTheGroupBeingOpened(): void {
+		$stale = $this->sid('stale');
+
+		$value = $this->openContextCookie(
+			[$stale => ['groupID' => 'g.ABCDEFGHIJKLMNOP', 'validUntil' => time() + 3600]],
+			$stale,
+		)['value'];
+
+		$this->assertSame($this->sid('new'), $value);
 	}
 
 	public function testDropsSessionsThatHaveExpired(): void {
-		$value = $this->openContextCookieValue([
-			's.dead' => ['groupID' => 'g.OTHERGROUP00000', 'validUntil' => time() - 10],
-		]);
+		$dead = $this->sid('dead');
 
-		$this->assertSame('s.new', $value);
+		$value = $this->openContextCookie(
+			[$dead => ['groupID' => 'g.OTHERGROUP00000', 'validUntil' => time() - 10]],
+			$dead,
+		)['value'];
+
+		$this->assertSame($this->sid('new'), $value);
+	}
+
+	/**
+	 * A public share is its own Etherpad author, so its session is not in
+	 * this author's listing. It is kept anyway — the browser had it — but
+	 * last, and under a tighter cap, because nothing here can tell it from a
+	 * value some other host under the shared cookie domain wrote.
+	 */
+	public function testKeepsIdsTheListingDoesNotKnowLastAndCapped(): void {
+		$known = $this->sid('known');
+		$foreign = array_map(fn (int $i): string => $this->sid('foreign' . $i), range(1, 8));
+
+		$value = $this->openContextCookie(
+			[$known => ['groupID' => 'g.OTHERGROUP00000', 'validUntil' => time() + 3600]],
+			implode(',', array_merge($foreign, [$known])),
+		)['value'];
+
+		$ids = explode(',', $value);
+		$this->assertSame($this->sid('new'), $ids[0]);
+		$this->assertSame($known, $ids[1]);
+		$this->assertCount(2 + 5, $ids);
+	}
+
+	public function testTheCookieOutlivesEveryIdItCarries(): void {
+		$longer = time() + 3600;
+		$other = $this->sid('other');
+
+		$cookie = $this->openContextCookie(
+			[$other => ['groupID' => 'g.BBBBBBBBBBBBBBBB', 'validUntil' => $longer]],
+			$other,
+		);
+
+		$this->assertSame($longer, $cookie['expires']);
 	}
 
 	public function testKeepsTheCookieBoundedAndDropsWhatExpiresSoonest(): void {
 		$sessions = [];
+		$ids = [];
 		foreach (range(1, 30) as $i) {
-			$sessions['s.g' . $i] = ['groupID' => 'g.GROUP' . str_pad((string)$i, 11, '0'), 'validUntil' => time() + 600 + $i];
+			$id = $this->sid('g' . $i);
+			$ids[] = $id;
+			$sessions[$id] = ['groupID' => 'g.GROUP' . str_pad((string)$i, 11, '0'), 'validUntil' => time() + 600 + $i];
 		}
 
-		$value = $this->openContextCookieValue($sessions);
-		$ids = explode(',', $value);
+		$value = $this->openContextCookie($sessions, implode(',', $ids))['value'];
+		$kept = explode(',', $value);
 
-		$this->assertCount(25, $ids);
-		$this->assertSame('s.new', $ids[0]);
-		// Longest-lived first after the pad being opened, soonest dropped.
-		$this->assertSame('s.g30', $ids[1]);
-		$this->assertNotContains('s.g1', $ids);
-		// Still comfortably inside what a cookie may carry.
+		$this->assertCount(25, $kept);
+		$this->assertSame($this->sid('new'), $kept[0]);
+		$this->assertSame($this->sid('g30'), $kept[1]);
+		$this->assertNotContains($this->sid('g1'), $kept);
 		$this->assertLessThan(2000, strlen($value));
 	}
 
-	/**
-	 * An author can hold several living sessions for one group — from opens
-	 * before the reuse existed, from the fallback, or from two opens racing.
-	 * Keyed by session they would each take a slot and push a third pad out.
-	 */
-	public function testKeepsOnlyTheLongestLivingSessionPerOtherGroup(): void {
-		$value = $this->openContextCookieValue([
-			's.b-short' => ['groupID' => 'g.BBBBBBBBBBBBBBBB', 'validUntil' => time() + 600],
-			's.b-long' => ['groupID' => 'g.BBBBBBBBBBBBBBBB', 'validUntil' => time() + 3600],
-			's.c' => ['groupID' => 'g.CCCCCCCCCCCCCCCC', 'validUntil' => time() + 1200],
-		]);
+	public function testIgnoresCookieValuesThatAreNotSessionIds(): void {
+		$value = $this->openContextCookie([], 'nonsense; HttpOnly,../etc,s.,s.' . str_repeat('a', 200))['value'];
 
-		$this->assertSame('s.new,s.b-long,s.c', $value);
+		$this->assertSame($this->sid('new'), $value);
+	}
+
+	public function testAcceptsTheQuotedCookieForm(): void {
+		$one = $this->sid('one');
+
+		$value = $this->openContextCookie([], '"' . $one . ' "')['value'];
+
+		$this->assertSame($this->sid('new') . ',' . $one, $value);
 	}
 
 	/**
-	 * Reusing a short-lived session must not shorten the cookie: the browser
-	 * would drop another pad's id that was still good for an hour.
-	 */
-	public function testTheCookieOutlivesEveryIdItCarries(): void {
-		$longer = time() + 3600;
-
-		$cookie = $this->openContextCookie([
-			's.same' => ['groupID' => 'g.ABCDEFGHIJKLMNOP', 'validUntil' => time() + 900],
-			's.other' => ['groupID' => 'g.BBBBBBBBBBBBBBBB', 'validUntil' => $longer],
-		]);
-
-		$this->assertSame('s.same,s.other', $cookie['value']);
-		$this->assertSame($longer, $cookie['expires']);
-	}
-
-	/**
-	 * When Etherpad cannot answer, the open still happens — with a fresh
-	 * session merged into what the browser sent, which is all this had
-	 * before the listing existed.
+	 * When Etherpad cannot answer, the open still happens — on the browser's
+	 * cookie alone, group-blind and capped tighter, and logged, because the
+	 * symptom this method prevents comes back on that path.
 	 */
 	public function testFallsBackToTheBrowsersCookieWhenTheListingFails(): void {
-		$this->assertSame('s.new,s.old', $this->openContextCookieValue(null, 's.old'));
+		$carried = array_map(fn (int $i): string => $this->sid('old' . $i), range(1, 8));
+
+		$value = $this->openContextCookie([], implode(',', $carried), 'g.ABCDEFGHIJKLMNOP', true)['value'];
+
+		$ids = explode(',', $value);
+		$this->assertSame($this->sid('new'), $ids[0]);
+		$this->assertCount(1 + 5, $ids);
 	}
 
-	public function testTheFallbackCarriesNothingOverThatIsNotASessionId(): void {
-		$this->assertSame('s.new', $this->openContextCookieValue(null, 'nonsense; HttpOnly,../etc,s.'));
-	}
+	public function testLogsWhenTheListingIsUnavailable(): void {
+		$etherpadClient = $this->createMock(EtherpadClient::class);
+		$etherpadClient->method('createSession')->willReturn($this->sid('new'));
+		$etherpadClient->method('listSessionsOfAuthor')
+			->willThrowException(new EtherpadClientException('unavailable'));
+		$etherpadClient->method('createAuthorIfNotExistsFor')->willReturn('a.author');
+		$etherpadClient->method('buildPadUrl')->willReturn('https://pad.example.test/p/x');
 
-	public function testTheFallbackAcceptsTheQuotedCookieForm(): void {
-		$this->assertSame('s.new,s.one,s.two', $this->openContextCookieValue(null, '"s.one, s.two"'));
+		$urlGenerator = $this->createMock(IURLGenerator::class);
+		$urlGenerator->method('getBaseUrl')->willReturn('https://cloud.example.test');
+		$request = $this->createMock(IRequest::class);
+		$logger = $this->createMock(LoggerInterface::class);
+		$logger->expects($this->once())->method('warning');
+
+		$service = new PadSessionService(
+			$etherpadClient,
+			$this->createMock(IConfig::class),
+			$urlGenerator,
+			new CookieDomainPolicy(),
+			$request,
+			$logger,
+		);
+
+		$service->createProtectedOpenContext('admin', 'Admin', 'g.ABCDEFGHIJKLMNOP$pad-1');
 	}
 
 	/**

--- a/tests/phpunit/unit/PadSessionServiceTest.php
+++ b/tests/phpunit/unit/PadSessionServiceTest.php
@@ -34,51 +34,116 @@ class PadSessionServiceTest extends TestCase {
 
 	/**
 	 * Each protected pad is its own Etherpad group, and a session grants
-	 * access to one group. Replacing the cookie took the other tab's access
-	 * away; Etherpad reads the value as a comma-separated list, so the ones
-	 * already there are kept.
+	 * access to one group. Etherpad holds the author's sessions and knows
+	 * which group each belongs to, so that list — not the incoming cookie —
+	 * decides what the cookie should say.
+	 *
+	 * @param array<string,array{groupID:string,validUntil:int}>|null $sessions null makes the listing fail
 	 */
-	private function openContextCookieValue(?string $incoming): string {
-		$etherpadClient = $this->createMock(EtherpadClient::class);
+	private function openContextCookieValue(
+		?array $sessions,
+		?string $incoming = null,
+		string $groupId = 'g.ABCDEFGHIJKLMNOP',
+		?EtherpadClient $client = null,
+	): string {
+		$etherpadClient = $client ?? $this->createMock(EtherpadClient::class);
+		if ($client === null) {
+			$etherpadClient->method('createSession')->willReturn('s.new');
+		}
+		if ($sessions === null) {
+			$etherpadClient->method('listSessionsOfAuthor')
+				->willThrowException(new EtherpadClientException('unavailable'));
+		} else {
+			$etherpadClient->method('listSessionsOfAuthor')->willReturn($sessions);
+		}
 		$etherpadClient->method('createAuthorIfNotExistsFor')->willReturn('a.author');
-		$etherpadClient->method('createSession')->willReturn('s.new');
 		$etherpadClient->method('buildPadUrl')->willReturn('https://pad.example.test/p/x');
 		$config = $this->createMock(IConfig::class);
 		$service = $this->buildService($etherpadClient, $config, 'https://cloud.example.test', $incoming);
 
-		return $service->createProtectedOpenContext('admin', 'Admin', 'g.ABCDEFGHIJKLMNOP$pad-1')['cookie']['value'];
+		return $service->createProtectedOpenContext('admin', 'Admin', $groupId . '$pad-1')['cookie']['value'];
 	}
 
-	public function testKeepsTheSessionsAlreadyInTheCookie(): void {
-		$this->assertSame('s.new,s.old', $this->openContextCookieValue('s.old'));
+	public function testCarriesTheAuthorsOtherLivingSessions(): void {
+		$value = $this->openContextCookieValue([
+			's.other' => ['groupID' => 'g.OTHERGROUP00000', 'validUntil' => time() + 3600],
+		]);
+
+		$this->assertSame('s.new,s.other', $value);
 	}
 
-	public function testPutsTheNewSessionFirstAndDropsDuplicates(): void {
-		$this->assertSame('s.new,s.one,s.two', $this->openContextCookieValue('s.one,s.new,s.two,s.one'));
+	/**
+	 * The bug a cookie-only list could not fix: every open minted a session
+	 * even for a pad already open, so ten entries meant ten opens. Opening
+	 * one pad repeatedly pushed the other out.
+	 */
+	public function testReusesTheLivingSessionOfTheGroupBeingOpened(): void {
+		$existing = time() + 3600;
+		$etherpadClient = $this->createMock(EtherpadClient::class);
+		$etherpadClient->expects($this->never())->method('createSession');
+
+		$value = $this->openContextCookieValue(
+			[
+				's.same' => ['groupID' => 'g.ABCDEFGHIJKLMNOP', 'validUntil' => $existing],
+				's.other' => ['groupID' => 'g.OTHERGROUP00000', 'validUntil' => time() + 60],
+			],
+			null,
+			'g.ABCDEFGHIJKLMNOP',
+			$etherpadClient,
+		);
+
+		$this->assertSame('s.same,s.other', $value);
 	}
 
-	public function testAcceptsTheQuotedCookieFormAndIgnoresSpacing(): void {
-		$this->assertSame('s.new,s.one,s.two', $this->openContextCookieValue('"s.one, s.two"'));
+	public function testMintsAFreshSessionWhenTheGroupsSessionIsAboutToExpire(): void {
+		$value = $this->openContextCookieValue([
+			's.nearly' => ['groupID' => 'g.ABCDEFGHIJKLMNOP', 'validUntil' => time() + 60],
+		]);
+
+		$this->assertSame('s.new', $value);
 	}
 
-	public function testCarriesNothingOverThatIsNotASessionId(): void {
-		$this->assertSame('s.new', $this->openContextCookieValue('nonsense; HttpOnly,../etc,s.'));
+	public function testDropsSessionsThatHaveExpired(): void {
+		$value = $this->openContextCookieValue([
+			's.dead' => ['groupID' => 'g.OTHERGROUP00000', 'validUntil' => time() - 10],
+		]);
+
+		$this->assertSame('s.new', $value);
 	}
 
-	public function testWritesOnlyTheNewSessionWhenNoCookieWasSent(): void {
-		$this->assertSame('s.new', $this->openContextCookieValue(null));
-	}
+	public function testKeepsTheCookieBoundedAndDropsWhatExpiresSoonest(): void {
+		$sessions = [];
+		foreach (range(1, 30) as $i) {
+			$sessions['s.g' . $i] = ['groupID' => 'g.GROUP' . str_pad((string)$i, 11, '0'), 'validUntil' => time() + 600 + $i];
+		}
 
-	public function testKeepsTheCookieBoundedAndDropsTheOldest(): void {
-		$incoming = implode(',', array_map(static fn (int $i): string => 's.old' . $i, range(1, 15)));
-
-		$value = $this->openContextCookieValue($incoming);
-
+		$value = $this->openContextCookieValue($sessions);
 		$ids = explode(',', $value);
-		$this->assertCount(10, $ids);
+
+		$this->assertCount(25, $ids);
 		$this->assertSame('s.new', $ids[0]);
-		$this->assertSame('s.old9', $ids[9]);
-		$this->assertNotContains('s.old10', $ids);
+		// Longest-lived first after the pad being opened, soonest dropped.
+		$this->assertSame('s.g30', $ids[1]);
+		$this->assertNotContains('s.g1', $ids);
+		// Still comfortably inside what a cookie may carry.
+		$this->assertLessThan(2000, strlen($value));
+	}
+
+	/**
+	 * When Etherpad cannot answer, the open still happens — with a fresh
+	 * session merged into what the browser sent, which is all this had
+	 * before the listing existed.
+	 */
+	public function testFallsBackToTheBrowsersCookieWhenTheListingFails(): void {
+		$this->assertSame('s.new,s.old', $this->openContextCookieValue(null, 's.old'));
+	}
+
+	public function testTheFallbackCarriesNothingOverThatIsNotASessionId(): void {
+		$this->assertSame('s.new', $this->openContextCookieValue(null, 'nonsense; HttpOnly,../etc,s.'));
+	}
+
+	public function testTheFallbackAcceptsTheQuotedCookieForm(): void {
+		$this->assertSame('s.new,s.one,s.two', $this->openContextCookieValue(null, '"s.one, s.two"'));
 	}
 
 	/**
@@ -259,11 +324,11 @@ class PadSessionServiceTest extends TestCase {
 	}
 
 	/**
-	 * A cached id whose name still matches costs one API call, not two. The
-	 * lookup used to run first and the name comparison after it, so the
-	 * cache saved nothing.
+	 * The author lookup runs even when the stored name matches: it is what
+	 * keeps Etherpad's copy of the name in step with Nextcloud's, and
+	 * nothing else repairs a name that drifted on the Etherpad side.
 	 */
-	public function testCreateProtectedOpenContextReusesTheCachedAuthorWithoutAskingEtherpad(): void {
+	public function testCreateProtectedOpenContextRefreshesTheAuthorNameOnEveryOpen(): void {
 		$uid = 'alice';
 		$displayName = 'Alice Example';
 		$padId = 'g.ABCDEFGHIJKLMNOP$pad-1';
@@ -273,7 +338,11 @@ class PadSessionServiceTest extends TestCase {
 		$padUrl = 'https://pad.example.test/p/' . rawurlencode($padId);
 
 		$etherpadClient = $this->createMock(EtherpadClient::class);
-		$etherpadClient->expects($this->never())->method('createAuthorIfNotExistsFor');
+		$etherpadClient->expects($this->once())
+			->method('createAuthorIfNotExistsFor')
+			->with('nc:' . $uid, $displayName)
+			->willReturn($authorId);
+		$etherpadClient->method('listSessionsOfAuthor')->willReturn([]);
 		$etherpadClient->expects($this->once())
 			->method('createSession')
 			->with($groupId, $authorId, $this->isType('int'))
@@ -354,13 +423,16 @@ class PadSessionServiceTest extends TestCase {
 		$sessionId = 's.fresh';
 
 		$etherpadClient = $this->createMock(EtherpadClient::class);
-		// Once, not twice: the cached name matches, so the open goes straight
-		// to createSession and only the bootstrap after its failure asks for
-		// an author.
-		$etherpadClient->expects($this->once())
+		$etherpadClient->expects($this->exactly(2))
 			->method('createAuthorIfNotExistsFor')
-			->with('nc:' . $uid, $displayName)
-			->willReturn($freshAuthorId);
+			->willReturnCallback(static function (string $authorMapper, string $name) use ($uid, $displayName, $cachedAuthorId, $freshAuthorId): string {
+				static $call = 0;
+				$call++;
+				TestCase::assertSame('nc:' . $uid, $authorMapper);
+				TestCase::assertSame($displayName, $name);
+				return $call === 1 ? $cachedAuthorId : $freshAuthorId;
+			});
+		$etherpadClient->method('listSessionsOfAuthor')->willReturn([]);
 		$etherpadClient->expects($this->exactly(2))
 			->method('createSession')
 			->willReturnCallback(static function (string $actualGroupId, string $actualAuthorId, int $validUntil) use ($groupId, $cachedAuthorId, $freshAuthorId, $sessionId): string {

--- a/tests/phpunit/unit/PadSessionServiceTest.php
+++ b/tests/phpunit/unit/PadSessionServiceTest.php
@@ -64,6 +64,22 @@ class PadSessionServiceTest extends TestCase {
 		return $service->createProtectedOpenContext('admin', 'Admin', $groupId . '$pad-1')['cookie']['value'];
 	}
 
+	/**
+	 * @param array<string,array{groupID:string,validUntil:int}> $sessions
+	 * @return array{name:string,value:string,expires:int,path:string,domain:string,secure:bool,http_only:bool,same_site:string}
+	 */
+	private function openContextCookie(array $sessions, string $groupId = 'g.ABCDEFGHIJKLMNOP'): array {
+		$etherpadClient = $this->createMock(EtherpadClient::class);
+		$etherpadClient->method('createSession')->willReturn('s.new');
+		$etherpadClient->method('listSessionsOfAuthor')->willReturn($sessions);
+		$etherpadClient->method('createAuthorIfNotExistsFor')->willReturn('a.author');
+		$etherpadClient->method('buildPadUrl')->willReturn('https://pad.example.test/p/x');
+
+		$service = $this->buildService($etherpadClient, $this->createMock(IConfig::class));
+
+		return $service->createProtectedOpenContext('admin', 'Admin', $groupId . '$pad-1')['cookie'];
+	}
+
 	public function testCarriesTheAuthorsOtherLivingSessions(): void {
 		$value = $this->openContextCookieValue([
 			's.other' => ['groupID' => 'g.OTHERGROUP00000', 'validUntil' => time() + 3600],
@@ -127,6 +143,37 @@ class PadSessionServiceTest extends TestCase {
 		$this->assertNotContains('s.g1', $ids);
 		// Still comfortably inside what a cookie may carry.
 		$this->assertLessThan(2000, strlen($value));
+	}
+
+	/**
+	 * An author can hold several living sessions for one group — from opens
+	 * before the reuse existed, from the fallback, or from two opens racing.
+	 * Keyed by session they would each take a slot and push a third pad out.
+	 */
+	public function testKeepsOnlyTheLongestLivingSessionPerOtherGroup(): void {
+		$value = $this->openContextCookieValue([
+			's.b-short' => ['groupID' => 'g.BBBBBBBBBBBBBBBB', 'validUntil' => time() + 600],
+			's.b-long' => ['groupID' => 'g.BBBBBBBBBBBBBBBB', 'validUntil' => time() + 3600],
+			's.c' => ['groupID' => 'g.CCCCCCCCCCCCCCCC', 'validUntil' => time() + 1200],
+		]);
+
+		$this->assertSame('s.new,s.b-long,s.c', $value);
+	}
+
+	/**
+	 * Reusing a short-lived session must not shorten the cookie: the browser
+	 * would drop another pad's id that was still good for an hour.
+	 */
+	public function testTheCookieOutlivesEveryIdItCarries(): void {
+		$longer = time() + 3600;
+
+		$cookie = $this->openContextCookie([
+			's.same' => ['groupID' => 'g.ABCDEFGHIJKLMNOP', 'validUntil' => time() + 900],
+			's.other' => ['groupID' => 'g.BBBBBBBBBBBBBBBB', 'validUntil' => $longer],
+		]);
+
+		$this->assertSame('s.same,s.other', $cookie['value']);
+		$this->assertSame($longer, $cookie['expires']);
 	}
 
 	/**

--- a/tests/phpunit/unit/PadSessionServiceTest.php
+++ b/tests/phpunit/unit/PadSessionServiceTest.php
@@ -237,6 +237,25 @@ class PadSessionServiceTest extends TestCase {
 		$this->assertCount(1 + 5, $ids);
 	}
 
+	/**
+	 * The listing is the call whose cost grows with every distinct pad the
+	 * user has ever opened. With nothing in the cookie there is nothing to
+	 * annotate, so the first open of a browsing session does not pay for it.
+	 */
+	public function testDoesNotAskForTheListingWhenTheBrowserSentNoSessions(): void {
+		$etherpadClient = $this->createMock(EtherpadClient::class);
+		$etherpadClient->expects($this->never())->method('listSessionsOfAuthor');
+		$etherpadClient->method('createSession')->willReturn($this->sid('new'));
+		$etherpadClient->method('createAuthorIfNotExistsFor')->willReturn('a.author');
+		$etherpadClient->method('buildPadUrl')->willReturn('https://pad.example.test/p/x');
+
+		$service = $this->buildService($etherpadClient, $this->createMock(IConfig::class));
+
+		$cookie = $service->createProtectedOpenContext('admin', 'Admin', 'g.ABCDEFGHIJKLMNOP$pad-1')['cookie'];
+
+		$this->assertSame($this->sid('new'), $cookie['value']);
+	}
+
 	public function testLogsWhenTheListingIsUnavailable(): void {
 		$etherpadClient = $this->createMock(EtherpadClient::class);
 		$etherpadClient->method('createSession')->willReturn($this->sid('new'));
@@ -247,7 +266,9 @@ class PadSessionServiceTest extends TestCase {
 
 		$urlGenerator = $this->createMock(IURLGenerator::class);
 		$urlGenerator->method('getBaseUrl')->willReturn('https://cloud.example.test');
+		// The listing is only asked for when the browser sent ids to annotate.
 		$request = $this->createMock(IRequest::class);
+		$request->method('getCookie')->with('sessionID')->willReturn($this->sid('carried'));
 		$logger = $this->createMock(LoggerInterface::class);
 		$logger->expects($this->once())->method('warning');
 

--- a/tests/phpunit/unit/PadSessionServiceTest.php
+++ b/tests/phpunit/unit/PadSessionServiceTest.php
@@ -9,6 +9,7 @@ use OCA\EtherpadNextcloud\Service\CookieDomainPolicy;
 use OCA\EtherpadNextcloud\Service\EtherpadClient;
 use OCA\EtherpadNextcloud\Service\PadSessionService;
 use OCP\IConfig;
+use OCP\IRequest;
 use OCP\IURLGenerator;
 use PHPUnit\Framework\TestCase;
 
@@ -18,10 +19,101 @@ class PadSessionServiceTest extends TestCase {
 	 * case runs against a Nextcloud that shares a parent with the Etherpad
 	 * host used in the fixtures.
 	 */
-	private function buildService(EtherpadClient $etherpadClient, IConfig $config, string $nextcloudUrl = 'https://cloud.example.test'): PadSessionService {
+	private function buildService(
+		EtherpadClient $etherpadClient,
+		IConfig $config,
+		string $nextcloudUrl = 'https://cloud.example.test',
+		?string $incomingSessionCookie = null,
+	): PadSessionService {
 		$urlGenerator = $this->createMock(IURLGenerator::class);
 		$urlGenerator->method('getBaseUrl')->willReturn($nextcloudUrl);
-		return new PadSessionService($etherpadClient, $config, $urlGenerator, new CookieDomainPolicy());
+		$request = $this->createMock(IRequest::class);
+		$request->method('getCookie')->with('sessionID')->willReturn($incomingSessionCookie);
+		return new PadSessionService($etherpadClient, $config, $urlGenerator, new CookieDomainPolicy(), $request);
+	}
+
+	/**
+	 * Each protected pad is its own Etherpad group, and a session grants
+	 * access to one group. Replacing the cookie took the other tab's access
+	 * away; Etherpad reads the value as a comma-separated list, so the ones
+	 * already there are kept.
+	 */
+	private function openContextCookieValue(?string $incoming): string {
+		$etherpadClient = $this->createMock(EtherpadClient::class);
+		$etherpadClient->method('createAuthorIfNotExistsFor')->willReturn('a.author');
+		$etherpadClient->method('createSession')->willReturn('s.new');
+		$etherpadClient->method('buildPadUrl')->willReturn('https://pad.example.test/p/x');
+		$config = $this->createMock(IConfig::class);
+		$service = $this->buildService($etherpadClient, $config, 'https://cloud.example.test', $incoming);
+
+		return $service->createProtectedOpenContext('admin', 'Admin', 'g.ABCDEFGHIJKLMNOP$pad-1')['cookie']['value'];
+	}
+
+	public function testKeepsTheSessionsAlreadyInTheCookie(): void {
+		$this->assertSame('s.new,s.old', $this->openContextCookieValue('s.old'));
+	}
+
+	public function testPutsTheNewSessionFirstAndDropsDuplicates(): void {
+		$this->assertSame('s.new,s.one,s.two', $this->openContextCookieValue('s.one,s.new,s.two,s.one'));
+	}
+
+	public function testAcceptsTheQuotedCookieFormAndIgnoresSpacing(): void {
+		$this->assertSame('s.new,s.one,s.two', $this->openContextCookieValue('"s.one, s.two"'));
+	}
+
+	public function testCarriesNothingOverThatIsNotASessionId(): void {
+		$this->assertSame('s.new', $this->openContextCookieValue('nonsense; HttpOnly,../etc,s.'));
+	}
+
+	public function testWritesOnlyTheNewSessionWhenNoCookieWasSent(): void {
+		$this->assertSame('s.new', $this->openContextCookieValue(null));
+	}
+
+	public function testKeepsTheCookieBoundedAndDropsTheOldest(): void {
+		$incoming = implode(',', array_map(static fn (int $i): string => 's.old' . $i, range(1, 15)));
+
+		$value = $this->openContextCookieValue($incoming);
+
+		$ids = explode(',', $value);
+		$this->assertCount(10, $ids);
+		$this->assertSame('s.new', $ids[0]);
+		$this->assertSame('s.old9', $ids[9]);
+		$this->assertNotContains('s.old10', $ids);
+	}
+
+	/**
+	 * A renamed user still reaches Etherpad: the cache answers "unchanged"
+	 * only when the stored name matches the one being opened with.
+	 */
+	public function testCreateProtectedOpenContextSyncsWhenTheDisplayNameChanged(): void {
+		$uid = 'alice';
+		$padId = 'g.ABCDEFGHIJKLMNOP$pad-1';
+
+		$etherpadClient = $this->createMock(EtherpadClient::class);
+		$etherpadClient->expects($this->once())
+			->method('createAuthorIfNotExistsFor')
+			->with('nc:' . $uid, 'Alice Renamed')
+			->willReturn('a.cached');
+		$etherpadClient->method('createSession')->willReturn('s.session');
+		$etherpadClient->method('buildPadUrl')->willReturn('https://pad.example.test/p/x');
+
+		$config = $this->createMock(IConfig::class);
+		$config->method('getAppValue')->willReturnMap([
+			['etherpad_nextcloud', 'etherpad_cookie_domain', '', ''],
+			['etherpad_nextcloud', 'etherpad_cookie_domain_configured', 'no', 'no'],
+			['etherpad_nextcloud', 'etherpad_host', '', 'https://pad.example.test'],
+		]);
+		$config->method('getUserValue')->willReturnMap([
+			[$uid, 'etherpad_nextcloud', 'etherpad_author_id', '', 'a.cached'],
+			[$uid, 'etherpad_nextcloud', 'etherpad_author_display_name', '', 'Alice Example'],
+		]);
+		$config->expects($this->once())
+			->method('setUserValue')
+			->with($uid, 'etherpad_nextcloud', 'etherpad_author_display_name', 'Alice Renamed');
+
+		$service = $this->buildService($etherpadClient, $config);
+
+		$service->createProtectedOpenContext($uid, 'Alice Renamed', $padId);
 	}
 
 	public function testExtractGroupIdReturnsGroupPrefix(): void {
@@ -166,7 +258,12 @@ class PadSessionServiceTest extends TestCase {
 		$this->assertStringNotContainsString("\r", $header);
 	}
 
-	public function testCreateProtectedOpenContextRefreshesCachedAuthorMapping(): void {
+	/**
+	 * A cached id whose name still matches costs one API call, not two. The
+	 * lookup used to run first and the name comparison after it, so the
+	 * cache saved nothing.
+	 */
+	public function testCreateProtectedOpenContextReusesTheCachedAuthorWithoutAskingEtherpad(): void {
 		$uid = 'alice';
 		$displayName = 'Alice Example';
 		$padId = 'g.ABCDEFGHIJKLMNOP$pad-1';
@@ -176,10 +273,7 @@ class PadSessionServiceTest extends TestCase {
 		$padUrl = 'https://pad.example.test/p/' . rawurlencode($padId);
 
 		$etherpadClient = $this->createMock(EtherpadClient::class);
-		$etherpadClient->expects($this->once())
-			->method('createAuthorIfNotExistsFor')
-			->with('nc:' . $uid, $displayName)
-			->willReturn($authorId);
+		$etherpadClient->expects($this->never())->method('createAuthorIfNotExistsFor');
 		$etherpadClient->expects($this->once())
 			->method('createSession')
 			->with($groupId, $authorId, $this->isType('int'))
@@ -260,15 +354,13 @@ class PadSessionServiceTest extends TestCase {
 		$sessionId = 's.fresh';
 
 		$etherpadClient = $this->createMock(EtherpadClient::class);
-		$etherpadClient->expects($this->exactly(2))
+		// Once, not twice: the cached name matches, so the open goes straight
+		// to createSession and only the bootstrap after its failure asks for
+		// an author.
+		$etherpadClient->expects($this->once())
 			->method('createAuthorIfNotExistsFor')
-			->willReturnCallback(static function (string $authorMapper, string $name) use ($uid, $displayName, $cachedAuthorId, $freshAuthorId): string {
-				static $call = 0;
-				$call++;
-				TestCase::assertSame('nc:' . $uid, $authorMapper);
-				TestCase::assertSame($displayName, $name);
-				return $call === 1 ? $cachedAuthorId : $freshAuthorId;
-			});
+			->with('nc:' . $uid, $displayName)
+			->willReturn($freshAuthorId);
 		$etherpadClient->expects($this->exactly(2))
 			->method('createSession')
 			->willReturnCallback(static function (string $actualGroupId, string $actualAuthorId, int $validUntil) use ($groupId, $cachedAuthorId, $freshAuthorId, $sessionId): string {

--- a/tests/phpunit/unit/PadSessionServiceTest.php
+++ b/tests/phpunit/unit/PadSessionServiceTest.php
@@ -176,8 +176,13 @@ class PadSessionServiceTest extends TestCase {
 		$this->assertSame($this->sid('new') . ',' . $known, $value);
 	}
 
+	/**
+	 * Strictly longer than the new session's hour, so this cannot pass with
+	 * the expiry taken from the new session alone — and cannot fail because
+	 * a second ticked between two time() calls.
+	 */
 	public function testTheCookieOutlivesEveryIdItCarries(): void {
-		$longer = time() + 3600;
+		$longer = time() + 7200;
 		$other = $this->sid('other');
 
 		$cookie = $this->openContextCookie(
@@ -185,16 +190,18 @@ class PadSessionServiceTest extends TestCase {
 			$other,
 		);
 
+		$this->assertSame($this->sid('new') . ',' . $other, $cookie['value']);
 		$this->assertSame($longer, $cookie['expires']);
 	}
 
 	public function testKeepsTheCookieBoundedAndDropsWhatExpiresSoonest(): void {
 		$sessions = [];
 		$ids = [];
-		foreach (range(1, 30) as $i) {
+		// A full cookie: the most this can ever have emitted.
+		foreach (range(1, 25) as $i) {
 			$id = $this->sid('g' . $i);
 			$ids[] = $id;
-			$sessions[$id] = ['groupID' => 'g.GROUP' . str_pad((string)$i, 11, '0'), 'validUntil' => time() + 600 + $i];
+			$sessions[$id] = ['groupID' => 'g.GROUP' . str_pad((string)$i, 11, '0', STR_PAD_LEFT), 'validUntil' => time() + 600 + $i];
 		}
 
 		$value = $this->openContextCookie($sessions, implode(',', $ids))['value'];
@@ -202,9 +209,24 @@ class PadSessionServiceTest extends TestCase {
 
 		$this->assertCount(25, $kept);
 		$this->assertSame($this->sid('new'), $kept[0]);
-		$this->assertSame($this->sid('g30'), $kept[1]);
+		// Longest-lived first after the pad being opened, soonest dropped.
+		$this->assertSame($this->sid('g25'), $kept[1]);
 		$this->assertNotContains($this->sid('g1'), $kept);
-		$this->assertLessThan(2000, strlen($value));
+		// 25 ids of 18 bytes with percent-encoded separators.
+		$this->assertLessThan(600, strlen($value));
+	}
+
+	/**
+	 * Any host under the shared parent domain can write this cookie, so the
+	 * parse must not grow with what it finds there. Nothing beyond what
+	 * could ever be emitted again is even looked at.
+	 */
+	public function testIgnoresMoreCookieIdsThanItCouldEverEmit(): void {
+		$ids = array_map(fn (int $i): string => $this->sid('junk' . $i), range(1, 100));
+
+		$value = $this->openContextCookie([], implode(',', $ids))['value'];
+
+		$this->assertSame($this->sid('new'), $value);
 	}
 
 	public function testIgnoresCookieValuesThatAreNotSessionIds(): void {
@@ -229,11 +251,6 @@ class PadSessionServiceTest extends TestCase {
 		$this->assertSame($this->sid('new') . ',' . $one, $value);
 	}
 
-	/**
-	 * When Etherpad cannot answer, the open still happens — on the browser's
-	 * cookie alone, group-blind and capped tighter, and logged, because the
-	 * symptom this method prevents comes back on that path.
-	 */
 	/**
 	 * Without the listing nothing can be attributed, so nothing is carried:
 	 * the open falls back to exactly what it did before this branch, one


### PR DESCRIPTION
Every protected pad lives in its own Etherpad group, and a session grants access to exactly one group. The `sessionID` cookie is the only place that state lives, and the open response wrote just its own id — so a second protected pad in a second tab silently took the first tab's access away. Measured against Etherpad 2.7.3: with only B's session in the cookie, pad A's export answers **403**; with `s.A,s.B` it answers **200**.

Etherpad has always read the value as a comma-separated list and picked the entry matching the group being opened, so the others only have to survive the write.

### What decides what survives

The browser's cookie is the candidate list. Nothing is added that was not already there, so an open cannot hand out access — it can only decline to take away what the browser was carrying, which dies at its own `validUntil`.

`listSessionsOfAuthor` then says which of those ids belong to this Etherpad author, which group each is for, and how long it lasts. That is what keeps **one entry per group rather than one per open**: without it, opening the same pad ten times filled the cookie with ten ids for one group and pushed the other pad out.

Ids the listing does not know are dropped. That throws away two different things, and only one of them is a loss:

- a protected **public share** is its own Etherpad author, so its session looks foreign to a logged-in user. Losing it means a share and an authenticated pad cannot be open at the same time — which was already the case before any of this.
- the session of **whoever used this browser before** looks exactly the same. Losing that one is the point: keeping it would let the next person to log in carry their pad until it expired.

Nothing here can tell the two apart, so the first is the price of the second.

The pad being opened always keeps its slot; beyond that the longest-lived win, capped at 25 — 522 bytes against the 4 KB a cookie may hold. The cookie expires with the longest-lived id it carries, or the browser would drop another pad's session that was still good for an hour.

### What it costs, deliberately

- **The listing is skipped where it cannot help**: no ids in the cookie, or a public-share open. There the author comes from the share token, so every anonymous visitor of one link shares it, and Etherpad deletes no sessions — a much-visited link would have every open downloading hundreds of entries.
- **One cookie now carries several sessions.** That is the point, but it also means a single exposure yields every open pad rather than one. The cookie cannot be `HttpOnly` before Etherpad 3.0.0 (verified: 2.7.3 reads it in `pad.ts` with `Cookies.get`, 3.0.0 reads it server-side from the socket.io handshake), and its domain cannot be narrowed — it has to reach Etherpad.
- **A revoked share stays usable until its session expires.** The overwrite that used to cut that off only ever helped if the user happened to open another protected pad; the window was the session TTL either way. Closing it needs `deleteSession`, which nothing in the app calls yet.
- **Two concurrent first opens still race.** Each reads before the other's session exists, so the later response's cookie omits the earlier's id. It is a lost `Set-Cookie` update between two HTTP responses, not an Etherpad problem, and there is no compare-and-set for it.

### Verification

The unit tests pin the rules against a stubbed listing. The e2e spec covers what they cannot reach: two protected pads, ten opens of the second through a real browser cookie jar, then the cookie holds two ids and **Etherpad itself** still serves pad A. Without that, a mismatch in Etherpad's real response would empty the listing on every open, restore the original bug in full, and leave the whole unit suite green.

Every behavioural change hangs on a test that was watched failing without it. Three of those tests were weaker than their names claimed until that check was run — one compared an expiry against itself, one built colliding group ids because `str_pad` fills on the right, and the e2e spec was written last precisely because it is the only one the stubs could not stand in for.

PHPUnit 649, Psalm `--no-cache` clean, Vitest 221 unchanged, Playwright 27 passed / 1 skipped against a Nextcloud 33 container.

### Reviewed along the way

Four rounds, each of which found something real. Two designs were tried and dropped: building the cookie from all of the author's sessions (it re-issued access to revoked pads and wiped other authors' ids), and reusing sessions (it handed out whatever remained of an old one instead of a full TTL, and inverted the eviction order). The API key no longer travels in a URL, the id shape is bounded and validated, the degraded path logs, and `docs/etherpad-integration.md` describes the flow that exists — including a `setAuthorName` call the code has never made.

### Known, not addressed here

A neighbouring host under the shared cookie domain can force one extra `listSessionsOfAuthor` call per open by writing a well-formed but meaningless id. Telling a plausible id from a forged one is exactly what nothing here can do — that is why the ownership rule exists — and the real answer is a server-side record of what was issued to whom, which is the same machinery that would close the revocation window and let sessions be deleted. Its expensive case is gone: public shares no longer fetch the listing at all, and for an authenticated user the response is bounded by their own history.
