### PR TITLE
Keep the session cookie from scripts where Etherpad allows it

### DIFF
--- a/docs/etherpad-integration.md
+++ b/docs/etherpad-integration.md
@@ -208,6 +208,12 @@ every protected pad. From 3.0.0 Etherpad takes the session id out of the
 socket.io handshake instead, and the cookie can be withheld from any script
 on the page. Measured on 2.7.3, 3.0.0 and 3.3.3.
 
+The boundary is the major version — Etherpad 3 and up — and it lives in
+`EtherpadReleasePolicy::HTTP_ONLY_SINCE_MAJOR`. The two test layers restate
+it rather than asking the app: `tests/e2e/specs/protected-session-cookie-httponly.spec.ts`
+and `tests/integration/e2e-protected-cookie-contract.sh`. Moving it means
+moving all three and this table.
+
 The app finds this out from `GET /health` (`releaseId`), which needs no api
 key. `/api` cannot answer it: it reports `1.3.1` on both 2.7.3 and 3.3.3.
 The answer is cached for an hour, retried at most once a minute after a
@@ -222,7 +228,7 @@ App config keys, none of them meant to be edited by hand except the first:
 
 | key | meaning |
 | --- | --- |
-| `etherpad_http_only_session_cookie` | `auto` (default), `yes` or `no`. The escape hatch when detection is wrong. `yes` against an Etherpad below 3.0 stops every protected pad from opening. |
+| `etherpad_http_only_session_cookie` | Exactly `auto` (default), `yes` or `no` — anything else is ignored with a log warning and the connection test says so. The escape hatch when detection is wrong. `yes` against an Etherpad below 3.0 stops every protected pad from opening. |
 | `etherpad_release_version` | last detected release |
 | `etherpad_release_checked_at` | when it was last confirmed |
 | `etherpad_release_host` | the API host it was read from |

--- a/docs/etherpad-integration.md
+++ b/docs/etherpad-integration.md
@@ -191,7 +191,7 @@ Cookie details:
 - Name: `sessionID`
 - `secure: true`
 - `samesite: None`
-- `http_only: false` (runtime compatibility with current Etherpad/socket flow on this deployment)
+- `http_only`: depends on the Etherpad release, see below
 - Domain handling:
   - if `etherpad_cookie_domain` is set, this value is used as-is
   - if empty, domain is derived from `etherpad_host`
@@ -200,12 +200,46 @@ Cookie details:
   - derivation is skipped for IP hosts and invalid host values
   - recommendation: use explicit `etherpad_cookie_domain` in multi-subdomain/proxy setups
 
+### `HttpOnly` and the Etherpad release
+
+Up to Etherpad 2.7.3 the pad app reads `sessionID` in the browser, so the
+cookie has to stay script-readable — `HttpOnly` there locks the user out of
+every protected pad. From 3.0.0 Etherpad takes the session id out of the
+socket.io handshake instead, and the cookie can be withheld from any script
+on the page. Measured on 2.7.3, 3.0.0 and 3.3.3.
+
+The app finds this out from `GET /health` (`releaseId`), which needs no api
+key. `/api` cannot answer it: it reports `1.3.1` on both 2.7.3 and 3.3.3.
+The answer is cached for an hour, retried at most once a minute after a
+failure, dropped after six hours without a successful check, and kept
+against the API host it was read from. Not knowing means a readable cookie.
+
+The connection test in the admin settings shows which release was found and
+what the cookie will be, and warns when the two have drifted apart — which
+is what a downgrade looks like from the outside.
+
+App config keys, none of them meant to be edited by hand except the first:
+
+| key | meaning |
+| --- | --- |
+| `etherpad_http_only_session_cookie` | `auto` (default), `yes` or `no`. The escape hatch when detection is wrong. `yes` against an Etherpad below 3.0 stops every protected pad from opening. |
+| `etherpad_release_version` | last detected release |
+| `etherpad_release_checked_at` | when it was last confirmed |
+| `etherpad_release_host` | the API host it was read from |
+| `etherpad_release_failed_at` | when the last check failed |
+
+```bash
+occ config:app:set etherpad_nextcloud etherpad_http_only_session_cookie --value=no
+```
+
 Regression safety check:
 
 - `tests/integration/e2e-protected-cookie-contract.sh` validates the protected open response cookie contract:
   - one `sessionID` `Set-Cookie` header from app flow
   - includes `Secure` and `SameSite=None`
-  - excludes `HttpOnly` (current runtime compatibility requirement)
+  - `HttpOnly` present exactly when the pad server's `/health` reports a
+    release of 3 or newer; skipped with a note when `/health` cannot be
+    reached from where the script runs
 
 ## Read-only Behavior
 

--- a/docs/etherpad-integration.md
+++ b/docs/etherpad-integration.md
@@ -217,8 +217,8 @@ moving all three and this table.
 The app finds this out from `GET /health` (`releaseId`), which needs no api
 key. `/api` cannot answer it: it reports `1.3.1` on both 2.7.3 and 3.3.3.
 The answer is cached for an hour, retried at most once a minute after a
-failure, dropped after six hours without a successful check, and kept
-against the API host it was read from. Not knowing means a readable cookie.
+failure, dropped after six hours without a successful check, and stored
+together with the API host it was read from. Not knowing means a readable cookie.
 
 The connection test in the admin settings shows which release was found and
 what the cookie will be, and warns when the two have drifted apart — which
@@ -229,10 +229,7 @@ App config keys, none of them meant to be edited by hand except the first:
 | key | meaning |
 | --- | --- |
 | `etherpad_http_only_session_cookie` | Exactly `auto` (default), `yes` or `no` — anything else is ignored with a log warning and the connection test says so. The escape hatch when detection is wrong. `yes` against an Etherpad below 3.0 stops every protected pad from opening. |
-| `etherpad_release_version` | last detected release |
-| `etherpad_release_checked_at` | when it was last confirmed |
-| `etherpad_release_host` | the API host it was read from |
-| `etherpad_release_failed_at` | when the last check failed |
+| `etherpad_release_state` | JSON: the detected release, the API host it was read from, when it was last confirmed, and when a check last failed. One value on purpose – a check that finishes after the app has been repointed can only write a record that says which server it is about, and the next reader discards it. |
 
 ```bash
 occ config:app:set etherpad_nextcloud etherpad_http_only_session_cookie --value=no

--- a/docs/etherpad-integration.md
+++ b/docs/etherpad-integration.md
@@ -228,7 +228,9 @@ App config keys, none of them meant to be edited by hand except the first:
 
 | key | meaning |
 | --- | --- |
-| `etherpad_http_only_session_cookie` | Exactly `auto` (default), `yes` or `no` — anything else is ignored with a log warning and the connection test says so. The escape hatch when detection is wrong. `yes` against an Etherpad below 3.0 stops every protected pad from opening. |
+| `etherpad_http_only_session_cookie` | Exactly `auto` (default), `yes` or `no` – anything else is ignored, with one warning per hour in the log and a line in the connection test. The escape hatch when detection is wrong. `yes` against an Etherpad below 3.0 stops every protected pad from opening. |
+| `etherpad_http_only_override_warned_at` | when the warning above was last written, so it is one line an hour rather than one per pad open |
+| `etherpad_release_failed` | JSON: when a check last failed, and for which host. Its own value, because a failure has nothing to say about the release – folding the two together made every failure overwrite the record. |
 | `etherpad_release_state` | JSON: the detected release, the API host it was read from, when it was last confirmed, and when a check last failed. One value on purpose – a check that finishes after the app has been repointed can only write a record that says which server it is about, and the next reader discards it. |
 
 ```bash

--- a/lib/Controller/AdminController.php
+++ b/lib/Controller/AdminController.php
@@ -116,6 +116,7 @@ class AdminController extends Controller {
 					'pending_delete_count' => $result->pendingDeleteCount,
 					// Machine-readable form of the protected-pads line above.
 					'protected_pads' => $this->describeCookieDomain($result->cookieDomain),
+					'session_cookie_release' => $result->sessionCookieRelease,
 					'checks' => $this->describeChecks($checks),
 				]);
 			},

--- a/lib/Service/EtherpadClient.php
+++ b/lib/Service/EtherpadClient.php
@@ -26,7 +26,8 @@ class EtherpadClient {
 	 */
 	public const DEFAULT_API_VERSION = '1.2.15';
 
-	private const REQUEST_TIMEOUT_SECONDS = 15;
+	/** Public so the admin connection test can ask for the same patience. */
+	public const REQUEST_TIMEOUT_SECONDS = 15;
 
 	/**
 	 * `/health` gets far less patience than an API call.
@@ -237,17 +238,26 @@ class EtherpadClient {
 	 * places as possible.
 	 *
 	 * A host may be given so the admin health check can ask about the
-	 * address being submitted rather than the one already stored.
+	 * address being submitted rather than the one already stored, and a
+	 * timeout so that check can be as patient as the calls beside it while
+	 * the open path stays impatient.
+	 *
+	 * What comes back is a version string and nothing else. It is written
+	 * into app config, read on every protected open and rendered to an
+	 * admin, so a pad server answering with a megabyte of prose after a
+	 * plausible prefix must not get any of that.
 	 */
-	public function detectReleaseVersion(?string $host = null): string {
+	public function detectReleaseVersion(?string $host = null, int $timeoutSeconds = self::HEALTH_TIMEOUT_SECONDS): string {
 		$apiHost = $host !== null && trim($host) !== '' ? rtrim(trim($host), '/') : $this->getApiHost();
-		$raw = $this->sendPublicGetRequest($apiHost . '/health', self::HEALTH_TIMEOUT_SECONDS);
+		$raw = $this->sendPublicGetRequest($apiHost . '/health', $timeoutSeconds);
 		$decoded = json_decode($raw, true);
 		$release = is_array($decoded) && isset($decoded['releaseId']) && is_string($decoded['releaseId'])
 			? trim($decoded['releaseId'])
 			: '';
 
-		if (preg_match('/^\d+\.\d+\.\d+/', $release) !== 1) {
+		// Anchored at both ends: `<major>.<minor>.<patch>` and at most a
+		// short pre-release tail after it.
+		if (preg_match('/^\d{1,6}\.\d{1,6}\.\d{1,6}([-+][0-9A-Za-z.-]{1,24})?$/', $release) !== 1) {
 			throw new EtherpadClientException('Could not detect the Etherpad release version.');
 		}
 

--- a/lib/Service/EtherpadClient.php
+++ b/lib/Service/EtherpadClient.php
@@ -28,6 +28,18 @@ class EtherpadClient {
 
 	private const REQUEST_TIMEOUT_SECONDS = 15;
 
+	/**
+	 * `/health` gets far less patience than an API call.
+	 *
+	 * Nothing depends on the answer: the caller falls back to the last known
+	 * release, and without one to the cookie it was writing before. It is
+	 * asked on the open path, though, so a pad server that accepts the
+	 * connection and then says nothing must not be able to hold an open
+	 * hostage for the full request timeout on top of the calls that do
+	 * matter.
+	 */
+	private const HEALTH_TIMEOUT_SECONDS = 3;
+
 	public function __construct(
 		private IConfig $config,
 		private AdminSettingsRepository $settingsRepository,
@@ -225,7 +237,7 @@ class EtherpadClient {
 	 * places as possible.
 	 */
 	public function detectReleaseVersion(): string {
-		$raw = $this->sendPublicGetRequest($this->getApiHost() . '/health');
+		$raw = $this->sendPublicGetRequest($this->getApiHost() . '/health', self::HEALTH_TIMEOUT_SECONDS);
 		$decoded = json_decode($raw, true);
 		$release = is_array($decoded) && isset($decoded['releaseId']) && is_string($decoded['releaseId'])
 			? trim($decoded['releaseId'])
@@ -378,7 +390,13 @@ class EtherpadClient {
 		return $scheme . '://' . $host . ':' . $port;
 	}
 
-	private function getApiHost(): string {
+	/**
+	 * The Etherpad the API calls actually go to: the admin's `etherpad_api_host`
+	 * when set, otherwise the public one. Exposed because what this server
+	 * says about itself is only true of this server – anything cached about a
+	 * release has to be kept against the endpoint it was read from.
+	 */
+	public function getApiHost(): string {
 		$apiHost = rtrim((string)$this->config->getAppValue('etherpad_nextcloud', 'etherpad_api_host', ''), '/');
 		if ($apiHost !== '') {
 			return $apiHost;
@@ -397,8 +415,8 @@ class EtherpadClient {
 		return $key;
 	}
 
-	private function sendPublicGetRequest(string $url): string {
-		$response = $this->doRequest('GET', $url, $this->baseRequestOptions());
+	private function sendPublicGetRequest(string $url, ?int $timeoutSeconds = null): string {
+		$response = $this->doRequest('GET', $url, $this->baseRequestOptions($timeoutSeconds));
 		$statusCode = $response->getStatusCode();
 		if ($statusCode >= 400) {
 			throw new EtherpadClientException('HTTP error (' . $statusCode . ')');
@@ -423,9 +441,9 @@ class EtherpadClient {
 	 *
 	 * @return array<string,mixed>
 	 */
-	private function baseRequestOptions(): array {
+	private function baseRequestOptions(?int $timeoutSeconds = null): array {
 		return [
-			'timeout' => self::REQUEST_TIMEOUT_SECONDS,
+			'timeout' => $timeoutSeconds ?? self::REQUEST_TIMEOUT_SECONDS,
 			'allow_redirects' => ['max' => 0],
 			'headers' => ['Accept' => 'application/json'],
 			'nextcloud' => ['allow_local_address' => true],

--- a/lib/Service/EtherpadClient.php
+++ b/lib/Service/EtherpadClient.php
@@ -235,9 +235,13 @@ class EtherpadClient {
 	 * `/health` needs no api key, which is why it is asked rather than an
 	 * API method: this runs on the open path, and the key belongs in as few
 	 * places as possible.
+	 *
+	 * A host may be given so the admin health check can ask about the
+	 * address being submitted rather than the one already stored.
 	 */
-	public function detectReleaseVersion(): string {
-		$raw = $this->sendPublicGetRequest($this->getApiHost() . '/health', self::HEALTH_TIMEOUT_SECONDS);
+	public function detectReleaseVersion(?string $host = null): string {
+		$apiHost = $host !== null && trim($host) !== '' ? rtrim(trim($host), '/') : $this->getApiHost();
+		$raw = $this->sendPublicGetRequest($apiHost . '/health', self::HEALTH_TIMEOUT_SECONDS);
 		$decoded = json_decode($raw, true);
 		$release = is_array($decoded) && isset($decoded['releaseId']) && is_string($decoded['releaseId'])
 			? trim($decoded['releaseId'])
@@ -415,7 +419,7 @@ class EtherpadClient {
 		return $key;
 	}
 
-	private function sendPublicGetRequest(string $url, ?int $timeoutSeconds = null): string {
+	private function sendPublicGetRequest(string $url, int $timeoutSeconds = self::REQUEST_TIMEOUT_SECONDS): string {
 		$response = $this->doRequest('GET', $url, $this->baseRequestOptions($timeoutSeconds));
 		$statusCode = $response->getStatusCode();
 		if ($statusCode >= 400) {
@@ -441,9 +445,9 @@ class EtherpadClient {
 	 *
 	 * @return array<string,mixed>
 	 */
-	private function baseRequestOptions(?int $timeoutSeconds = null): array {
+	private function baseRequestOptions(int $timeoutSeconds = self::REQUEST_TIMEOUT_SECONDS): array {
 		return [
-			'timeout' => $timeoutSeconds ?? self::REQUEST_TIMEOUT_SECONDS,
+			'timeout' => $timeoutSeconds,
 			'allow_redirects' => ['max' => 0],
 			'headers' => ['Accept' => 'application/json'],
 			'nextcloud' => ['allow_local_address' => true],

--- a/lib/Service/EtherpadClient.php
+++ b/lib/Service/EtherpadClient.php
@@ -237,18 +237,19 @@ class EtherpadClient {
 	 * API method: this runs on the open path, and the key belongs in as few
 	 * places as possible.
 	 *
-	 * A host may be given so the admin health check can ask about the
-	 * address being submitted rather than the one already stored, and a
-	 * timeout so that check can be as patient as the calls beside it while
-	 * the open path stays impatient.
+	 * The host is given rather than looked up here: the caller files the
+	 * answer under a host, and that has to be the host that was asked. The
+	 * admin health check asks about the address being submitted rather than
+	 * the one already stored, and passes a timeout so it can be as patient
+	 * as the calls beside it while the open path stays impatient.
 	 *
 	 * What comes back is a version string and nothing else. It is written
 	 * into app config, read on every protected open and rendered to an
 	 * admin, so a pad server answering with a megabyte of prose after a
 	 * plausible prefix must not get any of that.
 	 */
-	public function detectReleaseVersion(?string $host = null, int $timeoutSeconds = self::HEALTH_TIMEOUT_SECONDS): string {
-		$apiHost = $host !== null && trim($host) !== '' ? rtrim(trim($host), '/') : $this->getApiHost();
+	public function detectReleaseVersion(string $host, int $timeoutSeconds = self::HEALTH_TIMEOUT_SECONDS): string {
+		$apiHost = trim($host) !== '' ? rtrim(trim($host), '/') : $this->getApiHost();
 		$raw = $this->sendPublicGetRequest($apiHost . '/health', $timeoutSeconds);
 		$decoded = json_decode($raw, true);
 		$release = is_array($decoded) && isset($decoded['releaseId']) && is_string($decoded['releaseId'])

--- a/lib/Service/EtherpadClient.php
+++ b/lib/Service/EtherpadClient.php
@@ -212,6 +212,32 @@ class EtherpadClient {
 		return ['pad_count' => $padCount];
 	}
 
+	/**
+	 * The Etherpad release this instance is running, as `/health` reports it.
+	 *
+	 * Not the API version: `/api` answers `1.3.1` on both Etherpad 2.7.3 and
+	 * 3.3.3, so it cannot tell the two apart. `releaseId` can, and the one
+	 * thing that turns on it — whether Etherpad still needs to read its
+	 * session cookie from JavaScript — changed between those two majors.
+	 *
+	 * `/health` needs no api key, which is why it is asked rather than an
+	 * API method: this runs on the open path, and the key belongs in as few
+	 * places as possible.
+	 */
+	public function detectReleaseVersion(): string {
+		$raw = $this->sendPublicGetRequest($this->getApiHost() . '/health');
+		$decoded = json_decode($raw, true);
+		$release = is_array($decoded) && isset($decoded['releaseId']) && is_string($decoded['releaseId'])
+			? trim($decoded['releaseId'])
+			: '';
+
+		if (preg_match('/^\d+\.\d+\.\d+/', $release) !== 1) {
+			throw new EtherpadClientException('Could not detect the Etherpad release version.');
+		}
+
+		return $release;
+	}
+
 	public function detectApiVersion(string $host): string {
 		$url = rtrim(trim($host), '/') . '/api';
 		$raw = $this->sendPublicGetRequest($url);

--- a/lib/Service/EtherpadHealthCheckService.php
+++ b/lib/Service/EtherpadHealthCheckService.php
@@ -138,6 +138,7 @@ class EtherpadHealthCheckService {
 			$latencyMs,
 			$target,
 			$this->pendingDeleteRetryService->countPendingDeletes(),
+			$this->releasePolicy->knownRelease(),
 			$cookieDomain,
 			$checks,
 		);
@@ -195,8 +196,10 @@ class EtherpadHealthCheckService {
 				$settings->etherpadApiHost,
 				EtherpadClient::REQUEST_TIMEOUT_SECONDS,
 			);
+			$probeError = null;
 		} catch (\Throwable $e) {
 			$release = '';
+			$probeError = $e;
 		}
 
 		$override = $this->releasePolicy->overrideMode();
@@ -209,14 +212,39 @@ class EtherpadHealthCheckService {
 			// which is what every Etherpad before 3.0 needs anyway. A pad
 			// server without /health, or a proxy that routes /api and not
 			// /health, works and merely misses a hardening.
+			//
+			// The reason is worth carrying, though. DNS, a TLS mismatch, a
+			// 404 because the proxy does not route /health, a 401 from proxy
+			// auth and a timeout are five different fixes, and the class
+			// already knows how to tell them apart.
 			return $this->sessionCookieItem(
 				HealthCheckItem::STATUS_SKIPPED,
 				$this->l10n->t('Session cookie: readable by scripts'),
-				$this->l10n->t('The Etherpad release could not be read from /health, so the cookie is left readable.'),
+				$this->l10n->t('The Etherpad release could not be read from /health, so the cookie is left readable.')
+					. ' ' . $this->describeProbeFailure($probeError),
 			);
 		}
 
-		$knownRelease = $this->releasePolicy->knownRelease();
+		// About the *stored* host: that is the one the open path resolves,
+		// and a form being typed says nothing about what pads are doing.
+		$configuredHost = $this->etherpadClient->getApiHost();
+		if (rtrim($configuredHost, '/') !== rtrim($settings->etherpadApiHost, '/')) {
+			// Somebody is testing an address before saving it. Comparing a
+			// probe of that address against what pads are doing now would
+			// read every planned migration as a live lockout.
+			return $this->sessionCookieItem(
+				HealthCheckItem::STATUS_OK,
+				$this->fill(
+					EtherpadReleasePolicy::allowsHttpOnly($release)
+						? $this->l10n->t('Session cookie: this address reports Etherpad {release} and would be sent an HttpOnly cookie')
+						: $this->l10n->t('Session cookie: this address reports Etherpad {release} and would be sent a script-readable cookie'),
+					['release' => $this->shorten($release)],
+				),
+				$this->l10n->t('Not the address currently in use — save the settings to switch pads over to it.'),
+			);
+		}
+
+		$knownRelease = $this->releasePolicy->knownRelease($configuredHost);
 		if ($knownRelease === '') {
 			return $this->sessionCookieItem(
 				HealthCheckItem::STATUS_OK,
@@ -252,6 +280,22 @@ class EtherpadHealthCheckService {
 				['release' => $this->shorten($knownRelease)],
 			),
 		);
+	}
+
+	/** The same vocabulary the rest of this class uses for a failed call. */
+	private function describeProbeFailure(?\Throwable $error): string {
+		if ($error === null) {
+			return '';
+		}
+
+		$detail = $error->getMessage();
+		$previous = $error->getPrevious();
+		if ($previous instanceof \Throwable && $previous->getMessage() !== '') {
+			$detail .= ' (' . $previous->getMessage() . ')';
+		}
+		$hint = $this->hintForReason($this->classifyFailure($detail));
+
+		return $this->shorten($detail) . ($hint !== '' ? ' ' . $hint : '');
 	}
 
 	/**

--- a/lib/Service/EtherpadHealthCheckService.php
+++ b/lib/Service/EtherpadHealthCheckService.php
@@ -145,28 +145,21 @@ class EtherpadHealthCheckService {
 	}
 
 	/**
-	 * What the Etherpad session cookie will look like, and why.
+	 * What the Etherpad session cookie will look like, and why — the one
+	 * place an admin can see it. When the detection is wrong the symptom is
+	 * that no protected pad opens and nothing else says why.
 	 *
-	 * The one place an admin can see it. The release decides whether the
-	 * cookie may be kept from JavaScript, it is discovered rather than
-	 * configured, and it lives in an app value with no field of its own —
-	 * so when the detection is wrong, the symptom is that no protected pad
-	 * opens and nothing anywhere says why.
+	 * Reads the answer the open path is using and probes the submitted host
+	 * separately: those two disagreeing *is* the lockout.
 	 *
-	 * It reads the answer the open path is using, and asks the host being
-	 * submitted separately. Those two can disagree — a cached release from
-	 * before a downgrade against a server that has since gone back to 2.x
-	 * — and that disagreement *is* the lockout, so it is what gets said.
+	 * Read, never resolved. Resolving would refresh an expired cache, which
+	 * probes the stored host and writes — so testing an unsaved form would
+	 * teach the open path something, and park real opens in the failure
+	 * backoff because somebody pressed a button.
 	 *
-	 * Read, not resolved: calling the policy's own predicate would refresh
-	 * an expired cache, which means probing the *stored* host and writing
-	 * three app values. Testing an unsaved form would teach the open path
-	 * something, and against a host that is gone it would also park real
-	 * pad opens in the failure backoff because somebody pressed a button.
-	 *
-	 * Everything lands on `etherpad_session_cookie`. Sharing a field with
-	 * the API lines means losing to them: the panel keeps the highest
-	 * severity per field, and a passing `api` outranks a skip.
+	 * Everything lands on `etherpad_session_cookie`: the panel keeps the
+	 * highest severity per field, so sharing one with the API lines means
+	 * losing to them.
 	 */
 	private function sessionCookieCheck(ValidatedAdminSettings $settings): HealthCheckItem {
 		if (!$settings->enableProtectedPads) {
@@ -189,9 +182,8 @@ class EtherpadHealthCheckService {
 		}
 
 		try {
-			// As patient as the calls beside it: a slow but healthy pad
-			// server is not a misconfiguration of this app, and this is not
-			// the open path.
+			// The full timeout, not the open path's three seconds: a slow
+			// but healthy pad server is not a misconfiguration.
 			$release = $this->etherpadClient->detectReleaseVersion(
 				$settings->etherpadApiHost,
 				EtherpadClient::REQUEST_TIMEOUT_SECONDS,
@@ -208,15 +200,10 @@ class EtherpadHealthCheckService {
 		}
 
 		if ($release === '') {
-			// Not a warning. Nothing is broken: the cookie stays readable,
-			// which is what every Etherpad before 3.0 needs anyway. A pad
-			// server without /health, or a proxy that routes /api and not
-			// /health, works and merely misses a hardening.
-			//
-			// The reason is worth carrying, though. DNS, a TLS mismatch, a
-			// 404 because the proxy does not route /health, a 401 from proxy
-			// auth and a timeout are five different fixes, and the class
-			// already knows how to tell them apart.
+			// Not a warning: the cookie stays readable, which is what every
+			// Etherpad before 3.0 needs anyway. The reason still matters —
+			// DNS, TLS, an unrouted /health and proxy auth are different
+			// fixes, and this class already tells them apart.
 			return $this->sessionCookieItem(
 				HealthCheckItem::STATUS_SKIPPED,
 				$this->l10n->t('Session cookie: readable by scripts'),
@@ -225,13 +212,11 @@ class EtherpadHealthCheckService {
 			);
 		}
 
-		// About the *stored* host: that is the one the open path resolves,
-		// and a form being typed says nothing about what pads are doing.
+		// The stored host is the one the open path resolves. Comparing a
+		// probe of an address being typed against what pads are doing would
+		// read every planned migration as a live lockout.
 		$configuredHost = $this->etherpadClient->getApiHost();
 		if (rtrim($configuredHost, '/') !== rtrim($settings->etherpadApiHost, '/')) {
-			// Somebody is testing an address before saving it. Comparing a
-			// probe of that address against what pads are doing now would
-			// read every planned migration as a live lockout.
 			return $this->sessionCookieItem(
 				HealthCheckItem::STATUS_OK,
 				$this->fill(
@@ -257,8 +242,6 @@ class EtherpadHealthCheckService {
 
 		$sending = EtherpadReleasePolicy::allowsHttpOnly($knownRelease);
 		if ($sending !== EtherpadReleasePolicy::allowsHttpOnly($release)) {
-			// The cache and the server disagree, which is precisely the
-			// lockout an admin comes here to explain.
 			return $this->sessionCookieItem(
 				HealthCheckItem::STATUS_WARNING,
 				$this->l10n->t('Etherpad session cookie'),
@@ -299,16 +282,11 @@ class EtherpadHealthCheckService {
 	}
 
 	/**
-	 * A hand-set flag, reported by what it costs rather than by the fact
-	 * that it is set.
-	 *
-	 * The two values are not symmetric. `yes` below Etherpad 3.0 stops every
-	 * protected pad from opening and has to shout. `no` gives up a hardening
-	 * and is what this app did before any of it — warning on that teaches an
-	 * admin to ignore the line that would have told them about the other.
-	 *
-	 * Either way it says what the release is, so somebody who reached for
-	 * the escape hatch during an outage can see whether they may put it back.
+	 * A hand-set flag, reported by what it costs. The two values are not
+	 * symmetric: `yes` below 3.0 stops every protected pad and has to
+	 * shout, `no` only gives up a hardening — warning on that teaches an
+	 * admin to ignore the line that matters. Both name the release, so
+	 * somebody who reached for the escape hatch can see if they may stop.
 	 */
 	private function overriddenSessionCookieItem(string $override, string $release): HealthCheckItem {
 		$forcedOn = $override === EtherpadReleasePolicy::OVERRIDE_YES;

--- a/lib/Service/EtherpadHealthCheckService.php
+++ b/lib/Service/EtherpadHealthCheckService.php
@@ -127,7 +127,7 @@ class EtherpadHealthCheckService {
 				'etherpad_api_key',
 			),
 			$this->baseUrlCheck->check($settings->etherpadHost),
-			$this->sessionCookieCheck($settings, $apiField),
+			$this->sessionCookieCheck($settings),
 		];
 
 		return new HealthCheckResult(
@@ -152,40 +152,38 @@ class EtherpadHealthCheckService {
 	 * so when the detection is wrong, the symptom is that no protected pad
 	 * opens and nothing anywhere says why.
 	 *
-	 * It reports what the open path is *doing*, which is not the same as
-	 * what this host would say if asked now. The open path answers from a
-	 * cached release, so right after a downgrade the cookie can be HttpOnly
-	 * against a pad server that has already gone back to 2.x — the exact
-	 * moment this line exists for. Asking as well, against the host being
-	 * submitted, is what turns "here is the cookie" into "and here is why
-	 * that is now wrong".
+	 * It reads the answer the open path is using, and asks the host being
+	 * submitted separately. Those two can disagree — a cached release from
+	 * before a downgrade against a server that has since gone back to 2.x
+	 * — and that disagreement *is* the lockout, so it is what gets said.
 	 *
-	 * Nothing is written to the cache from here: a form that is not saved
-	 * should not teach the open path anything, and the cache is keyed by
-	 * host so a saved change re-checks by itself.
+	 * Read, not resolved: calling the policy's own predicate would refresh
+	 * an expired cache, which means probing the *stored* host and writing
+	 * three app values. Testing an unsaved form would teach the open path
+	 * something, and against a host that is gone it would also park real
+	 * pad opens in the failure backoff because somebody pressed a button.
+	 *
+	 * Everything lands on `etherpad_session_cookie`. Sharing a field with
+	 * the API lines means losing to them: the panel keeps the highest
+	 * severity per field, and a passing `api` outranks a skip.
 	 */
-	private function sessionCookieCheck(ValidatedAdminSettings $settings, string $apiField): HealthCheckItem {
+	private function sessionCookieCheck(ValidatedAdminSettings $settings): HealthCheckItem {
 		if (!$settings->enableProtectedPads) {
-			return new HealthCheckItem(
-				'session_cookie',
+			return $this->sessionCookieItem(
 				HealthCheckItem::STATUS_SKIPPED,
 				$this->l10n->t('Session cookie: not checked, protected pads are off'),
-				'',
-				'etherpad_session_cookie',
 			);
 		}
 
-		$httpOnly = $this->releasePolicy->supportsHttpOnlySessionCookie();
-		$override = $this->releasePolicy->overrideMode();
-		if ($override !== EtherpadReleasePolicy::OVERRIDE_AUTO) {
-			return new HealthCheckItem(
-				'session_cookie',
+		$unrecognised = $this->releasePolicy->unrecognisedOverride();
+		if ($unrecognised !== '') {
+			return $this->sessionCookieItem(
 				HealthCheckItem::STATUS_WARNING,
 				$this->l10n->t('Etherpad session cookie'),
-				$httpOnly
-					? $this->l10n->t('HttpOnly is switched on by hand. Etherpad below 3.0 cannot read the cookie, and protected pads will not open.')
-					: $this->l10n->t('HttpOnly is switched off by hand. The pad server is not asked.'),
-				'etherpad_session_cookie',
+				$this->fill(
+					$this->l10n->t('"{value}" is not one of auto, yes or no, so it is being ignored and the release decides. Set one of those three, or remove the setting.'),
+					['value' => $unrecognised],
+				),
 			);
 		}
 
@@ -198,49 +196,104 @@ class EtherpadHealthCheckService {
 				EtherpadClient::REQUEST_TIMEOUT_SECONDS,
 			);
 		} catch (\Throwable $e) {
+			$release = '';
+		}
+
+		$override = $this->releasePolicy->overrideMode();
+		if ($override !== EtherpadReleasePolicy::OVERRIDE_AUTO) {
+			return $this->overriddenSessionCookieItem($override, $release);
+		}
+
+		if ($release === '') {
 			// Not a warning. Nothing is broken: the cookie stays readable,
-			// which is what every Etherpad before 3.0 needs anyway. An
-			// Etherpad without /health, or a proxy that routes /api and not
-			// /health, is a deployment that works and misses a hardening.
-			return new HealthCheckItem(
-				'session_cookie',
+			// which is what every Etherpad before 3.0 needs anyway. A pad
+			// server without /health, or a proxy that routes /api and not
+			// /health, works and merely misses a hardening.
+			return $this->sessionCookieItem(
 				HealthCheckItem::STATUS_SKIPPED,
 				$this->l10n->t('Session cookie: readable by scripts'),
 				$this->l10n->t('The Etherpad release could not be read from /health, so the cookie is left readable.'),
-				$apiField,
 			);
 		}
 
-		$serverAllowsHttpOnly = EtherpadReleasePolicy::allowsHttpOnly($release);
-		if ($serverAllowsHttpOnly !== $httpOnly) {
+		$knownRelease = $this->releasePolicy->knownRelease();
+		if ($knownRelease === '') {
+			return $this->sessionCookieItem(
+				HealthCheckItem::STATUS_OK,
+				$this->fill(
+					$this->l10n->t('Session cookie: Etherpad {release}, checked on the first protected pad open'),
+					['release' => $this->shorten($release)],
+				),
+			);
+		}
+
+		$sending = EtherpadReleasePolicy::allowsHttpOnly($knownRelease);
+		if ($sending !== EtherpadReleasePolicy::allowsHttpOnly($release)) {
 			// The cache and the server disagree, which is precisely the
 			// lockout an admin comes here to explain.
-			return new HealthCheckItem(
-				'session_cookie',
+			return $this->sessionCookieItem(
 				HealthCheckItem::STATUS_WARNING,
 				$this->l10n->t('Etherpad session cookie'),
 				$this->fill(
-					$httpOnly
-						? $this->l10n->t('Pads are being sent an HttpOnly cookie from an earlier check, but this server reports Etherpad {release}, which reads the cookie in the browser. Protected pads will not open until the check is repeated.')
-						: $this->l10n->t('This server reports Etherpad {release}, which reads the session server-side, but pads are still being sent a script-readable cookie from an earlier check.'),
-					['release' => $this->shorten($release)],
+					$sending
+						? $this->l10n->t('Pads are being sent an HttpOnly cookie, from Etherpad {known} seen earlier, but this server reports {release}, which reads the cookie in the browser. Protected pads will not open until that is checked again.')
+						: $this->l10n->t('This server reports Etherpad {release}, which reads the session server-side, but pads are still being sent a script-readable cookie from Etherpad {known} seen earlier.'),
+					['release' => $this->shorten($release), 'known' => $this->shorten($knownRelease)],
 				),
-				$apiField,
 			);
 		}
 
-		return new HealthCheckItem(
-			'session_cookie',
+		return $this->sessionCookieItem(
 			HealthCheckItem::STATUS_OK,
 			$this->fill(
-				$httpOnly
+				$sending
 					? $this->l10n->t('Session cookie kept from scripts (Etherpad {release})')
 					: $this->l10n->t('Session cookie readable by scripts (Etherpad {release})'),
-				['release' => $this->shorten($release)],
+				['release' => $this->shorten($knownRelease)],
 			),
-			'',
-			'etherpad_session_cookie',
 		);
+	}
+
+	/**
+	 * A hand-set flag, reported by what it costs rather than by the fact
+	 * that it is set.
+	 *
+	 * The two values are not symmetric. `yes` below Etherpad 3.0 stops every
+	 * protected pad from opening and has to shout. `no` gives up a hardening
+	 * and is what this app did before any of it — warning on that teaches an
+	 * admin to ignore the line that would have told them about the other.
+	 *
+	 * Either way it says what the release is, so somebody who reached for
+	 * the escape hatch during an outage can see whether they may put it back.
+	 */
+	private function overriddenSessionCookieItem(string $override, string $release): HealthCheckItem {
+		$forcedOn = $override === EtherpadReleasePolicy::OVERRIDE_YES;
+		$serverReads = $release === ''
+			? $this->l10n->t('The pad server did not report its release.')
+			: $this->fill(
+				EtherpadReleasePolicy::allowsHttpOnly($release)
+					? $this->l10n->t('This server reports Etherpad {release}, which reads the session server-side — automatic detection would set the same thing.')
+					: $this->l10n->t('This server reports Etherpad {release}, which reads the session in the browser.'),
+				['release' => $this->shorten($release)],
+			);
+
+		if (!$forcedOn) {
+			return $this->sessionCookieItem(
+				HealthCheckItem::STATUS_OK,
+				$this->l10n->t('Session cookie readable by scripts (set by hand)'),
+				$serverReads,
+			);
+		}
+
+		return $this->sessionCookieItem(
+			HealthCheckItem::STATUS_WARNING,
+			$this->l10n->t('Etherpad session cookie'),
+			$this->l10n->t('HttpOnly is switched on by hand. An Etherpad below 3.0 cannot read the cookie, and no protected pad will open.') . ' ' . $serverReads,
+		);
+	}
+
+	private function sessionCookieItem(string $status, string $label, string $detail = ''): HealthCheckItem {
+		return new HealthCheckItem('session_cookie', $status, $label, $detail, 'etherpad_session_cookie');
 	}
 
 	/**

--- a/lib/Service/EtherpadHealthCheckService.php
+++ b/lib/Service/EtherpadHealthCheckService.php
@@ -9,8 +9,10 @@ declare(strict_types=1);
 
 namespace OCA\EtherpadNextcloud\Service;
 
+use OCA\EtherpadNextcloud\AppInfo\Application;
 use OCA\EtherpadNextcloud\Exception\AdminHealthCheckException;
 use OCA\EtherpadNextcloud\Exception\EtherpadClientException;
+use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IURLGenerator;
 
@@ -36,6 +38,7 @@ class EtherpadHealthCheckService {
 		private CookieDomainPolicy $cookieDomainPolicy,
 		private BaseUrlReachabilityCheck $baseUrlCheck,
 		private IURLGenerator $urlGenerator,
+		private IConfig $config,
 	) {
 	}
 
@@ -126,6 +129,7 @@ class EtherpadHealthCheckService {
 				'etherpad_api_key',
 			),
 			$this->baseUrlCheck->check($settings->etherpadHost),
+			$this->sessionCookieCheck($settings),
 		];
 
 		return new HealthCheckResult(
@@ -138,6 +142,74 @@ class EtherpadHealthCheckService {
 			$this->pendingDeleteRetryService->countPendingDeletes(),
 			$cookieDomain,
 			$checks,
+		);
+	}
+
+	/**
+	 * What the Etherpad session cookie will look like, and why.
+	 *
+	 * The one place an admin can see it. The release decides whether the
+	 * cookie may be kept from JavaScript, it is discovered rather than
+	 * configured, and it lives in an app value with no field of its own —
+	 * so when the detection is wrong, the symptom is that no protected pad
+	 * opens and nothing anywhere says why.
+	 *
+	 * Asked against the host being submitted, not the one already stored,
+	 * like every other line here. Nothing is written to the cache from this:
+	 * a form that is not saved should not teach the open path anything, and
+	 * the cache is keyed by host so a saved change re-checks by itself.
+	 */
+	private function sessionCookieCheck(ValidatedAdminSettings $settings): HealthCheckItem {
+		if (!$settings->enableProtectedPads) {
+			return new HealthCheckItem(
+				'session_cookie',
+				HealthCheckItem::STATUS_SKIPPED,
+				$this->l10n->t('Etherpad session cookie'),
+				$this->l10n->t('Not checked: protected pads are switched off.'),
+			);
+		}
+
+		$override = strtolower(trim((string)$this->config->getAppValue(
+			Application::APP_ID,
+			EtherpadReleasePolicy::OVERRIDE_KEY,
+			'auto',
+		)));
+		if ($override === 'yes' || $override === 'no') {
+			return new HealthCheckItem(
+				'session_cookie',
+				HealthCheckItem::STATUS_WARNING,
+				$this->l10n->t('Etherpad session cookie'),
+				$override === 'yes'
+					? $this->l10n->t('HttpOnly is switched on by hand. Etherpad below 3.0 cannot read the cookie, and protected pads will not open.')
+					: $this->l10n->t('HttpOnly is switched off by hand. The pad server is not asked.'),
+			);
+		}
+
+		try {
+			$release = $this->etherpadClient->detectReleaseVersion($settings->etherpadApiHost);
+		} catch (\Throwable $e) {
+			return new HealthCheckItem(
+				'session_cookie',
+				HealthCheckItem::STATUS_WARNING,
+				$this->l10n->t('Etherpad session cookie'),
+				$this->l10n->t('Could not read the Etherpad release from /health, so the cookie stays readable by scripts.'),
+				'etherpad_api_host',
+			);
+		}
+
+		return new HealthCheckItem(
+			'session_cookie',
+			HealthCheckItem::STATUS_OK,
+			$this->l10n->t('Etherpad session cookie'),
+			EtherpadReleasePolicy::allowsHttpOnly($release)
+				? $this->fill(
+					$this->l10n->t('Etherpad {release} reads the session server-side, so the cookie is set HttpOnly.'),
+					['release' => $release],
+				)
+				: $this->fill(
+					$this->l10n->t('Etherpad {release} reads the session in the browser, so the cookie stays readable by scripts.'),
+					['release' => $release],
+				),
 		);
 	}
 

--- a/lib/Service/EtherpadHealthCheckService.php
+++ b/lib/Service/EtherpadHealthCheckService.php
@@ -9,10 +9,8 @@ declare(strict_types=1);
 
 namespace OCA\EtherpadNextcloud\Service;
 
-use OCA\EtherpadNextcloud\AppInfo\Application;
 use OCA\EtherpadNextcloud\Exception\AdminHealthCheckException;
 use OCA\EtherpadNextcloud\Exception\EtherpadClientException;
-use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IURLGenerator;
 
@@ -38,7 +36,7 @@ class EtherpadHealthCheckService {
 		private CookieDomainPolicy $cookieDomainPolicy,
 		private BaseUrlReachabilityCheck $baseUrlCheck,
 		private IURLGenerator $urlGenerator,
-		private IConfig $config,
+		private EtherpadReleasePolicy $releasePolicy,
 	) {
 	}
 
@@ -129,7 +127,7 @@ class EtherpadHealthCheckService {
 				'etherpad_api_key',
 			),
 			$this->baseUrlCheck->check($settings->etherpadHost),
-			$this->sessionCookieCheck($settings),
+			$this->sessionCookieCheck($settings, $apiField),
 		];
 
 		return new HealthCheckResult(
@@ -154,62 +152,94 @@ class EtherpadHealthCheckService {
 	 * so when the detection is wrong, the symptom is that no protected pad
 	 * opens and nothing anywhere says why.
 	 *
-	 * Asked against the host being submitted, not the one already stored,
-	 * like every other line here. Nothing is written to the cache from this:
-	 * a form that is not saved should not teach the open path anything, and
-	 * the cache is keyed by host so a saved change re-checks by itself.
+	 * It reports what the open path is *doing*, which is not the same as
+	 * what this host would say if asked now. The open path answers from a
+	 * cached release, so right after a downgrade the cookie can be HttpOnly
+	 * against a pad server that has already gone back to 2.x — the exact
+	 * moment this line exists for. Asking as well, against the host being
+	 * submitted, is what turns "here is the cookie" into "and here is why
+	 * that is now wrong".
+	 *
+	 * Nothing is written to the cache from here: a form that is not saved
+	 * should not teach the open path anything, and the cache is keyed by
+	 * host so a saved change re-checks by itself.
 	 */
-	private function sessionCookieCheck(ValidatedAdminSettings $settings): HealthCheckItem {
+	private function sessionCookieCheck(ValidatedAdminSettings $settings, string $apiField): HealthCheckItem {
 		if (!$settings->enableProtectedPads) {
 			return new HealthCheckItem(
 				'session_cookie',
 				HealthCheckItem::STATUS_SKIPPED,
-				$this->l10n->t('Etherpad session cookie'),
-				$this->l10n->t('Not checked: protected pads are switched off.'),
+				$this->l10n->t('Session cookie: not checked, protected pads are off'),
+				'',
+				'etherpad_session_cookie',
 			);
 		}
 
-		$override = strtolower(trim((string)$this->config->getAppValue(
-			Application::APP_ID,
-			EtherpadReleasePolicy::OVERRIDE_KEY,
-			'auto',
-		)));
-		if ($override === 'yes' || $override === 'no') {
+		$httpOnly = $this->releasePolicy->supportsHttpOnlySessionCookie();
+		$override = $this->releasePolicy->overrideMode();
+		if ($override !== EtherpadReleasePolicy::OVERRIDE_AUTO) {
 			return new HealthCheckItem(
 				'session_cookie',
 				HealthCheckItem::STATUS_WARNING,
 				$this->l10n->t('Etherpad session cookie'),
-				$override === 'yes'
+				$httpOnly
 					? $this->l10n->t('HttpOnly is switched on by hand. Etherpad below 3.0 cannot read the cookie, and protected pads will not open.')
 					: $this->l10n->t('HttpOnly is switched off by hand. The pad server is not asked.'),
+				'etherpad_session_cookie',
 			);
 		}
 
 		try {
-			$release = $this->etherpadClient->detectReleaseVersion($settings->etherpadApiHost);
+			// As patient as the calls beside it: a slow but healthy pad
+			// server is not a misconfiguration of this app, and this is not
+			// the open path.
+			$release = $this->etherpadClient->detectReleaseVersion(
+				$settings->etherpadApiHost,
+				EtherpadClient::REQUEST_TIMEOUT_SECONDS,
+			);
 		} catch (\Throwable $e) {
+			// Not a warning. Nothing is broken: the cookie stays readable,
+			// which is what every Etherpad before 3.0 needs anyway. An
+			// Etherpad without /health, or a proxy that routes /api and not
+			// /health, is a deployment that works and misses a hardening.
+			return new HealthCheckItem(
+				'session_cookie',
+				HealthCheckItem::STATUS_SKIPPED,
+				$this->l10n->t('Session cookie: readable by scripts'),
+				$this->l10n->t('The Etherpad release could not be read from /health, so the cookie is left readable.'),
+				$apiField,
+			);
+		}
+
+		$serverAllowsHttpOnly = EtherpadReleasePolicy::allowsHttpOnly($release);
+		if ($serverAllowsHttpOnly !== $httpOnly) {
+			// The cache and the server disagree, which is precisely the
+			// lockout an admin comes here to explain.
 			return new HealthCheckItem(
 				'session_cookie',
 				HealthCheckItem::STATUS_WARNING,
 				$this->l10n->t('Etherpad session cookie'),
-				$this->l10n->t('Could not read the Etherpad release from /health, so the cookie stays readable by scripts.'),
-				'etherpad_api_host',
+				$this->fill(
+					$httpOnly
+						? $this->l10n->t('Pads are being sent an HttpOnly cookie from an earlier check, but this server reports Etherpad {release}, which reads the cookie in the browser. Protected pads will not open until the check is repeated.')
+						: $this->l10n->t('This server reports Etherpad {release}, which reads the session server-side, but pads are still being sent a script-readable cookie from an earlier check.'),
+					['release' => $this->shorten($release)],
+				),
+				$apiField,
 			);
 		}
 
 		return new HealthCheckItem(
 			'session_cookie',
 			HealthCheckItem::STATUS_OK,
-			$this->l10n->t('Etherpad session cookie'),
-			EtherpadReleasePolicy::allowsHttpOnly($release)
-				? $this->fill(
-					$this->l10n->t('Etherpad {release} reads the session server-side, so the cookie is set HttpOnly.'),
-					['release' => $release],
-				)
-				: $this->fill(
-					$this->l10n->t('Etherpad {release} reads the session in the browser, so the cookie stays readable by scripts.'),
-					['release' => $release],
-				),
+			$this->fill(
+				$httpOnly
+					? $this->l10n->t('Session cookie kept from scripts (Etherpad {release})')
+					: $this->l10n->t('Session cookie readable by scripts (Etherpad {release})'),
+				['release' => $this->shorten($release)],
+			),
+			'',
+			'etherpad_session_cookie',
 		);
 	}
 

--- a/lib/Service/EtherpadReleasePolicy.php
+++ b/lib/Service/EtherpadReleasePolicy.php
@@ -72,6 +72,11 @@ class EtherpadReleasePolicy {
 
 	/** auto (detect) | yes (force HttpOnly) | no (force a readable cookie). */
 	public const OVERRIDE_KEY = 'etherpad_http_only_session_cookie';
+	private const OVERRIDE_WARNED_KEY = 'etherpad_http_only_override_warned_at';
+
+	/** How often an ignored override is worth a line. */
+	private const OVERRIDE_WARNING_INTERVAL_SECONDS = 3600;
+
 	public const OVERRIDE_AUTO = 'auto';
 	public const OVERRIDE_YES = 'yes';
 	public const OVERRIDE_NO = 'no';
@@ -200,10 +205,11 @@ class EtherpadReleasePolicy {
 	 * silently, with the mode resolving correctly while the connection test
 	 * calls the same value unrecognised, or the reverse.
 	 *
-	 * Not logged. It is read on every protected open, and a warning per
-	 * open for a setting whose effect is "ignored" is a hundred identical
-	 * lines an hour at the same level as real problems. The connection test
-	 * says it on request, which is where somebody is looking.
+	 * A value that is none of the three is worth saying — it is an escape
+	 * hatch reached for during an outage, and `true` or `off` silently
+	 * meaning `auto` is exactly the kind of thing an admin needs told. But
+	 * this is read on every protected open, so it is said at most once an
+	 * hour rather than a hundred times.
 	 *
 	 * @return array{mode:string,unrecognised:string}
 	 */
@@ -216,7 +222,38 @@ class EtherpadReleasePolicy {
 			return ['mode' => self::OVERRIDE_AUTO, 'unrecognised' => ''];
 		}
 
-		return ['mode' => self::OVERRIDE_AUTO, 'unrecognised' => substr($override, 0, 32)];
+		$unrecognised = substr($override, 0, 32);
+		$this->warnAboutOverride($unrecognised);
+		return ['mode' => self::OVERRIDE_AUTO, 'unrecognised' => $unrecognised];
+	}
+
+	/**
+	 * One line an hour about a setting that is being ignored.
+	 *
+	 * The stamp goes through app config rather than the memory cache
+	 * because an instance without one still deserves the warning, and the
+	 * race between two workers costs at most a second line. Best effort
+	 * throughout: this is called from the admin health check as well, where
+	 * it is outside the guard that keeps an open from failing.
+	 */
+	private function warnAboutOverride(string $value): void {
+		try {
+			$now = $this->timeFactory->getTime();
+			$age = $this->ageOf((int)$this->read(self::OVERRIDE_WARNED_KEY), $now);
+			if ($age !== null && $age < self::OVERRIDE_WARNING_INTERVAL_SECONDS) {
+				return;
+			}
+
+			$this->config->setAppValue(self::APP_ID, self::OVERRIDE_WARNED_KEY, (string)$now);
+			$this->logger->warning('Ignoring an unrecognised value for the Etherpad session cookie setting.', [
+				'app' => self::APP_ID,
+				'setting' => self::OVERRIDE_KEY,
+				'value' => $value,
+				'expected' => [self::OVERRIDE_AUTO, self::OVERRIDE_YES, self::OVERRIDE_NO],
+			]);
+		} catch (\Throwable) {
+			// Nothing here is worth failing anything over.
+		}
 	}
 
 	/**
@@ -321,8 +358,14 @@ class EtherpadReleasePolicy {
 			return $cached;
 		}
 
+		// The failure stamp is deliberately left alone. It is the one value
+		// here that is not read per host, and clearing it would wipe a
+		// backoff a concurrent check just took for a *different* host —
+		// which without a memcache means that host's next opens each wait
+		// out the health timeout again. It also does not need clearing: a
+		// fresh record returns above, before the stamp is ever consulted,
+		// and by the time the hour is up any stamp is far past its minute.
 		$this->writeState($host, $release, $now);
-		$this->clearFailure();
 		$this->releaseTheClaim($cache, $host);
 		if ($release !== $cached) {
 			$this->logger->info('Detected the Etherpad release.', [
@@ -374,10 +417,6 @@ class EtherpadReleasePolicy {
 			'host' => $host,
 			'at' => $now,
 		]));
-	}
-
-	private function clearFailure(): void {
-		$this->config->setAppValue(self::APP_ID, self::FAILED_KEY, '');
 	}
 
 	/**

--- a/lib/Service/EtherpadReleasePolicy.php
+++ b/lib/Service/EtherpadReleasePolicy.php
@@ -27,6 +27,11 @@ use Psr\Log\LoggerInterface;
  * and 3.3.3. `/health` reports a `releaseId`, and that is the only thing
  * that separates them.
  *
+ * Every answer here is reversible by an admin: `etherpad_http_only_session_cookie`
+ * is `auto` by default and takes `yes` or `no`. The failure mode of getting
+ * this wrong is total — not one protected pad opens — so it does not rest
+ * on detection alone.
+ *
  * @psalm-api
  */
 class EtherpadReleasePolicy {
@@ -36,8 +41,25 @@ class EtherpadReleasePolicy {
 	private const HOST_KEY = 'etherpad_release_host';
 	private const FAILED_AT_KEY = 'etherpad_release_failed_at';
 
-	/** The first release that reads the session cookie server-side. */
-	private const HTTP_ONLY_SINCE = '3.0.0';
+	/** auto (detect) | yes (force HttpOnly) | no (force a readable cookie). */
+	public const OVERRIDE_KEY = 'etherpad_http_only_session_cookie';
+
+	/**
+	 * The first major that reads the session cookie server-side.
+	 *
+	 * Measured, not read off a changelog, and measured at the boundary
+	 * rather than around it: with `HttpOnly` forced on, a protected pad on
+	 * **2.7.3** loads and never becomes usable, while **3.0.0** and
+	 * **3.3.3** work. The e2e stack takes a full tag, so `EP_VERSION=3.0.0`
+	 * reproduces the middle one.
+	 *
+	 * Compared by major on purpose. A patch-level comparison would have to
+	 * answer what `3.0.0-beta.1` is, and PHP sorts that *below* `3.0.0`
+	 * while the e2e spec — which has to make the same call in TypeScript —
+	 * would read the major and disagree. One rule, expressible in both
+	 * languages, and the thing that actually changed was the major.
+	 */
+	private const HTTP_ONLY_SINCE_MAJOR = 3;
 
 	/**
 	 * How long a detected release is trusted.
@@ -51,14 +73,31 @@ class EtherpadReleasePolicy {
 	private const TTL_SECONDS = 3600;
 
 	/**
+	 * When a release stops being believed at all.
+	 *
+	 * The sentence above only holds if the cache does turn over, and on the
+	 * failure path it did not: the last known release was served again on
+	 * every open and nothing ever dropped it. An admin who moves back to an
+	 * Etherpad 2 whose `/health` is unreachable — behind proxy auth, or
+	 * simply not routed — would have had a locked-out instance forever,
+	 * asked once a minute.
+	 *
+	 * So a release that has not been confirmed for six hours stops counting,
+	 * and the class falls back to the answer it defines for not knowing.
+	 * Long enough to ride out an outage, and an outage of the pad server is
+	 * not a time when pads open anyway; short enough that a misconfiguration
+	 * heals inside a working day, with the override for anyone who cannot
+	 * wait.
+	 */
+	private const MAX_STALE_SECONDS = 6 * 3600;
+
+	/**
 	 * How long a failed check is left alone.
 	 *
 	 * Without it, a pad server that accepts the connection and then says
 	 * nothing costs every single open the health timeout, for as long as it
-	 * stays that way – the failure path returns the last known release but
-	 * records nothing, so the next open starts over. This bounds that to one
-	 * attempt a minute. Much shorter than the TTL: a check that failed has
-	 * told us nothing, so there is nothing to hold on to for an hour.
+	 * stays that way. This bounds that to one attempt a minute, and doubles
+	 * as the claim that keeps concurrent opens from all probing at once.
 	 */
 	private const FAILURE_BACKOFF_SECONDS = 60;
 
@@ -71,6 +110,17 @@ class EtherpadReleasePolicy {
 	}
 
 	/**
+	 * Whether a release reads its session cookie server-side.
+	 *
+	 * Public and pure so the admin health check can say what the cookie will
+	 * be without a second copy of the rule.
+	 */
+	public static function allowsHttpOnly(string $release): bool {
+		$major = (int)(explode('.', ltrim(trim($release), 'v'))[0] ?? '0');
+		return $major >= self::HTTP_ONLY_SINCE_MAJOR;
+	}
+
+	/**
 	 * Whether the session cookie may be withheld from JavaScript.
 	 *
 	 * Unknown means no. Getting this wrong in one direction costs a
@@ -78,20 +128,44 @@ class EtherpadReleasePolicy {
 	 * so the answer without an answer is the one that keeps them working.
 	 */
 	public function supportsHttpOnlySessionCookie(): bool {
-		$release = $this->resolveRelease();
-		return $release !== '' && version_compare($release, self::HTTP_ONLY_SINCE, '>=');
+		$override = strtolower($this->read(self::OVERRIDE_KEY));
+		if ($override === 'yes') {
+			return true;
+		}
+		if ($override === 'no') {
+			return false;
+		}
+
+		return self::allowsHttpOnly($this->resolveRelease());
+	}
+
+	/** The release currently believed, without asking anything. For the admin view. */
+	public function knownRelease(): string {
+		return $this->read(self::RELEASE_KEY);
 	}
 
 	/**
 	 * The cached release, refreshed when it has gone stale.
 	 *
-	 * A detection that fails keeps the last known answer rather than
-	 * dropping to unknown: this runs on the open path, and a pad server
-	 * that is briefly unreachable should not change how the cookie is
-	 * written. It never throws for the same reason — nothing here is worth
-	 * failing an open over.
+	 * A detection that fails keeps the last known answer for a while rather
+	 * than dropping to unknown at the first blip: this runs on the open
+	 * path, and a pad server that is briefly unreachable should not change
+	 * how the cookie is written. It never throws, for the same reason —
+	 * nothing here is worth failing an open over.
 	 */
 	private function resolveRelease(): string {
+		try {
+			return $this->resolveReleaseOrThrow();
+		} catch (\Throwable $e) {
+			$this->logger->warning('Could not work out the Etherpad release; writing a script-readable session cookie.', [
+				'app' => self::APP_ID,
+				'exception' => $e,
+			]);
+			return '';
+		}
+	}
+
+	private function resolveReleaseOrThrow(): string {
 		$host = $this->etherpadClient->getApiHost();
 		$now = $this->timeFactory->getTime();
 
@@ -104,18 +178,37 @@ class EtherpadReleasePolicy {
 		}
 
 		$cached = $this->read(self::RELEASE_KEY);
-		if ($cached !== '' && $now - (int)$this->read(self::CHECKED_AT_KEY) < self::TTL_SECONDS) {
+		$age = $this->ageOf(self::CHECKED_AT_KEY, $now);
+		if ($cached !== '' && $age >= self::MAX_STALE_SECONDS) {
+			// Nothing has confirmed this for hours. Whatever it says, it is
+			// no longer evidence about the server answering today.
+			$this->logger->warning('The last known Etherpad release is too old to trust; falling back to a script-readable session cookie.', [
+				'app' => self::APP_ID,
+				'staleRelease' => $cached,
+				'ageSeconds' => $age,
+			]);
+			$this->forgetFor($host);
+			$cached = '';
+		}
+
+		if ($cached !== '' && $age < self::TTL_SECONDS) {
 			return $cached;
 		}
-		if ($now - (int)$this->read(self::FAILED_AT_KEY) < self::FAILURE_BACKOFF_SECONDS) {
+		if ($this->ageOf(self::FAILED_AT_KEY, $now) < self::FAILURE_BACKOFF_SECONDS) {
+			// Either a recent failure, or another request checking right
+			// now — the claim below makes those look the same on purpose.
 			return $cached;
 		}
+
+		// Claim the check before making it, so a hundred opens arriving at
+		// the moment the hour turns do not each spend a round trip on the
+		// same question. A claim that goes nowhere expires as a failure.
+		$this->config->setAppValue(self::APP_ID, self::FAILED_AT_KEY, (string)$now);
 
 		try {
 			$release = $this->etherpadClient->detectReleaseVersion();
 		} catch (\Throwable $e) {
-			$this->config->setAppValue(self::APP_ID, self::FAILED_AT_KEY, (string)$now);
-			$this->logger->debug('Could not read the Etherpad release; keeping the last known one.', [
+			$this->logger->warning('Could not read the Etherpad release from /health.', [
 				'app' => self::APP_ID,
 				'cachedRelease' => $cached,
 				'exception' => $e,
@@ -134,6 +227,25 @@ class EtherpadReleasePolicy {
 			]);
 		}
 		return $release;
+	}
+
+	/**
+	 * How long ago a stamp was written, counting anything in the future as
+	 * forever ago.
+	 *
+	 * A clock that jumps backwards — an NTP correction, a restored snapshot,
+	 * a cluster node that drifts — otherwise leaves a stamp ahead of `now`,
+	 * and a negative age is younger than every window there is. The cache
+	 * would then freeze until real time caught up: hours in which a
+	 * downgrade goes unnoticed. A stamp from the future is not evidence
+	 * about the past, so it counts for nothing.
+	 */
+	private function ageOf(string $key, int $now): int {
+		$stamp = (int)$this->read($key);
+		if ($stamp <= 0 || $stamp > $now) {
+			return PHP_INT_MAX;
+		}
+		return $now - $stamp;
 	}
 
 	private function read(string $key): string {

--- a/lib/Service/EtherpadReleasePolicy.php
+++ b/lib/Service/EtherpadReleasePolicy.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace OCA\EtherpadNextcloud\Service;
 
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\ICacheFactory;
 use OCP\IConfig;
 use Psr\Log\LoggerInterface;
 
@@ -43,6 +44,9 @@ class EtherpadReleasePolicy {
 
 	/** auto (detect) | yes (force HttpOnly) | no (force a readable cookie). */
 	public const OVERRIDE_KEY = 'etherpad_http_only_session_cookie';
+	public const OVERRIDE_AUTO = 'auto';
+	public const OVERRIDE_YES = 'yes';
+	public const OVERRIDE_NO = 'no';
 
 	/**
 	 * The first major that reads the session cookie server-side.
@@ -96,8 +100,9 @@ class EtherpadReleasePolicy {
 	 *
 	 * Without it, a pad server that accepts the connection and then says
 	 * nothing costs every single open the health timeout, for as long as it
-	 * stays that way. This bounds that to one attempt a minute, and doubles
-	 * as the claim that keeps concurrent opens from all probing at once.
+	 * stays that way. This bounds that to one attempt a minute. It is also
+	 * how long the claim below is held, so a worker that dies mid-check
+	 * blocks nothing for longer than a retry would have waited anyway.
 	 */
 	private const FAILURE_BACKOFF_SECONDS = 60;
 
@@ -105,6 +110,7 @@ class EtherpadReleasePolicy {
 		private EtherpadClient $etherpadClient,
 		private IConfig $config,
 		private ITimeFactory $timeFactory,
+		private ICacheFactory $cacheFactory,
 		private LoggerInterface $logger,
 	) {
 	}
@@ -128,15 +134,38 @@ class EtherpadReleasePolicy {
 	 * so the answer without an answer is the one that keeps them working.
 	 */
 	public function supportsHttpOnlySessionCookie(): bool {
-		$override = strtolower($this->read(self::OVERRIDE_KEY));
-		if ($override === 'yes') {
-			return true;
-		}
-		if ($override === 'no') {
+		try {
+			$override = $this->overrideMode();
+			if ($override !== self::OVERRIDE_AUTO) {
+				return $override === self::OVERRIDE_YES;
+			}
+
+			return self::allowsHttpOnly($this->resolveReleaseOrThrow());
+		} catch (\Throwable $e) {
+			// The promise this class makes: an open never fails because of
+			// it. Reading the override is inside the guard too — it is the
+			// first app-config read of some requests, and a database blip
+			// there would otherwise escape a predicate that says it cannot.
+			$this->logger->warning('Could not work out the Etherpad release; writing a script-readable session cookie.', [
+				'app' => self::APP_ID,
+				'exception' => $e,
+			]);
 			return false;
 		}
+	}
 
-		return self::allowsHttpOnly($this->resolveRelease());
+	/**
+	 * What the admin has decided, if anything.
+	 *
+	 * Public so the admin health check reports on the same reading rather
+	 * than parsing the value a second time with its own default — the same
+	 * reason `allowsHttpOnly()` is public: one rule, one place.
+	 */
+	public function overrideMode(): string {
+		$override = strtolower($this->read(self::OVERRIDE_KEY));
+		return in_array($override, [self::OVERRIDE_YES, self::OVERRIDE_NO], true)
+			? $override
+			: self::OVERRIDE_AUTO;
 	}
 
 	/** The release currently believed, without asking anything. For the admin view. */
@@ -150,21 +179,8 @@ class EtherpadReleasePolicy {
 	 * A detection that fails keeps the last known answer for a while rather
 	 * than dropping to unknown at the first blip: this runs on the open
 	 * path, and a pad server that is briefly unreachable should not change
-	 * how the cookie is written. It never throws, for the same reason —
-	 * nothing here is worth failing an open over.
+	 * how the cookie is written.
 	 */
-	private function resolveRelease(): string {
-		try {
-			return $this->resolveReleaseOrThrow();
-		} catch (\Throwable $e) {
-			$this->logger->warning('Could not work out the Etherpad release; writing a script-readable session cookie.', [
-				'app' => self::APP_ID,
-				'exception' => $e,
-			]);
-			return '';
-		}
-	}
-
 	private function resolveReleaseOrThrow(): string {
 		$host = $this->etherpadClient->getApiHost();
 		$now = $this->timeFactory->getTime();
@@ -179,7 +195,7 @@ class EtherpadReleasePolicy {
 
 		$cached = $this->read(self::RELEASE_KEY);
 		$age = $this->ageOf(self::CHECKED_AT_KEY, $now);
-		if ($cached !== '' && $age >= self::MAX_STALE_SECONDS) {
+		if ($cached !== '' && $age !== null && $age >= self::MAX_STALE_SECONDS) {
 			// Nothing has confirmed this for hours. Whatever it says, it is
 			// no longer evidence about the server answering today.
 			$this->logger->warning('The last known Etherpad release is too old to trust; falling back to a script-readable session cookie.', [
@@ -191,23 +207,23 @@ class EtherpadReleasePolicy {
 			$cached = '';
 		}
 
-		if ($cached !== '' && $age < self::TTL_SECONDS) {
-			return $cached;
-		}
-		if ($this->ageOf(self::FAILED_AT_KEY, $now) < self::FAILURE_BACKOFF_SECONDS) {
-			// Either a recent failure, or another request checking right
-			// now — the claim below makes those look the same on purpose.
+		if ($cached !== '' && $age !== null && $age < self::TTL_SECONDS) {
 			return $cached;
 		}
 
-		// Claim the check before making it, so a hundred opens arriving at
-		// the moment the hour turns do not each spend a round trip on the
-		// same question. A claim that goes nowhere expires as a failure.
-		$this->config->setAppValue(self::APP_ID, self::FAILED_AT_KEY, (string)$now);
+		$failedAge = $this->ageOf(self::FAILED_AT_KEY, $now);
+		if ($failedAge !== null && $failedAge < self::FAILURE_BACKOFF_SECONDS) {
+			return $cached;
+		}
+		if (!$this->claimTheCheck()) {
+			// Another worker is asking right now.
+			return $cached;
+		}
 
 		try {
 			$release = $this->etherpadClient->detectReleaseVersion();
 		} catch (\Throwable $e) {
+			$this->config->setAppValue(self::APP_ID, self::FAILED_AT_KEY, (string)$now);
 			$this->logger->warning('Could not read the Etherpad release from /health.', [
 				'app' => self::APP_ID,
 				'cachedRelease' => $cached,
@@ -230,22 +246,52 @@ class EtherpadReleasePolicy {
 	}
 
 	/**
-	 * How long ago a stamp was written, counting anything in the future as
-	 * forever ago.
+	 * How long ago a stamp was written, or null when it does not say.
 	 *
 	 * A clock that jumps backwards — an NTP correction, a restored snapshot,
-	 * a cluster node that drifts — otherwise leaves a stamp ahead of `now`,
-	 * and a negative age is younger than every window there is. The cache
-	 * would then freeze until real time caught up: hours in which a
-	 * downgrade goes unnoticed. A stamp from the future is not evidence
-	 * about the past, so it counts for nothing.
+	 * a cluster node that drifts — leaves a stamp ahead of `now`, and a
+	 * negative age is younger than every window there is: the cache would
+	 * freeze until real time caught up, hours in which a downgrade goes
+	 * unnoticed. So a stamp from the future is not an age at all.
+	 *
+	 * Null rather than a very large number, because the two readings of
+	 * "no usable age" differ. Not knowing means check again now. It does
+	 * not mean the release is hours stale — answering that would wipe a
+	 * cache seconds old and log that it was hours old, over a clock that
+	 * moved by a second.
 	 */
-	private function ageOf(string $key, int $now): int {
+	private function ageOf(string $key, int $now): ?int {
 		$stamp = (int)$this->read($key);
 		if ($stamp <= 0 || $stamp > $now) {
-			return PHP_INT_MAX;
+			return null;
 		}
 		return $now - $stamp;
+	}
+
+	/**
+	 * Take the right to make the check, if nobody else holds it.
+	 *
+	 * The obvious way to do this — write the timestamp before asking — does
+	 * not work across workers. Nextcloud loads an app's config once per
+	 * request and serves later reads from that copy, so a hundred opens
+	 * arriving together have all already read the old value and none of
+	 * them sees anybody else's write. They would each spend a round trip
+	 * on the same question.
+	 *
+	 * A distributed cache is the thing that is actually shared. `add()`
+	 * succeeds for exactly one caller, which is the whole requirement. Not
+	 * every deployment has one; a single-node instance without a memory
+	 * cache has one worker per open and nothing to coordinate with, so
+	 * going ahead is the right answer there.
+	 */
+	private function claimTheCheck(): bool {
+		if (!$this->cacheFactory->isAvailable()) {
+			return true;
+		}
+
+		return $this->cacheFactory
+			->createDistributed(self::APP_ID . '/release/')
+			->add('probe', '1', self::FAILURE_BACKOFF_SECONDS);
 	}
 
 	private function read(string $key): string {

--- a/lib/Service/EtherpadReleasePolicy.php
+++ b/lib/Service/EtherpadReleasePolicy.php
@@ -33,6 +33,8 @@ class EtherpadReleasePolicy {
 	private const APP_ID = 'etherpad_nextcloud';
 	private const RELEASE_KEY = 'etherpad_release_version';
 	private const CHECKED_AT_KEY = 'etherpad_release_checked_at';
+	private const HOST_KEY = 'etherpad_release_host';
+	private const FAILED_AT_KEY = 'etherpad_release_failed_at';
 
 	/** The first release that reads the session cookie server-side. */
 	private const HTTP_ONLY_SINCE = '3.0.0';
@@ -47,6 +49,18 @@ class EtherpadReleasePolicy {
 	 * would stop opening until the cache turned over.
 	 */
 	private const TTL_SECONDS = 3600;
+
+	/**
+	 * How long a failed check is left alone.
+	 *
+	 * Without it, a pad server that accepts the connection and then says
+	 * nothing costs every single open the health timeout, for as long as it
+	 * stays that way – the failure path returns the last known release but
+	 * records nothing, so the next open starts over. This bounds that to one
+	 * attempt a minute. Much shorter than the TTL: a check that failed has
+	 * told us nothing, so there is nothing to hold on to for an hour.
+	 */
+	private const FAILURE_BACKOFF_SECONDS = 60;
 
 	public function __construct(
 		private EtherpadClient $etherpadClient,
@@ -78,17 +92,29 @@ class EtherpadReleasePolicy {
 	 * failing an open over.
 	 */
 	private function resolveRelease(): string {
-		$cached = trim((string)$this->config->getAppValue(self::APP_ID, self::RELEASE_KEY, ''));
-		$checkedAt = (int)$this->config->getAppValue(self::APP_ID, self::CHECKED_AT_KEY, '0');
+		$host = $this->etherpadClient->getApiHost();
 		$now = $this->timeFactory->getTime();
 
-		if ($cached !== '' && $checkedAt > 0 && ($now - $checkedAt) < self::TTL_SECONDS) {
+		if ($this->read(self::HOST_KEY) !== $host) {
+			// A different pad server answers now. What the last one said
+			// about itself says nothing about this one, and an admin who
+			// repoints the app at an Etherpad 2 must not have it sent a
+			// cookie its pad app cannot read for the rest of the hour.
+			$this->forgetFor($host);
+		}
+
+		$cached = $this->read(self::RELEASE_KEY);
+		if ($cached !== '' && $now - (int)$this->read(self::CHECKED_AT_KEY) < self::TTL_SECONDS) {
+			return $cached;
+		}
+		if ($now - (int)$this->read(self::FAILED_AT_KEY) < self::FAILURE_BACKOFF_SECONDS) {
 			return $cached;
 		}
 
 		try {
 			$release = $this->etherpadClient->detectReleaseVersion();
 		} catch (\Throwable $e) {
+			$this->config->setAppValue(self::APP_ID, self::FAILED_AT_KEY, (string)$now);
 			$this->logger->debug('Could not read the Etherpad release; keeping the last known one.', [
 				'app' => self::APP_ID,
 				'cachedRelease' => $cached,
@@ -99,6 +125,7 @@ class EtherpadReleasePolicy {
 
 		$this->config->setAppValue(self::APP_ID, self::RELEASE_KEY, $release);
 		$this->config->setAppValue(self::APP_ID, self::CHECKED_AT_KEY, (string)$now);
+		$this->config->setAppValue(self::APP_ID, self::FAILED_AT_KEY, '0');
 		if ($release !== $cached) {
 			$this->logger->info('Detected the Etherpad release.', [
 				'app' => self::APP_ID,
@@ -107,5 +134,17 @@ class EtherpadReleasePolicy {
 			]);
 		}
 		return $release;
+	}
+
+	private function read(string $key): string {
+		return trim((string)$this->config->getAppValue(self::APP_ID, $key, ''));
+	}
+
+	/** Drop everything known about a release, and note whose it would be now. */
+	private function forgetFor(string $host): void {
+		$this->config->setAppValue(self::APP_ID, self::HOST_KEY, $host);
+		$this->config->setAppValue(self::APP_ID, self::RELEASE_KEY, '');
+		$this->config->setAppValue(self::APP_ID, self::CHECKED_AT_KEY, '0');
+		$this->config->setAppValue(self::APP_ID, self::FAILED_AT_KEY, '0');
 	}
 }

--- a/lib/Service/EtherpadReleasePolicy.php
+++ b/lib/Service/EtherpadReleasePolicy.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Copyright (c) 2026 Jacob Bühler
+ */
+
+namespace OCA\EtherpadNextcloud\Service;
+
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\IConfig;
+use Psr\Log\LoggerInterface;
+
+/**
+ * What the Etherpad on the other end is old enough to still need.
+ *
+ * One thing turns on this today: the session cookie. Up to Etherpad 2.7.3
+ * the pad app reads `sessionID` itself, in the browser, with
+ * `Cookies.get` — so the cookie has to be script-readable and `HttpOnly`
+ * would simply lock the user out of every protected pad. From 3.0.0 the
+ * server takes it out of the socket.io handshake instead, and the browser
+ * never needs to see it.
+ *
+ * The API version cannot answer this: `/api` says `1.3.1` on both 2.7.3
+ * and 3.3.3. `/health` reports a `releaseId`, and that is the only thing
+ * that separates them.
+ *
+ * @psalm-api
+ */
+class EtherpadReleasePolicy {
+	private const APP_ID = 'etherpad_nextcloud';
+	private const RELEASE_KEY = 'etherpad_release_version';
+	private const CHECKED_AT_KEY = 'etherpad_release_checked_at';
+
+	/** The first release that reads the session cookie server-side. */
+	private const HTTP_ONLY_SINCE = '3.0.0';
+
+	/**
+	 * How long a detected release is trusted.
+	 *
+	 * Short, and the reason is the downgrade rather than the upgrade. An
+	 * Etherpad that goes 2 → 3 while this is stale only misses a hardening
+	 * for an hour. One that goes 3 → 2 with a stale answer would be sent an
+	 * `HttpOnly` cookie its pad app cannot read, and every protected pad
+	 * would stop opening until the cache turned over.
+	 */
+	private const TTL_SECONDS = 3600;
+
+	public function __construct(
+		private EtherpadClient $etherpadClient,
+		private IConfig $config,
+		private ITimeFactory $timeFactory,
+		private LoggerInterface $logger,
+	) {
+	}
+
+	/**
+	 * Whether the session cookie may be withheld from JavaScript.
+	 *
+	 * Unknown means no. Getting this wrong in one direction costs a
+	 * hardening; in the other it costs every protected pad on the instance,
+	 * so the answer without an answer is the one that keeps them working.
+	 */
+	public function supportsHttpOnlySessionCookie(): bool {
+		$release = $this->resolveRelease();
+		return $release !== '' && version_compare($release, self::HTTP_ONLY_SINCE, '>=');
+	}
+
+	/**
+	 * The cached release, refreshed when it has gone stale.
+	 *
+	 * A detection that fails keeps the last known answer rather than
+	 * dropping to unknown: this runs on the open path, and a pad server
+	 * that is briefly unreachable should not change how the cookie is
+	 * written. It never throws for the same reason — nothing here is worth
+	 * failing an open over.
+	 */
+	private function resolveRelease(): string {
+		$cached = trim((string)$this->config->getAppValue(self::APP_ID, self::RELEASE_KEY, ''));
+		$checkedAt = (int)$this->config->getAppValue(self::APP_ID, self::CHECKED_AT_KEY, '0');
+		$now = $this->timeFactory->getTime();
+
+		if ($cached !== '' && $checkedAt > 0 && ($now - $checkedAt) < self::TTL_SECONDS) {
+			return $cached;
+		}
+
+		try {
+			$release = $this->etherpadClient->detectReleaseVersion();
+		} catch (\Throwable $e) {
+			$this->logger->debug('Could not read the Etherpad release; keeping the last known one.', [
+				'app' => self::APP_ID,
+				'cachedRelease' => $cached,
+				'exception' => $e,
+			]);
+			return $cached;
+		}
+
+		$this->config->setAppValue(self::APP_ID, self::RELEASE_KEY, $release);
+		$this->config->setAppValue(self::APP_ID, self::CHECKED_AT_KEY, (string)$now);
+		if ($release !== $cached) {
+			$this->logger->info('Detected the Etherpad release.', [
+				'app' => self::APP_ID,
+				'release' => $release,
+				'previousRelease' => $cached,
+			]);
+		}
+		return $release;
+	}
+}

--- a/lib/Service/EtherpadReleasePolicy.php
+++ b/lib/Service/EtherpadReleasePolicy.php
@@ -58,6 +58,18 @@ class EtherpadReleasePolicy {
 	 */
 	private const STATE_KEY = 'etherpad_release_state';
 
+	/**
+	 * When a check last failed, and for which host. Its own value.
+	 *
+	 * A failure has nothing to say about the release, so it must not carry
+	 * one. Folding it into the record above made every failure a full
+	 * rewrite of the record — and a worker whose check times out cannot see
+	 * the success another worker wrote in the meantime, so it would put the
+	 * old release back with a fresh-looking timestamp. After a downgrade
+	 * that is an hour of HttpOnly against an Etherpad 2.
+	 */
+	private const FAILED_KEY = 'etherpad_release_failed';
+
 	/** auto (detect) | yes (force HttpOnly) | no (force a readable cookie). */
 	public const OVERRIDE_KEY = 'etherpad_http_only_session_cookie';
 	public const OVERRIDE_AUTO = 'auto';
@@ -177,18 +189,34 @@ class EtherpadReleasePolicy {
 	 * reason `allowsHttpOnly()` is public: one rule, one place.
 	 */
 	public function overrideMode(): string {
+		return $this->readOverride()['mode'];
+	}
+
+	/**
+	 * The stored override, read once.
+	 *
+	 * Both public faces come from here rather than each parsing the value:
+	 * a fourth accepted spelling added to one and not the other would fail
+	 * silently, with the mode resolving correctly while the connection test
+	 * calls the same value unrecognised, or the reverse.
+	 *
+	 * Not logged. It is read on every protected open, and a warning per
+	 * open for a setting whose effect is "ignored" is a hundred identical
+	 * lines an hour at the same level as real problems. The connection test
+	 * says it on request, which is where somebody is looking.
+	 *
+	 * @return array{mode:string,unrecognised:string}
+	 */
+	private function readOverride(): array {
 		$override = strtolower($this->read(self::OVERRIDE_KEY));
-		if (in_array($override, [self::OVERRIDE_YES, self::OVERRIDE_NO, self::OVERRIDE_AUTO, ''], true)) {
-			return $override === '' ? self::OVERRIDE_AUTO : $override;
+		if (in_array($override, [self::OVERRIDE_YES, self::OVERRIDE_NO], true)) {
+			return ['mode' => $override, 'unrecognised' => ''];
+		}
+		if (in_array($override, [self::OVERRIDE_AUTO, ''], true)) {
+			return ['mode' => self::OVERRIDE_AUTO, 'unrecognised' => ''];
 		}
 
-		$this->logger->warning('Ignoring an unrecognised value for the Etherpad session cookie setting.', [
-			'app' => self::APP_ID,
-			'setting' => self::OVERRIDE_KEY,
-			'value' => substr($override, 0, 32),
-			'expected' => [self::OVERRIDE_AUTO, self::OVERRIDE_YES, self::OVERRIDE_NO],
-		]);
-		return self::OVERRIDE_AUTO;
+		return ['mode' => self::OVERRIDE_AUTO, 'unrecognised' => substr($override, 0, 32)];
 	}
 
 	/**
@@ -202,18 +230,28 @@ class EtherpadReleasePolicy {
 	 * them nothing is overridden. So it is worth being able to say.
 	 */
 	public function unrecognisedOverride(): string {
-		$override = strtolower($this->read(self::OVERRIDE_KEY));
-		if (in_array($override, [self::OVERRIDE_YES, self::OVERRIDE_NO, self::OVERRIDE_AUTO, ''], true)) {
-			return '';
-		}
-
-		return substr($override, 0, 32);
+		return $this->readOverride()['unrecognised'];
 	}
 
-	/** The release currently believed, without asking anything. For the admin view. */
-	public function knownRelease(): string {
+	/**
+	 * The release the open path is going by right now, without asking
+	 * anything and without writing anything.
+	 *
+	 * Same staleness rule as the open path, or it would not be the same
+	 * answer: a record nothing has confirmed for six hours stops counting
+	 * there, and a reader that skipped that would report a cookie the
+	 * opposite of the one going out — and, against an Etherpad 2, warn
+	 * about a lockout the rule had already healed.
+	 *
+	 * @param string|null $host the host to ask about, or null for the
+	 *   configured one. A record about a different server is not an answer
+	 *   about this one.
+	 */
+	public function knownRelease(?string $host = null): string {
 		try {
-			return $this->readState($this->etherpadClient->getApiHost())['release'];
+			$state = $this->readState($host ?? $this->etherpadClient->getApiHost());
+			$age = $this->ageOf($state['checkedAt'], $this->timeFactory->getTime());
+			return ($age === null || $age >= self::MAX_STALE_SECONDS) ? '' : $state['release'];
 		} catch (\Throwable) {
 			return '';
 		}
@@ -234,10 +272,13 @@ class EtherpadReleasePolicy {
 
 		$cached = $state['release'];
 		$age = $this->ageOf($state['checkedAt'], $now);
-		if ($cached !== '' && $age !== null && $age >= self::MAX_STALE_SECONDS) {
+		if ($cached !== '' && ($age === null || $age >= self::MAX_STALE_SECONDS)) {
 			// Nothing has confirmed this for hours. Whatever it says, it is
-			// no longer evidence about the server answering today.
-			$this->logger->warning('The last known Etherpad release is too old to trust; falling back to a script-readable session cookie.', [
+			// no longer evidence about the server answering today. Debug,
+			// not a warning: the reason it is not being confirmed already
+			// logs a warning at the probe, once per backoff window, while
+			// this branch is reached by every open until one succeeds.
+			$this->logger->debug('The last known Etherpad release is too old to trust; falling back to a script-readable session cookie.', [
 				'app' => self::APP_ID,
 				'staleRelease' => $cached,
 				'ageSeconds' => $age,
@@ -249,11 +290,13 @@ class EtherpadReleasePolicy {
 			return $cached;
 		}
 
-		$failedAge = $this->ageOf($state['failedAt'], $now);
+		$failedAge = $this->ageOf($this->readFailure($host), $now);
 		if ($failedAge !== null && $failedAge < self::FAILURE_BACKOFF_SECONDS) {
 			return $cached;
 		}
-		if (!$this->claimTheCheck($host)) {
+
+		$cache = $this->probeCache();
+		if (!$this->claimTheCheck($cache, $host)) {
 			// Another worker is asking right now.
 			return $cached;
 		}
@@ -264,17 +307,23 @@ class EtherpadReleasePolicy {
 			// be the one that was asked.
 			$release = $this->etherpadClient->detectReleaseVersion($host);
 		} catch (\Throwable $e) {
-			$this->writeState($host, $cached, $state['checkedAt'], $now);
+			// Only that it failed, and when. A failure knows nothing about
+			// the release, and this worker cannot see a success another one
+			// may have written while it was waiting — writing the record
+			// back would put a stale release in front of a fresh one.
+			$this->writeFailure($host, $now);
 			$this->logger->warning('Could not read the Etherpad release from /health.', [
 				'app' => self::APP_ID,
+				'host' => $host,
 				'cachedRelease' => $cached,
 				'exception' => $e,
 			]);
 			return $cached;
 		}
 
-		$this->writeState($host, $release, $now, 0);
-		$this->releaseTheClaim($host);
+		$this->writeState($host, $release, $now);
+		$this->clearFailure();
+		$this->releaseTheClaim($cache, $host);
 		if ($release !== $cached) {
 			$this->logger->info('Detected the Etherpad release.', [
 				'app' => self::APP_ID,
@@ -289,30 +338,58 @@ class EtherpadReleasePolicy {
 	 * What is on record about this host, or nothing when the record is
 	 * about a different one.
 	 *
-	 * @return array{release:string,checkedAt:int,failedAt:int}
+	 * @return array{release:string,checkedAt:int}
 	 */
 	private function readState(string $host): array {
-		$empty = ['release' => '', 'checkedAt' => 0, 'failedAt' => 0];
 		$decoded = json_decode($this->read(self::STATE_KEY), true);
 		if (!is_array($decoded) || ($decoded['host'] ?? null) !== $host) {
-			return $empty;
+			return ['release' => '', 'checkedAt' => 0];
 		}
 
 		$release = $decoded['release'] ?? '';
 		return [
 			'release' => is_string($release) ? $release : '',
 			'checkedAt' => (int)($decoded['checkedAt'] ?? 0),
-			'failedAt' => (int)($decoded['failedAt'] ?? 0),
 		];
 	}
 
-	private function writeState(string $host, string $release, int $checkedAt, int $failedAt): void {
-		$this->config->setAppValue(self::APP_ID, self::STATE_KEY, (string)json_encode([
+	private function writeState(string $host, string $release, int $checkedAt): void {
+		$this->config->setAppValue(self::APP_ID, self::STATE_KEY, $this->encode([
 			'host' => $host,
 			'release' => $release,
 			'checkedAt' => $checkedAt,
-			'failedAt' => $failedAt,
 		]));
+	}
+
+	/** When a check for this host last failed, or 0. */
+	private function readFailure(string $host): int {
+		$decoded = json_decode($this->read(self::FAILED_KEY), true);
+		return is_array($decoded) && ($decoded['host'] ?? null) === $host
+			? (int)($decoded['at'] ?? 0)
+			: 0;
+	}
+
+	private function writeFailure(string $host, int $now): void {
+		$this->config->setAppValue(self::APP_ID, self::FAILED_KEY, $this->encode([
+			'host' => $host,
+			'at' => $now,
+		]));
+	}
+
+	private function clearFailure(): void {
+		$this->config->setAppValue(self::APP_ID, self::FAILED_KEY, '');
+	}
+
+	/**
+	 * @param array<string,mixed> $value
+	 *
+	 * Throws rather than storing ''. An empty value reads back as no record
+	 * at all, so a silent encoding failure would mean nothing is ever
+	 * cached and nothing ever backs off — every protected open probing
+	 * /health again, with the write reporting success.
+	 */
+	private function encode(array $value): string {
+		return json_encode($value, JSON_THROW_ON_ERROR);
 	}
 
 	/**
@@ -362,14 +439,18 @@ class EtherpadReleasePolicy {
 	 * new server's first check would be turned away by a claim taken for
 	 * the old one. Released as soon as the answer is written, so the next
 	 * refresh is not waiting out a minute that has already done its job.
+	 *
+	 * The cache is resolved once by the caller and handed to both halves,
+	 * so a claim cannot be taken from one backend and released against
+	 * another — or, if availability changes mid-request, taken and never
+	 * given back.
 	 */
-	private function claimTheCheck(string $host): bool {
-		$cache = $this->probeCache();
+	private function claimTheCheck(?IMemcache $cache, string $host): bool {
 		return $cache === null || $cache->add($this->claimKey($host), '1', self::FAILURE_BACKOFF_SECONDS);
 	}
 
-	private function releaseTheClaim(string $host): void {
-		$this->probeCache()?->remove($this->claimKey($host));
+	private function releaseTheClaim(?IMemcache $cache, string $host): void {
+		$cache?->remove($this->claimKey($host));
 	}
 
 	private function claimKey(string $host): string {

--- a/lib/Service/EtherpadReleasePolicy.php
+++ b/lib/Service/EtherpadReleasePolicy.php
@@ -38,10 +38,25 @@ use Psr\Log\LoggerInterface;
  */
 class EtherpadReleasePolicy {
 	private const APP_ID = 'etherpad_nextcloud';
-	private const RELEASE_KEY = 'etherpad_release_version';
-	private const CHECKED_AT_KEY = 'etherpad_release_checked_at';
-	private const HOST_KEY = 'etherpad_release_host';
-	private const FAILED_AT_KEY = 'etherpad_release_failed_at';
+
+	/**
+	 * Everything known about the pad server's release, in one value.
+	 *
+	 * One value rather than four keys, and the host lives inside it. A
+	 * check for the host configured a moment ago can finish after the app
+	 * has been repointed, and with a separate host marker its write would
+	 * file the old server's release under the new server's name — for an
+	 * hour, and for an Etherpad 2 that means no protected pad opens at all.
+	 * Neither ordering nor a re-read before writing can prevent that:
+	 * Nextcloud loads an app's config once per request, so the late writer
+	 * cannot see the repointing at all.
+	 *
+	 * Keeping the host in the record does prevent it. A stale write can
+	 * only produce a record that says which server it is about, and the
+	 * next reader compares that against the host configured now and throws
+	 * it away. The cost of losing the race is one extra check.
+	 */
+	private const STATE_KEY = 'etherpad_release_state';
 
 	/** auto (detect) | yes (force HttpOnly) | no (force a readable cookie). */
 	public const OVERRIDE_KEY = 'etherpad_http_only_session_cookie';
@@ -197,7 +212,11 @@ class EtherpadReleasePolicy {
 
 	/** The release currently believed, without asking anything. For the admin view. */
 	public function knownRelease(): string {
-		return $this->read(self::RELEASE_KEY);
+		try {
+			return $this->readState($this->etherpadClient->getApiHost())['release'];
+		} catch (\Throwable) {
+			return '';
+		}
 	}
 
 	/**
@@ -211,17 +230,10 @@ class EtherpadReleasePolicy {
 	private function resolveReleaseOrThrow(): string {
 		$host = $this->etherpadClient->getApiHost();
 		$now = $this->timeFactory->getTime();
+		$state = $this->readState($host);
 
-		if ($this->read(self::HOST_KEY) !== $host) {
-			// A different pad server answers now. What the last one said
-			// about itself says nothing about this one, and an admin who
-			// repoints the app at an Etherpad 2 must not have it sent a
-			// cookie its pad app cannot read for the rest of the hour.
-			$this->forgetFor($host);
-		}
-
-		$cached = $this->read(self::RELEASE_KEY);
-		$age = $this->ageOf(self::CHECKED_AT_KEY, $now);
+		$cached = $state['release'];
+		$age = $this->ageOf($state['checkedAt'], $now);
 		if ($cached !== '' && $age !== null && $age >= self::MAX_STALE_SECONDS) {
 			// Nothing has confirmed this for hours. Whatever it says, it is
 			// no longer evidence about the server answering today.
@@ -230,7 +242,6 @@ class EtherpadReleasePolicy {
 				'staleRelease' => $cached,
 				'ageSeconds' => $age,
 			]);
-			$this->forgetFor($host);
 			$cached = '';
 		}
 
@@ -238,7 +249,7 @@ class EtherpadReleasePolicy {
 			return $cached;
 		}
 
-		$failedAge = $this->ageOf(self::FAILED_AT_KEY, $now);
+		$failedAge = $this->ageOf($state['failedAt'], $now);
 		if ($failedAge !== null && $failedAge < self::FAILURE_BACKOFF_SECONDS) {
 			return $cached;
 		}
@@ -248,9 +259,12 @@ class EtherpadReleasePolicy {
 		}
 
 		try {
-			$release = $this->etherpadClient->detectReleaseVersion();
+			// The host is passed rather than looked up again inside the
+			// client: the answer is filed under this one, so this one has to
+			// be the one that was asked.
+			$release = $this->etherpadClient->detectReleaseVersion($host);
 		} catch (\Throwable $e) {
-			$this->config->setAppValue(self::APP_ID, self::FAILED_AT_KEY, (string)$now);
+			$this->writeState($host, $cached, $state['checkedAt'], $now);
 			$this->logger->warning('Could not read the Etherpad release from /health.', [
 				'app' => self::APP_ID,
 				'cachedRelease' => $cached,
@@ -259,9 +273,7 @@ class EtherpadReleasePolicy {
 			return $cached;
 		}
 
-		$this->config->setAppValue(self::APP_ID, self::RELEASE_KEY, $release);
-		$this->config->setAppValue(self::APP_ID, self::CHECKED_AT_KEY, (string)$now);
-		$this->config->setAppValue(self::APP_ID, self::FAILED_AT_KEY, '0');
+		$this->writeState($host, $release, $now, 0);
 		$this->releaseTheClaim($host);
 		if ($release !== $cached) {
 			$this->logger->info('Detected the Etherpad release.', [
@@ -271,6 +283,36 @@ class EtherpadReleasePolicy {
 			]);
 		}
 		return $release;
+	}
+
+	/**
+	 * What is on record about this host, or nothing when the record is
+	 * about a different one.
+	 *
+	 * @return array{release:string,checkedAt:int,failedAt:int}
+	 */
+	private function readState(string $host): array {
+		$empty = ['release' => '', 'checkedAt' => 0, 'failedAt' => 0];
+		$decoded = json_decode($this->read(self::STATE_KEY), true);
+		if (!is_array($decoded) || ($decoded['host'] ?? null) !== $host) {
+			return $empty;
+		}
+
+		$release = $decoded['release'] ?? '';
+		return [
+			'release' => is_string($release) ? $release : '',
+			'checkedAt' => (int)($decoded['checkedAt'] ?? 0),
+			'failedAt' => (int)($decoded['failedAt'] ?? 0),
+		];
+	}
+
+	private function writeState(string $host, string $release, int $checkedAt, int $failedAt): void {
+		$this->config->setAppValue(self::APP_ID, self::STATE_KEY, (string)json_encode([
+			'host' => $host,
+			'release' => $release,
+			'checkedAt' => $checkedAt,
+			'failedAt' => $failedAt,
+		]));
 	}
 
 	/**
@@ -288,8 +330,7 @@ class EtherpadReleasePolicy {
 	 * cache seconds old and log that it was hours old, over a clock that
 	 * moved by a second.
 	 */
-	private function ageOf(string $key, int $now): ?int {
-		$stamp = (int)$this->read($key);
+	private function ageOf(int $stamp, int $now): ?int {
 		if ($stamp <= 0 || $stamp > $now) {
 			return null;
 		}
@@ -348,11 +389,4 @@ class EtherpadReleasePolicy {
 		return trim((string)$this->config->getAppValue(self::APP_ID, $key, ''));
 	}
 
-	/** Drop everything known about a release, and note whose it would be now. */
-	private function forgetFor(string $host): void {
-		$this->config->setAppValue(self::APP_ID, self::HOST_KEY, $host);
-		$this->config->setAppValue(self::APP_ID, self::RELEASE_KEY, '');
-		$this->config->setAppValue(self::APP_ID, self::CHECKED_AT_KEY, '0');
-		$this->config->setAppValue(self::APP_ID, self::FAILED_AT_KEY, '0');
-	}
 }

--- a/lib/Service/EtherpadReleasePolicy.php
+++ b/lib/Service/EtherpadReleasePolicy.php
@@ -16,23 +16,14 @@ use OCP\IConfig;
 use Psr\Log\LoggerInterface;
 
 /**
- * What the Etherpad on the other end is old enough to still need.
+ * Which Etherpad releases can be sent a session cookie the browser cannot
+ * read.
  *
- * One thing turns on this today: the session cookie. Up to Etherpad 2.7.3
- * the pad app reads `sessionID` itself, in the browser, with
- * `Cookies.get` — so the cookie has to be script-readable and `HttpOnly`
- * would simply lock the user out of every protected pad. From 3.0.0 the
- * server takes it out of the socket.io handshake instead, and the browser
- * never needs to see it.
+ * The release, not the API version: `/api` answers `1.3.1` on both 2.7.3
+ * and 3.3.3, so only `/health`'s `releaseId` tells them apart.
  *
- * The API version cannot answer this: `/api` says `1.3.1` on both 2.7.3
- * and 3.3.3. `/health` reports a `releaseId`, and that is the only thing
- * that separates them.
- *
- * Every answer here is reversible by an admin: `etherpad_http_only_session_cookie`
- * is `auto` by default and takes `yes` or `no`. The failure mode of getting
- * this wrong is total — not one protected pad opens — so it does not rest
- * on detection alone.
+ * What changes at 3.0, what the cache does and how an admin overrides it
+ * are in docs/etherpad-integration.md.
  *
  * @psalm-api
  */
@@ -40,33 +31,23 @@ class EtherpadReleasePolicy {
 	private const APP_ID = 'etherpad_nextcloud';
 
 	/**
-	 * Everything known about the pad server's release, in one value.
+	 * The detected release together with the host it was read from.
 	 *
-	 * One value rather than four keys, and the host lives inside it. A
-	 * check for the host configured a moment ago can finish after the app
-	 * has been repointed, and with a separate host marker its write would
-	 * file the old server's release under the new server's name — for an
-	 * hour, and for an Etherpad 2 that means no protected pad opens at all.
-	 * Neither ordering nor a re-read before writing can prevent that:
-	 * Nextcloud loads an app's config once per request, so the late writer
-	 * cannot see the repointing at all.
-	 *
-	 * Keeping the host in the record does prevent it. A stale write can
-	 * only produce a record that says which server it is about, and the
-	 * next reader compares that against the host configured now and throws
-	 * it away. The cost of losing the race is one extra check.
+	 * The host belongs inside the record, not in a key beside it. A check
+	 * for the previously configured host can finish after the app has been
+	 * repointed, and app config is loaded once per request, so that write
+	 * can neither be prevented nor noticed — but a record that names its
+	 * own host is simply not read as an answer about the new one.
 	 */
 	private const STATE_KEY = 'etherpad_release_state';
 
 	/**
-	 * When a check last failed, and for which host. Its own value.
+	 * When a check last failed, and for which host.
 	 *
-	 * A failure has nothing to say about the release, so it must not carry
-	 * one. Folding it into the record above made every failure a full
-	 * rewrite of the record — and a worker whose check times out cannot see
-	 * the success another worker wrote in the meantime, so it would put the
-	 * old release back with a fresh-looking timestamp. After a downgrade
-	 * that is an hour of HttpOnly against an Etherpad 2.
+	 * Kept apart from the record above and never written with it: a failing
+	 * worker cannot see a success another worker wrote while it waited, so
+	 * writing the record back would put a stale release in front of a fresh
+	 * one.
 	 */
 	private const FAILED_KEY = 'etherpad_release_failed';
 
@@ -82,60 +63,36 @@ class EtherpadReleasePolicy {
 	public const OVERRIDE_NO = 'no';
 
 	/**
-	 * The first major that reads the session cookie server-side.
+	 * The first major that reads the session cookie server-side. Measured
+	 * against 2.7.3, 3.0.0 and 3.3.3.
 	 *
-	 * Measured, not read off a changelog, and measured at the boundary
-	 * rather than around it: with `HttpOnly` forced on, a protected pad on
-	 * **2.7.3** loads and never becomes usable, while **3.0.0** and
-	 * **3.3.3** work. The e2e stack takes a full tag, so `EP_VERSION=3.0.0`
-	 * reproduces the middle one.
-	 *
-	 * Compared by major on purpose. A patch-level comparison would have to
-	 * answer what `3.0.0-beta.1` is, and PHP sorts that *below* `3.0.0`
-	 * while the e2e spec — which has to make the same call in TypeScript —
-	 * would read the major and disagree. One rule, expressible in both
-	 * languages, and the thing that actually changed was the major.
+	 * By major rather than `version_compare`: the e2e spec and the bash
+	 * contract restate this rule, and PHP sorts `3.0.0-beta.1` below
+	 * `3.0.0` while either of those reads it as a 3.
 	 */
 	private const HTTP_ONLY_SINCE_MAJOR = 3;
 
 	/**
-	 * How long a detected release is trusted.
-	 *
-	 * Short, and the reason is the downgrade rather than the upgrade. An
-	 * Etherpad that goes 2 → 3 while this is stale only misses a hardening
-	 * for an hour. One that goes 3 → 2 with a stale answer would be sent an
-	 * `HttpOnly` cookie its pad app cannot read, and every protected pad
-	 * would stop opening until the cache turned over.
+	 * How long a detected release is trusted. Short because of the
+	 * downgrade: a stale 3 means an `HttpOnly` cookie an Etherpad 2 cannot
+	 * read, and no protected pad opens.
 	 */
 	private const TTL_SECONDS = 3600;
 
 	/**
 	 * When a release stops being believed at all.
 	 *
-	 * The sentence above only holds if the cache does turn over, and on the
-	 * failure path it did not: the last known release was served again on
-	 * every open and nothing ever dropped it. An admin who moves back to an
-	 * Etherpad 2 whose `/health` is unreachable — behind proxy auth, or
-	 * simply not routed — would have had a locked-out instance forever,
-	 * asked once a minute.
-	 *
-	 * So a release that has not been confirmed for six hours stops counting,
-	 * and the class falls back to the answer it defines for not knowing.
-	 * Long enough to ride out an outage, and an outage of the pad server is
-	 * not a time when pads open anyway; short enough that a misconfiguration
-	 * heals inside a working day, with the override for anyone who cannot
-	 * wait.
+	 * The TTL above only bounds a downgrade while checks keep succeeding.
+	 * This bounds it when they stop: a pad server whose `/health` has been
+	 * unreachable for six hours can no longer keep an instance locked out.
 	 */
 	private const MAX_STALE_SECONDS = 6 * 3600;
 
 	/**
-	 * How long a failed check is left alone.
-	 *
-	 * Without it, a pad server that accepts the connection and then says
-	 * nothing costs every single open the health timeout, for as long as it
-	 * stays that way. This bounds that to one attempt a minute. It is also
-	 * how long the claim below is held, so a worker that dies mid-check
-	 * blocks nothing for longer than a retry would have waited anyway.
+	 * How long a failed check is left alone, so a pad server that accepts
+	 * the connection and then says nothing does not cost every open the
+	 * health timeout. Also how long the probe claim is held, so a worker
+	 * that dies mid-check blocks nothing longer than a retry would.
 	 */
 	private const FAILURE_BACKOFF_SECONDS = 60;
 
@@ -148,12 +105,7 @@ class EtherpadReleasePolicy {
 	) {
 	}
 
-	/**
-	 * Whether a release reads its session cookie server-side.
-	 *
-	 * Public and pure so the admin health check can say what the cookie will
-	 * be without a second copy of the rule.
-	 */
+	/** Public and pure so the health check needs no second copy of the rule. */
 	public static function allowsHttpOnly(string $release): bool {
 		return (int)explode('.', ltrim(trim($release), 'v'))[0] >= self::HTTP_ONLY_SINCE_MAJOR;
 	}
@@ -161,9 +113,8 @@ class EtherpadReleasePolicy {
 	/**
 	 * Whether the session cookie may be withheld from JavaScript.
 	 *
-	 * Unknown means no. Getting this wrong in one direction costs a
-	 * hardening; in the other it costs every protected pad on the instance,
-	 * so the answer without an answer is the one that keeps them working.
+	 * Unknown means no: being wrong that way costs a hardening, the other
+	 * way costs every protected pad on the instance.
 	 */
 	public function supportsHttpOnlySessionCookie(): bool {
 		try {
@@ -174,10 +125,9 @@ class EtherpadReleasePolicy {
 
 			return self::allowsHttpOnly($this->resolveReleaseOrThrow());
 		} catch (\Throwable $e) {
-			// The promise this class makes: an open never fails because of
-			// it. Reading the override is inside the guard too — it is the
-			// first app-config read of some requests, and a database blip
-			// there would otherwise escape a predicate that says it cannot.
+			// An open never fails because of this. The override read is
+			// inside the guard for the same reason: on many requests it is
+			// the first app-config read there is.
 			$this->logger->warning('Could not work out the Etherpad release; writing a script-readable session cookie.', [
 				'app' => self::APP_ID,
 				'exception' => $e,
@@ -186,13 +136,7 @@ class EtherpadReleasePolicy {
 		}
 	}
 
-	/**
-	 * What the admin has decided, if anything.
-	 *
-	 * Public so the admin health check reports on the same reading rather
-	 * than parsing the value a second time with its own default — the same
-	 * reason `allowsHttpOnly()` is public: one rule, one place.
-	 */
+	/** Public so the health check reports on the same reading, not its own. */
 	public function overrideMode(): string {
 		return $this->readOverride()['mode'];
 	}
@@ -205,11 +149,9 @@ class EtherpadReleasePolicy {
 	 * silently, with the mode resolving correctly while the connection test
 	 * calls the same value unrecognised, or the reverse.
 	 *
-	 * A value that is none of the three is worth saying — it is an escape
-	 * hatch reached for during an outage, and `true` or `off` silently
-	 * meaning `auto` is exactly the kind of thing an admin needs told. But
-	 * this is read on every protected open, so it is said at most once an
-	 * hour rather than a hundred times.
+	 * A value that is none of the three is worth saying — `true` or `off`
+	 * silently meaning `auto` is the kind of thing that hides an outage —
+	 * but this runs on every open, so it is said once an hour.
 	 *
 	 * @return array{mode:string,unrecognised:string}
 	 */
@@ -228,13 +170,10 @@ class EtherpadReleasePolicy {
 	}
 
 	/**
-	 * One line an hour about a setting that is being ignored.
-	 *
-	 * The stamp goes through app config rather than the memory cache
-	 * because an instance without one still deserves the warning, and the
-	 * race between two workers costs at most a second line. Best effort
-	 * throughout: this is called from the admin health check as well, where
-	 * it is outside the guard that keeps an open from failing.
+	 * The stamp goes through app config rather than the memory cache so an
+	 * instance without one still gets the warning; two workers racing cost
+	 * a second line. Best effort: the health check calls this outside the
+	 * guard that keeps an open from failing.
 	 */
 	private function warnAboutOverride(string $value): void {
 		try {
@@ -271,14 +210,11 @@ class EtherpadReleasePolicy {
 	}
 
 	/**
-	 * The release the open path is going by right now, without asking
-	 * anything and without writing anything.
+	 * The release the open path is going by, without asking or writing
+	 * anything.
 	 *
-	 * Same staleness rule as the open path, or it would not be the same
-	 * answer: a record nothing has confirmed for six hours stops counting
-	 * there, and a reader that skipped that would report a cookie the
-	 * opposite of the one going out — and, against an Etherpad 2, warn
-	 * about a lockout the rule had already healed.
+	 * Applies the same staleness rule, or it would not be the same answer —
+	 * the admin panel reports this as what pads are being sent.
 	 *
 	 * @param string|null $host the host to ask about, or null for the
 	 *   configured one. A record about a different server is not an answer
@@ -295,12 +231,9 @@ class EtherpadReleasePolicy {
 	}
 
 	/**
-	 * The cached release, refreshed when it has gone stale.
-	 *
-	 * A detection that fails keeps the last known answer for a while rather
-	 * than dropping to unknown at the first blip: this runs on the open
-	 * path, and a pad server that is briefly unreachable should not change
-	 * how the cookie is written.
+	 * The cached release, refreshed when it has gone stale. A failed check
+	 * keeps the last known answer rather than dropping to unknown at the
+	 * first blip.
 	 */
 	private function resolveReleaseOrThrow(): string {
 		$host = $this->etherpadClient->getApiHost();
@@ -310,11 +243,9 @@ class EtherpadReleasePolicy {
 		$cached = $state['release'];
 		$age = $this->ageOf($state['checkedAt'], $now);
 		if ($cached !== '' && ($age === null || $age >= self::MAX_STALE_SECONDS)) {
-			// Nothing has confirmed this for hours. Whatever it says, it is
-			// no longer evidence about the server answering today. Debug,
-			// not a warning: the reason it is not being confirmed already
-			// logs a warning at the probe, once per backoff window, while
-			// this branch is reached by every open until one succeeds.
+			// Debug rather than warning: the probe below already warns about
+			// the reason, once per backoff window, while this branch is
+			// reached by every open until one succeeds.
 			$this->logger->debug('The last known Etherpad release is too old to trust; falling back to a script-readable session cookie.', [
 				'app' => self::APP_ID,
 				'staleRelease' => $cached,
@@ -339,15 +270,11 @@ class EtherpadReleasePolicy {
 		}
 
 		try {
-			// The host is passed rather than looked up again inside the
-			// client: the answer is filed under this one, so this one has to
-			// be the one that was asked.
+			// Passed, not looked up again: the answer is filed under this
+			// host, so this host has to be the one asked.
 			$release = $this->etherpadClient->detectReleaseVersion($host);
 		} catch (\Throwable $e) {
-			// Only that it failed, and when. A failure knows nothing about
-			// the release, and this worker cannot see a success another one
-			// may have written while it was waiting — writing the record
-			// back would put a stale release in front of a fresh one.
+			// Only that it failed, and when — see FAILED_KEY.
 			$this->writeFailure($host, $now);
 			$this->logger->warning('Could not read the Etherpad release from /health.', [
 				'app' => self::APP_ID,
@@ -358,13 +285,9 @@ class EtherpadReleasePolicy {
 			return $cached;
 		}
 
-		// The failure stamp is deliberately left alone. It is the one value
-		// here that is not read per host, and clearing it would wipe a
-		// backoff a concurrent check just took for a *different* host —
-		// which without a memcache means that host's next opens each wait
-		// out the health timeout again. It also does not need clearing: a
-		// fresh record returns above, before the stamp is ever consulted,
-		// and by the time the hour is up any stamp is far past its minute.
+		// The failure stamp is left alone on purpose: clearing it would wipe
+		// a backoff another host's check just took. It also needs no
+		// clearing — a fresh record returns above, before the stamp is read.
 		$this->writeState($host, $release, $now);
 		$this->releaseTheClaim($cache, $host);
 		if ($release !== $cached) {
@@ -420,12 +343,11 @@ class EtherpadReleasePolicy {
 	}
 
 	/**
-	 * @param array<string,mixed> $value
-	 *
 	 * Throws rather than storing ''. An empty value reads back as no record
 	 * at all, so a silent encoding failure would mean nothing is ever
-	 * cached and nothing ever backs off — every protected open probing
-	 * /health again, with the write reporting success.
+	 * cached and nothing ever backs off.
+	 *
+	 * @param array<string,mixed> $value
 	 */
 	private function encode(array $value): string {
 		return json_encode($value, JSON_THROW_ON_ERROR);
@@ -434,17 +356,11 @@ class EtherpadReleasePolicy {
 	/**
 	 * How long ago a stamp was written, or null when it does not say.
 	 *
-	 * A clock that jumps backwards — an NTP correction, a restored snapshot,
-	 * a cluster node that drifts — leaves a stamp ahead of `now`, and a
-	 * negative age is younger than every window there is: the cache would
-	 * freeze until real time caught up, hours in which a downgrade goes
-	 * unnoticed. So a stamp from the future is not an age at all.
-	 *
-	 * Null rather than a very large number, because the two readings of
-	 * "no usable age" differ. Not knowing means check again now. It does
-	 * not mean the release is hours stale — answering that would wipe a
-	 * cache seconds old and log that it was hours old, over a clock that
-	 * moved by a second.
+	 * A stamp from the future is not an age: a clock that jumps backwards
+	 * would otherwise look younger than every window and freeze the cache.
+	 * Null rather than a huge number, because not knowing means "check
+	 * again", not "hours stale" — the latter would wipe a fresh cache and
+	 * log that it was old.
 	 */
 	private function ageOf(int $stamp, int $now): ?int {
 		if ($stamp <= 0 || $stamp > $now) {
@@ -456,33 +372,19 @@ class EtherpadReleasePolicy {
 	/**
 	 * Take the right to make the check, if nobody else holds it.
 	 *
-	 * The obvious way to do this — write the timestamp before asking — does
-	 * not work across workers. Nextcloud loads an app's config once per
-	 * request and serves later reads from that copy, so a hundred opens
-	 * arriving together have all already read the old value and none of
-	 * them sees anybody else's write. They would each spend a round trip
-	 * on the same question.
+	 * Not through app config: it is loaded once per request, so workers
+	 * never see each other's writes and would each spend a round trip on
+	 * the same question. A distributed cache is what is actually shared.
 	 *
-	 * A distributed cache is the thing that is actually shared. `add()`
-	 * succeeds for exactly one caller, which is the whole requirement — but
-	 * it is declared on `IMemcache`, not on the `ICache` that
-	 * `createDistributed()` promises. Every backend Nextcloud actually
-	 * hands back implements it; the contract does not say so, so it is
-	 * asked rather than assumed.
+	 * `add()` is declared on `IMemcache`, while `createDistributed()`
+	 * promises only an `ICache` — every backend Nextcloud hands back
+	 * implements both, the contract does not say so, so it is asked.
+	 * Nothing to claim with means one worker per open and nothing to
+	 * coordinate, so the check goes ahead.
 	 *
-	 * Not every deployment has a memory cache at all. One without has a
-	 * worker per open and nothing to coordinate with, so going ahead is the
-	 * right answer there — as it is for a backend that cannot claim.
-	 *
-	 * Keyed by host, because a claim outlives a repointing otherwise: the
-	 * new server's first check would be turned away by a claim taken for
-	 * the old one. Released as soon as the answer is written, so the next
-	 * refresh is not waiting out a minute that has already done its job.
-	 *
-	 * The cache is resolved once by the caller and handed to both halves,
-	 * so a claim cannot be taken from one backend and released against
-	 * another — or, if availability changes mid-request, taken and never
-	 * given back.
+	 * Keyed by host, or a claim outlives a repointing. The cache is
+	 * resolved once by the caller and handed to both halves, so a claim
+	 * cannot be taken from one backend and released against another.
 	 */
 	private function claimTheCheck(?IMemcache $cache, string $host): bool {
 		return $cache === null || $cache->add($this->claimKey($host), '1', self::FAILURE_BACKOFF_SECONDS);

--- a/lib/Service/EtherpadReleasePolicy.php
+++ b/lib/Service/EtherpadReleasePolicy.php
@@ -11,6 +11,7 @@ namespace OCA\EtherpadNextcloud\Service;
 
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\ICacheFactory;
+use OCP\IMemcache;
 use OCP\IConfig;
 use Psr\Log\LoggerInterface;
 
@@ -122,8 +123,7 @@ class EtherpadReleasePolicy {
 	 * be without a second copy of the rule.
 	 */
 	public static function allowsHttpOnly(string $release): bool {
-		$major = (int)(explode('.', ltrim(trim($release), 'v'))[0] ?? '0');
-		return $major >= self::HTTP_ONLY_SINCE_MAJOR;
+		return (int)explode('.', ltrim(trim($release), 'v'))[0] >= self::HTTP_ONLY_SINCE_MAJOR;
 	}
 
 	/**
@@ -163,9 +163,36 @@ class EtherpadReleasePolicy {
 	 */
 	public function overrideMode(): string {
 		$override = strtolower($this->read(self::OVERRIDE_KEY));
-		return in_array($override, [self::OVERRIDE_YES, self::OVERRIDE_NO], true)
-			? $override
-			: self::OVERRIDE_AUTO;
+		if (in_array($override, [self::OVERRIDE_YES, self::OVERRIDE_NO, self::OVERRIDE_AUTO, ''], true)) {
+			return $override === '' ? self::OVERRIDE_AUTO : $override;
+		}
+
+		$this->logger->warning('Ignoring an unrecognised value for the Etherpad session cookie setting.', [
+			'app' => self::APP_ID,
+			'setting' => self::OVERRIDE_KEY,
+			'value' => substr($override, 0, 32),
+			'expected' => [self::OVERRIDE_AUTO, self::OVERRIDE_YES, self::OVERRIDE_NO],
+		]);
+		return self::OVERRIDE_AUTO;
+	}
+
+	/**
+	 * A stored override that is none of the three words, or '' when there
+	 * is no such problem.
+	 *
+	 * This is the setting an admin reaches for while protected pads are
+	 * down, typed into `occ` from memory: `true`, `1`, `off`, `disabled`.
+	 * Every one of those silently means `auto`, and the connection test
+	 * would then confirm the automatic behaviour as fine — actively telling
+	 * them nothing is overridden. So it is worth being able to say.
+	 */
+	public function unrecognisedOverride(): string {
+		$override = strtolower($this->read(self::OVERRIDE_KEY));
+		if (in_array($override, [self::OVERRIDE_YES, self::OVERRIDE_NO, self::OVERRIDE_AUTO, ''], true)) {
+			return '';
+		}
+
+		return substr($override, 0, 32);
 	}
 
 	/** The release currently believed, without asking anything. For the admin view. */
@@ -215,7 +242,7 @@ class EtherpadReleasePolicy {
 		if ($failedAge !== null && $failedAge < self::FAILURE_BACKOFF_SECONDS) {
 			return $cached;
 		}
-		if (!$this->claimTheCheck()) {
+		if (!$this->claimTheCheck($host)) {
 			// Another worker is asking right now.
 			return $cached;
 		}
@@ -235,6 +262,7 @@ class EtherpadReleasePolicy {
 		$this->config->setAppValue(self::APP_ID, self::RELEASE_KEY, $release);
 		$this->config->setAppValue(self::APP_ID, self::CHECKED_AT_KEY, (string)$now);
 		$this->config->setAppValue(self::APP_ID, self::FAILED_AT_KEY, '0');
+		$this->releaseTheClaim($host);
 		if ($release !== $cached) {
 			$this->logger->info('Detected the Etherpad release.', [
 				'app' => self::APP_ID,
@@ -279,19 +307,41 @@ class EtherpadReleasePolicy {
 	 * on the same question.
 	 *
 	 * A distributed cache is the thing that is actually shared. `add()`
-	 * succeeds for exactly one caller, which is the whole requirement. Not
-	 * every deployment has one; a single-node instance without a memory
-	 * cache has one worker per open and nothing to coordinate with, so
-	 * going ahead is the right answer there.
+	 * succeeds for exactly one caller, which is the whole requirement — but
+	 * it is declared on `IMemcache`, not on the `ICache` that
+	 * `createDistributed()` promises. Every backend Nextcloud actually
+	 * hands back implements it; the contract does not say so, so it is
+	 * asked rather than assumed.
+	 *
+	 * Not every deployment has a memory cache at all. One without has a
+	 * worker per open and nothing to coordinate with, so going ahead is the
+	 * right answer there — as it is for a backend that cannot claim.
+	 *
+	 * Keyed by host, because a claim outlives a repointing otherwise: the
+	 * new server's first check would be turned away by a claim taken for
+	 * the old one. Released as soon as the answer is written, so the next
+	 * refresh is not waiting out a minute that has already done its job.
 	 */
-	private function claimTheCheck(): bool {
+	private function claimTheCheck(string $host): bool {
+		$cache = $this->probeCache();
+		return $cache === null || $cache->add($this->claimKey($host), '1', self::FAILURE_BACKOFF_SECONDS);
+	}
+
+	private function releaseTheClaim(string $host): void {
+		$this->probeCache()?->remove($this->claimKey($host));
+	}
+
+	private function claimKey(string $host): string {
+		return 'probe-' . md5($host);
+	}
+
+	private function probeCache(): ?IMemcache {
 		if (!$this->cacheFactory->isAvailable()) {
-			return true;
+			return null;
 		}
 
-		return $this->cacheFactory
-			->createDistributed(self::APP_ID . '/release/')
-			->add('probe', '1', self::FAILURE_BACKOFF_SECONDS);
+		$cache = $this->cacheFactory->createDistributed(self::APP_ID . '/release/');
+		return $cache instanceof IMemcache ? $cache : null;
 	}
 
 	private function read(string $key): string {

--- a/lib/Service/EtherpadReleasePolicy.php
+++ b/lib/Service/EtherpadReleasePolicy.php
@@ -17,13 +17,10 @@ use Psr\Log\LoggerInterface;
 
 /**
  * Which Etherpad releases can be sent a session cookie the browser cannot
- * read.
+ * read. The release, not the API version: `/api` answers `1.3.1` on both
+ * 2.7.3 and 3.3.3, so only `/health`'s `releaseId` tells them apart.
  *
- * The release, not the API version: `/api` answers `1.3.1` on both 2.7.3
- * and 3.3.3, so only `/health`'s `releaseId` tells them apart.
- *
- * What changes at 3.0, what the cache does and how an admin overrides it
- * are in docs/etherpad-integration.md.
+ * docs/etherpad-integration.md has the operator's version.
  *
  * @psalm-api
  */
@@ -31,31 +28,25 @@ class EtherpadReleasePolicy {
 	private const APP_ID = 'etherpad_nextcloud';
 
 	/**
-	 * The detected release together with the host it was read from.
-	 *
-	 * The host belongs inside the record, not in a key beside it. A check
-	 * for the previously configured host can finish after the app has been
-	 * repointed, and app config is loaded once per request, so that write
-	 * can neither be prevented nor noticed — but a record that names its
-	 * own host is simply not read as an answer about the new one.
+	 * The detected release together with the host it was read from — inside
+	 * the record, not in a key beside it. A check for the old host can land
+	 * after a repointing, and app config is loaded once per request, so
+	 * that write can neither be prevented nor noticed; a record that names
+	 * its own host is simply not read as an answer about the new one.
 	 */
 	private const STATE_KEY = 'etherpad_release_state';
 
 	/**
-	 * When a check last failed, and for which host.
-	 *
-	 * Kept apart from the record above and never written with it: a failing
-	 * worker cannot see a success another worker wrote while it waited, so
-	 * writing the record back would put a stale release in front of a fresh
-	 * one.
+	 * When a check last failed, and for which host. Never written together
+	 * with the record above: a failing worker cannot see a success another
+	 * one wrote while it waited, so it would put a stale release in front
+	 * of a fresh one.
 	 */
 	private const FAILED_KEY = 'etherpad_release_failed';
 
 	/** auto (detect) | yes (force HttpOnly) | no (force a readable cookie). */
 	public const OVERRIDE_KEY = 'etherpad_http_only_session_cookie';
 	private const OVERRIDE_WARNED_KEY = 'etherpad_http_only_override_warned_at';
-
-	/** How often an ignored override is worth a line. */
 	private const OVERRIDE_WARNING_INTERVAL_SECONDS = 3600;
 
 	public const OVERRIDE_AUTO = 'auto';
@@ -64,35 +55,26 @@ class EtherpadReleasePolicy {
 
 	/**
 	 * The first major that reads the session cookie server-side. Measured
-	 * against 2.7.3, 3.0.0 and 3.3.3.
-	 *
-	 * By major rather than `version_compare`: the e2e spec and the bash
-	 * contract restate this rule, and PHP sorts `3.0.0-beta.1` below
-	 * `3.0.0` while either of those reads it as a 3.
+	 * against 2.7.3, 3.0.0 and 3.3.3. By major rather than
+	 * `version_compare`, because the e2e spec and the bash contract restate
+	 * this rule and both read `3.0.0-beta.1` as a 3 where PHP does not.
 	 */
 	private const HTTP_ONLY_SINCE_MAJOR = 3;
 
-	/**
-	 * How long a detected release is trusted. Short because of the
-	 * downgrade: a stale 3 means an `HttpOnly` cookie an Etherpad 2 cannot
-	 * read, and no protected pad opens.
-	 */
+	/** Short because of the downgrade: a stale 3 locks out an Etherpad 2. */
 	private const TTL_SECONDS = 3600;
 
 	/**
-	 * When a release stops being believed at all.
-	 *
-	 * The TTL above only bounds a downgrade while checks keep succeeding.
-	 * This bounds it when they stop: a pad server whose `/health` has been
-	 * unreachable for six hours can no longer keep an instance locked out.
+	 * The TTL only bounds a downgrade while checks succeed. This bounds it
+	 * when they stop, so an unreachable `/health` cannot keep an instance
+	 * locked out for good.
 	 */
 	private const MAX_STALE_SECONDS = 6 * 3600;
 
 	/**
-	 * How long a failed check is left alone, so a pad server that accepts
-	 * the connection and then says nothing does not cost every open the
-	 * health timeout. Also how long the probe claim is held, so a worker
-	 * that dies mid-check blocks nothing longer than a retry would.
+	 * How long a failed check is left alone, so a silent pad server does
+	 * not cost every open the health timeout. Also how long the probe claim
+	 * is held, so a worker that dies mid-check blocks nothing longer.
 	 */
 	private const FAILURE_BACKOFF_SECONDS = 60;
 
@@ -149,9 +131,8 @@ class EtherpadReleasePolicy {
 	 * silently, with the mode resolving correctly while the connection test
 	 * calls the same value unrecognised, or the reverse.
 	 *
-	 * A value that is none of the three is worth saying — `true` or `off`
-	 * silently meaning `auto` is the kind of thing that hides an outage —
-	 * but this runs on every open, so it is said once an hour.
+	 * A value that is none of the three is worth saying, but this runs on
+	 * every open, so it is said once an hour.
 	 *
 	 * @return array{mode:string,unrecognised:string}
 	 */
@@ -170,10 +151,9 @@ class EtherpadReleasePolicy {
 	}
 
 	/**
-	 * The stamp goes through app config rather than the memory cache so an
-	 * instance without one still gets the warning; two workers racing cost
-	 * a second line. Best effort: the health check calls this outside the
-	 * guard that keeps an open from failing.
+	 * Through app config rather than the memory cache, so an instance
+	 * without one still gets the warning. Best effort: the health check
+	 * calls this outside the guard that keeps an open from failing.
 	 */
 	private function warnAboutOverride(string $value): void {
 		try {
@@ -196,14 +176,9 @@ class EtherpadReleasePolicy {
 	}
 
 	/**
-	 * A stored override that is none of the three words, or '' when there
-	 * is no such problem.
-	 *
-	 * This is the setting an admin reaches for while protected pads are
-	 * down, typed into `occ` from memory: `true`, `1`, `off`, `disabled`.
-	 * Every one of those silently means `auto`, and the connection test
-	 * would then confirm the automatic behaviour as fine — actively telling
-	 * them nothing is overridden. So it is worth being able to say.
+	 * A stored override that is none of the three words, or ''. `true`,
+	 * `1`, `off` all silently mean `auto`, and the connection test would
+	 * otherwise confirm the automatic behaviour as fine.
 	 */
 	public function unrecognisedOverride(): string {
 		return $this->readOverride()['unrecognised'];
@@ -211,14 +186,11 @@ class EtherpadReleasePolicy {
 
 	/**
 	 * The release the open path is going by, without asking or writing
-	 * anything.
+	 * anything. Applies the same staleness rule, or it would not be the
+	 * same answer — the admin panel reports this as what pads are sent.
 	 *
-	 * Applies the same staleness rule, or it would not be the same answer —
-	 * the admin panel reports this as what pads are being sent.
-	 *
-	 * @param string|null $host the host to ask about, or null for the
-	 *   configured one. A record about a different server is not an answer
-	 *   about this one.
+	 * @param string|null $host null for the configured host. A record about
+	 *   a different server is not an answer about this one.
 	 */
 	public function knownRelease(?string $host = null): string {
 		try {
@@ -230,11 +202,7 @@ class EtherpadReleasePolicy {
 		}
 	}
 
-	/**
-	 * The cached release, refreshed when it has gone stale. A failed check
-	 * keeps the last known answer rather than dropping to unknown at the
-	 * first blip.
-	 */
+	/** A failed check keeps the last known answer rather than dropping it. */
 	private function resolveReleaseOrThrow(): string {
 		$host = $this->etherpadClient->getApiHost();
 		$now = $this->timeFactory->getTime();
@@ -354,13 +322,11 @@ class EtherpadReleasePolicy {
 	}
 
 	/**
-	 * How long ago a stamp was written, or null when it does not say.
-	 *
-	 * A stamp from the future is not an age: a clock that jumps backwards
-	 * would otherwise look younger than every window and freeze the cache.
-	 * Null rather than a huge number, because not knowing means "check
-	 * again", not "hours stale" — the latter would wipe a fresh cache and
-	 * log that it was old.
+	 * How long ago a stamp was written, or null when it does not say. A
+	 * stamp from the future is not an age — a clock that jumps backwards
+	 * would look younger than every window and freeze the cache. Null
+	 * rather than a huge number: not knowing means "check again", not
+	 * "hours stale".
 	 */
 	private function ageOf(int $stamp, int $now): ?int {
 		if ($stamp <= 0 || $stamp > $now) {
@@ -373,18 +339,15 @@ class EtherpadReleasePolicy {
 	 * Take the right to make the check, if nobody else holds it.
 	 *
 	 * Not through app config: it is loaded once per request, so workers
-	 * never see each other's writes and would each spend a round trip on
-	 * the same question. A distributed cache is what is actually shared.
-	 *
-	 * `add()` is declared on `IMemcache`, while `createDistributed()`
-	 * promises only an `ICache` — every backend Nextcloud hands back
-	 * implements both, the contract does not say so, so it is asked.
-	 * Nothing to claim with means one worker per open and nothing to
+	 * never see each other's writes. A distributed cache is what is
+	 * actually shared — and `add()` is declared on `IMemcache` while
+	 * `createDistributed()` promises only an `ICache`, so it is asked for
+	 * rather than assumed. Nothing to claim with means nothing to
 	 * coordinate, so the check goes ahead.
 	 *
-	 * Keyed by host, or a claim outlives a repointing. The cache is
-	 * resolved once by the caller and handed to both halves, so a claim
-	 * cannot be taken from one backend and released against another.
+	 * Keyed by host, or a claim outlives a repointing. Resolved once by the
+	 * caller and handed to both halves, so a claim cannot be taken from one
+	 * backend and released against another.
 	 */
 	private function claimTheCheck(?IMemcache $cache, string $host): bool {
 		return $cache === null || $cache->add($this->claimKey($host), '1', self::FAILURE_BACKOFF_SECONDS);

--- a/lib/Service/HealthCheckResult.php
+++ b/lib/Service/HealthCheckResult.php
@@ -18,6 +18,12 @@ class HealthCheckResult {
 		public readonly int $latencyMs,
 		public readonly string $target,
 		public readonly int $pendingDeleteCount,
+		/**
+		 * The Etherpad release the open path is currently going by, or ''
+		 * when it has none. Not the release this check just probed: the
+		 * point of reporting it is that the two can differ.
+		 */
+		public readonly string $sessionCookieRelease,
 		/** null when protected pads are switched off, so nothing was checked. */
 		public readonly ?CookieDomainDecision $cookieDomain,
 		/** @var list<HealthCheckItem> */

--- a/lib/Service/PadSessionService.php
+++ b/lib/Service/PadSessionService.php
@@ -54,6 +54,7 @@ class PadSessionService {
 		private IConfig $config,
 		private IURLGenerator $urlGenerator,
 		private CookieDomainPolicy $cookieDomainPolicy,
+		private EtherpadReleasePolicy $releasePolicy,
 		private IRequest $request,
 		private LoggerInterface $logger,
 	) {
@@ -296,9 +297,12 @@ class PadSessionService {
 			'path' => '/',
 			'domain' => $cookieDomain,
 			'secure' => true,
-			// Etherpad reads its session cookie client-side in the pad app, so this
-			// must remain script-readable for protected pad opens to work.
-			'http_only' => false,
+			// Up to Etherpad 2.7.3 the pad app reads `sessionID` itself, in
+			// the browser — HttpOnly there would lock the user out of every
+			// protected pad. From 3.0.0 the server takes it out of the
+			// socket.io handshake and the browser never needs to see it, so
+			// the cookie can be kept away from any script on the page.
+			'http_only' => $this->releasePolicy->supportsHttpOnlySessionCookie(),
 			'same_site' => 'None',
 		];
 	}

--- a/templates/admin-settings.php
+++ b/templates/admin-settings.php
@@ -94,6 +94,14 @@
 		</p>
 		<p class="settings-hint ep-field-hint" id="epnc-hint-cookie-domain"><?php p((string)$_['l10n']['etherpad_cookie_domain_hint']); ?></p>
 
+		<?php // The session cookie belongs to no input: the release decides it,
+		// and the release is discovered rather than typed. Without a slot of
+		// its own the connection test would count the line and render it
+		// nowhere. ?>
+		<p>
+			<span class="ep-check-result" data-check-result="etherpad_session_cookie" role="status"></span>
+		</p>
+
 		<div class="etherpad-nextcloud-admin-actions">
 			<button type="button" id="etherpad-nextcloud-health-check"><?php p((string)$_['l10n']['health_button']); ?></button>
 		</div>

--- a/tests/e2e/fixtures/dav.ts
+++ b/tests/e2e/fixtures/dav.ts
@@ -4,7 +4,7 @@
  */
 import { E2E } from './env'
 
-const basicAuthHeader = (): string => {
+export const basicAuthHeader = (): string => {
 	const auth = Buffer.from(`${E2E.user}:${E2E.appPassword}`).toString('base64')
 	return `Basic ${auth}`
 }

--- a/tests/e2e/fixtures/env.ts
+++ b/tests/e2e/fixtures/env.ts
@@ -52,6 +52,15 @@ export const E2E = {
 	 * Optional: only the throwaway container stack knows its own API key,
 	 * and a spec that needs it skips elsewhere rather than failing.
 	 */
+	/**
+	 * The pad server's address on its own. `/health` needs no api key, so a
+	 * spec that only asks that must not be gated on one — a target that
+	 * configured the URL and nothing else would skip in silence.
+	 */
+	get etherpadUrl(): string | null {
+		const url = process.env.E2E_ETHERPAD_URL?.trim()
+		return url ? url.replace(/\/+$/, '') : null
+	},
 	get etherpadApi(): { url: string, key: string } | null {
 		const url = process.env.E2E_ETHERPAD_URL?.trim()
 		const key = process.env.E2E_ETHERPAD_API_KEY?.trim()

--- a/tests/e2e/fixtures/env.ts
+++ b/tests/e2e/fixtures/env.ts
@@ -52,6 +52,11 @@ export const E2E = {
 	 * Optional: only the throwaway container stack knows its own API key,
 	 * and a spec that needs it skips elsewhere rather than failing.
 	 */
+	get etherpadApi(): { url: string, key: string } | null {
+		const url = process.env.E2E_ETHERPAD_URL?.trim()
+		const key = process.env.E2E_ETHERPAD_API_KEY?.trim()
+		return (url && key) ? { url: url.replace(/\/+$/, ''), key } : null
+	},
 	/**
 	 * The pad server's address on its own. `/health` needs no api key, so a
 	 * spec that only asks that must not be gated on one — a target that
@@ -60,11 +65,6 @@ export const E2E = {
 	get etherpadUrl(): string | null {
 		const url = process.env.E2E_ETHERPAD_URL?.trim()
 		return url ? url.replace(/\/+$/, '') : null
-	},
-	get etherpadApi(): { url: string, key: string } | null {
-		const url = process.env.E2E_ETHERPAD_URL?.trim()
-		const key = process.env.E2E_ETHERPAD_API_KEY?.trim()
-		return (url && key) ? { url: url.replace(/\/+$/, ''), key } : null
 	},
 	/**
 	 * App password used for non-browser WebDAV/API setup and teardown

--- a/tests/e2e/specs/protected-session-cookie-httponly.spec.ts
+++ b/tests/e2e/specs/protected-session-cookie-httponly.spec.ts
@@ -88,6 +88,37 @@ test.describe('the session cookie and the Etherpad that reads it', () => {
 			} else {
 				expect(setCookie, `Etherpad ${release} reads the session in the browser`).not.toContain('HttpOnly')
 			}
+
+			// An absent flag is the default, so on an Etherpad 2 target the
+			// branch above passes just as well when detection is broken end
+			// to end — /health blocked from inside the container, the policy
+			// throwing, the flag removed altogether. This spec asks from the
+			// runner's network; the app asks from inside, against its own
+			// configured api host. So make it say what it found: the
+			// connection test reports the release the app itself read, and
+			// naming it is only possible if that half is live.
+			const connectionTest = await api.post(
+				`${E2E.baseURL}/index.php/apps/etherpad_nextcloud/api/v1/admin/health`,
+				{
+					headers: {
+						Authorization: basicAuthHeader(),
+						'OCS-APIRequest': 'true',
+						Accept: 'application/json',
+						'Content-Type': 'application/json',
+					},
+					// The connection test validates the form as submitted, and
+					// the base URL is required there. Same server either way.
+					data: { etherpad_host: etherpadUrl! },
+				},
+			)
+			expect(connectionTest.status(), await connectionTest.text()).toBe(200)
+			const checks = ((await connectionTest.json()) as { checks?: Array<{ id: string, label: string, detail: string }> }).checks ?? []
+			const sessionCookie = checks.find((c) => c.id === 'session_cookie')
+			expect(sessionCookie, 'the connection test should report on the session cookie').toBeDefined()
+			expect(
+				`${sessionCookie!.label} ${sessionCookie!.detail}`,
+				'the app should name the release it read for itself',
+			).toContain(release)
 		} finally {
 			await api.dispose()
 		}

--- a/tests/e2e/specs/protected-session-cookie-httponly.spec.ts
+++ b/tests/e2e/specs/protected-session-cookie-httponly.spec.ts
@@ -55,10 +55,12 @@ test.describe('the session cookie and the Etherpad that reads it', () => {
 			expect(health.status()).toBe(200)
 			const release = String(((await health.json()) as { releaseId?: string }).releaseId ?? '')
 			expect(release, 'Etherpad /health should report a releaseId').toMatch(/^\d+\.\d+\.\d+/)
-			// The same rule the app applies, and the reason it is the major
-			// rather than the full version: this has to be expressible here
-			// too, and PHP sorts `3.0.0-beta.1` below `3.0.0` while any
-			// reading of it here would call it a 3.
+			// The same rule the app applies — EtherpadReleasePolicy's
+			// HTTP_ONLY_SINCE_MAJOR — restated rather than imported, because
+			// a test that derives its expectation from the thing under test
+			// asserts nothing. It is the major rather than the full version
+			// exactly so it can be restated: PHP sorts `3.0.0-beta.1` below
+			// `3.0.0` while any reading of it here calls it a 3.
 			const readsItServerSide = Number(release.split('.')[0]) >= 3
 
 			await createPadAtPath(`/${padName}`, 'protected')
@@ -94,9 +96,13 @@ test.describe('the session cookie and the Etherpad that reads it', () => {
 			// to end — /health blocked from inside the container, the policy
 			// throwing, the flag removed altogether. This spec asks from the
 			// runner's network; the app asks from inside, against its own
-			// configured api host. So make it say what it found: the
-			// connection test reports the release the app itself read, and
-			// naming it is only possible if that half is live.
+			// configured api host.
+			//
+			// So make it say what it *stored*. The connection test reports
+			// the cached release — the one the open path above actually used
+			// to decide this cookie — so naming it is only possible if the
+			// whole path ran: probe from inside the container, parse, write,
+			// read back.
 			const connectionTest = await api.post(
 				`${E2E.baseURL}/index.php/apps/etherpad_nextcloud/api/v1/admin/health`,
 				{
@@ -117,7 +123,7 @@ test.describe('the session cookie and the Etherpad that reads it', () => {
 			expect(sessionCookie, 'the connection test should report on the session cookie').toBeDefined()
 			expect(
 				`${sessionCookie!.label} ${sessionCookie!.detail}`,
-				'the app should name the release it read for itself',
+				'the app should name the release it cached for itself when opening the pad',
 			).toContain(release)
 		} finally {
 			await api.dispose()

--- a/tests/e2e/specs/protected-session-cookie-httponly.spec.ts
+++ b/tests/e2e/specs/protected-session-cookie-httponly.spec.ts
@@ -18,12 +18,23 @@ import { uniquePadName } from '../fixtures/nextcloud'
  * same question and holds the answer against the cookie that actually
  * goes out, so one spec is right on both halves of the matrix.
  *
- * What the flag being wrong actually costs is measured elsewhere:
- * `pad-author-display-name` drives Etherpad's own toolbar two frames
- * deep, and with `HttpOnly` forced on 2.7.3 the pad app never becomes
- * usable. The other `protected-*` specs cannot see that — they work at
+ * What the flag being wrong actually costs is a property of Etherpad
+ * rather than of this app, and it is measured by hand. The recipe, so it
+ * is repeatable rather than remembered:
+ *
+ *     occ config:app:set etherpad_nextcloud \
+ *       etherpad_http_only_session_cookie --value=yes
+ *     tests/e2e/docker/run-suite.sh pad-author-display-name
+ *
+ * On an Etherpad 2 stack that fails: the pad loads and never becomes
+ * usable, because its pad app reads the cookie with `Cookies.get`. On
+ * 3.0.0 and 3.3.3 it passes. `EP_VERSION` takes a full tag, so
+ * `EP_VERSION=3.0.0 tests/e2e/docker/up.sh` reproduces the boundary
+ * itself.
+ *
+ * The other `protected-*` specs cannot see any of this — they work at
  * request level, where nothing ever needs to read the cookie from
- * JavaScript, and they pass either way.
+ * JavaScript, and they pass either way. Which is why this one exists.
  */
 test.describe('the session cookie and the Etherpad that reads it', () => {
 	const padName = uniquePadName('httponly')
@@ -33,47 +44,52 @@ test.describe('the session cookie and the Etherpad that reads it', () => {
 	})
 
 	test('is kept from scripts exactly where Etherpad reads it server-side', async () => {
-		const etherpad = E2E.etherpadApi
-		test.skip(etherpad === null, 'E2E_ETHERPAD_URL / E2E_ETHERPAD_API_KEY not configured; Etherpad-side spec skipped.')
+		const etherpadUrl = E2E.etherpadUrl
+		test.skip(etherpadUrl === null, 'E2E_ETHERPAD_URL not configured; Etherpad-side spec skipped.')
 
 		// `storageState` is inherited from the project inside a test, and a
 		// browser session here would authenticate as somebody else.
 		const api = await playwrightRequest.newContext({ storageState: { cookies: [], origins: [] } })
+		try {
+			const health = await api.get(`${etherpadUrl!}/health`)
+			expect(health.status()).toBe(200)
+			const release = String(((await health.json()) as { releaseId?: string }).releaseId ?? '')
+			expect(release, 'Etherpad /health should report a releaseId').toMatch(/^\d+\.\d+\.\d+/)
+			// The same rule the app applies, and the reason it is the major
+			// rather than the full version: this has to be expressible here
+			// too, and PHP sorts `3.0.0-beta.1` below `3.0.0` while any
+			// reading of it here would call it a 3.
+			const readsItServerSide = Number(release.split('.')[0]) >= 3
 
-		const health = await api.get(`${etherpad!.url}/health`)
-		expect(health.status()).toBe(200)
-		const release = String(((await health.json()) as { releaseId?: string }).releaseId ?? '')
-		expect(release, 'Etherpad /health should report a releaseId').toMatch(/^\d+\.\d+\.\d+/)
-		const readsItServerSide = Number(release.split('.')[0]) >= 3
+			await createPadAtPath(`/${padName}`, 'protected')
 
-		await createPadAtPath(`/${padName}`, 'protected')
+			const opened = await api.post(
+				`${E2E.baseURL}/index.php/apps/etherpad_nextcloud/api/v1/pads/open`,
+				{
+					headers: { Authorization: basicAuthHeader(), 'OCS-APIRequest': 'true', Accept: 'application/json' },
+					form: { file: `/${padName}` },
+				},
+			)
+			expect(opened.status(), await opened.text()).toBe(200)
 
-		const opened = await api.post(
-			`${E2E.baseURL}/index.php/apps/etherpad_nextcloud/api/v1/pads/open`,
-			{
-				headers: { Authorization: basicAuthHeader(), 'OCS-APIRequest': 'true', Accept: 'application/json' },
-				form: { file: `/${padName}` },
-			},
-		)
-		expect(opened.status(), await opened.text()).toBe(200)
+			const setCookie = opened.headersArray()
+				.filter((h) => h.name.toLowerCase() === 'set-cookie')
+				.map((h) => h.value)
+				.find((value) => value.startsWith('sessionID='))
+			expect(setCookie, 'a protected open should set the Etherpad session cookie').toBeDefined()
 
-		const setCookie = opened.headersArray()
-			.filter((h) => h.name.toLowerCase() === 'set-cookie')
-			.map((h) => h.value)
-			.find((value) => value.startsWith('sessionID='))
-		expect(setCookie, 'a protected open should set the Etherpad session cookie').toBeDefined()
+			// Secure and SameSite=None hold either way: the cookie has to reach
+			// a pad server on another host.
+			expect(setCookie).toContain('Secure')
+			expect(setCookie).toContain('SameSite=None')
 
-		// Secure and SameSite=None hold either way: the cookie has to reach a
-		// pad server on another host.
-		expect(setCookie).toContain('Secure')
-		expect(setCookie).toContain('SameSite=None')
-
-		if (readsItServerSide) {
-			expect(setCookie, `Etherpad ${release} reads the session server-side`).toContain('HttpOnly')
-		} else {
-			expect(setCookie, `Etherpad ${release} reads the session in the browser`).not.toContain('HttpOnly')
+			if (readsItServerSide) {
+				expect(setCookie, `Etherpad ${release} reads the session server-side`).toContain('HttpOnly')
+			} else {
+				expect(setCookie, `Etherpad ${release} reads the session in the browser`).not.toContain('HttpOnly')
+			}
+		} finally {
+			await api.dispose()
 		}
-
-		await api.dispose()
 	})
 })

--- a/tests/e2e/specs/protected-session-cookie-httponly.spec.ts
+++ b/tests/e2e/specs/protected-session-cookie-httponly.spec.ts
@@ -16,8 +16,14 @@ import { uniquePadName } from '../fixtures/nextcloud'
  *
  * The app asks `/health` which one it is talking to. This spec asks the
  * same question and holds the answer against the cookie that actually
- * goes out, so one spec is right on both halves of the matrix — and the
- * protected specs running beside it are what prove the pads still open.
+ * goes out, so one spec is right on both halves of the matrix.
+ *
+ * What the flag being wrong actually costs is measured elsewhere:
+ * `pad-author-display-name` drives Etherpad's own toolbar two frames
+ * deep, and with `HttpOnly` forced on 2.7.3 the pad app never becomes
+ * usable. The other `protected-*` specs cannot see that — they work at
+ * request level, where nothing ever needs to read the cookie from
+ * JavaScript, and they pass either way.
  */
 test.describe('the session cookie and the Etherpad that reads it', () => {
 	const padName = uniquePadName('httponly')

--- a/tests/e2e/specs/protected-session-cookie-httponly.spec.ts
+++ b/tests/e2e/specs/protected-session-cookie-httponly.spec.ts
@@ -8,33 +8,20 @@ import { basicAuthHeader, createPadAtPath, deleteViaDav } from '../fixtures/dav'
 import { uniquePadName } from '../fixtures/nextcloud'
 
 /**
- * Up to Etherpad 2.7.3 the pad app reads `sessionID` itself, in the
- * browser, so the cookie has to stay script-readable — `HttpOnly` there is
- * not a hardening but a lockout from every protected pad. From 3.0.0 the
- * server takes the session id out of the socket.io handshake and nothing
- * on the page needs to see it.
+ * Holds the cookie that actually goes out against the release `/health`
+ * reports, so one spec is right on both halves of the matrix.
  *
- * The app asks `/health` which one it is talking to. This spec asks the
- * same question and holds the answer against the cookie that actually
- * goes out, so one spec is right on both halves of the matrix.
+ * The other `protected-*` specs cannot see this: they work at request
+ * level, where nothing needs to read the cookie from JavaScript, and pass
+ * either way. Which is why this one exists.
  *
- * What the flag being wrong actually costs is a property of Etherpad
- * rather than of this app, and it is measured by hand. The recipe, so it
- * is repeatable rather than remembered:
+ * What a wrong flag costs is a property of Etherpad, not of this app, and
+ * is measured by hand — on an Etherpad 2 stack the pad loads and never
+ * becomes usable:
  *
  *     occ config:app:set etherpad_nextcloud \
  *       etherpad_http_only_session_cookie --value=yes
  *     tests/e2e/docker/run-suite.sh pad-author-display-name
- *
- * On an Etherpad 2 stack that fails: the pad loads and never becomes
- * usable, because its pad app reads the cookie with `Cookies.get`. On
- * 3.0.0 and 3.3.3 it passes. `EP_VERSION` takes a full tag, so
- * `EP_VERSION=3.0.0 tests/e2e/docker/up.sh` reproduces the boundary
- * itself.
- *
- * The other `protected-*` specs cannot see any of this — they work at
- * request level, where nothing ever needs to read the cookie from
- * JavaScript, and they pass either way. Which is why this one exists.
  */
 test.describe('the session cookie and the Etherpad that reads it', () => {
 	const padName = uniquePadName('httponly')
@@ -55,12 +42,9 @@ test.describe('the session cookie and the Etherpad that reads it', () => {
 			expect(health.status()).toBe(200)
 			const release = String(((await health.json()) as { releaseId?: string }).releaseId ?? '')
 			expect(release, 'Etherpad /health should report a releaseId').toMatch(/^\d+\.\d+\.\d+/)
-			// The same rule the app applies — EtherpadReleasePolicy's
-			// HTTP_ONLY_SINCE_MAJOR — restated rather than imported, because
-			// a test that derives its expectation from the thing under test
-			// asserts nothing. It is the major rather than the full version
-			// exactly so it can be restated: PHP sorts `3.0.0-beta.1` below
-			// `3.0.0` while any reading of it here calls it a 3.
+			// EtherpadReleasePolicy's HTTP_ONLY_SINCE_MAJOR, restated rather
+			// than imported: a test that derives its expectation from the
+			// thing under test asserts nothing.
 			const readsItServerSide = Number(release.split('.')[0]) >= 3
 
 			await createPadAtPath(`/${padName}`, 'protected')
@@ -93,16 +77,9 @@ test.describe('the session cookie and the Etherpad that reads it', () => {
 
 			// An absent flag is the default, so on an Etherpad 2 target the
 			// branch above passes just as well when detection is broken end
-			// to end — /health blocked from inside the container, the policy
-			// throwing, the flag removed altogether. This spec asks from the
-			// runner's network; the app asks from inside, against its own
-			// configured api host.
-			//
-			// So make it say what it *stored*. The connection test reports
-			// the cached release — the one the open path above actually used
-			// to decide this cookie — so naming it is only possible if the
-			// whole path ran: probe from inside the container, parse, write,
-			// read back.
+			// to end. This spec asks /health from the runner's network; the
+			// app asks from inside the container. So make it say what it
+			// *stored* — only possible if that whole path ran.
 			const connectionTest = await api.post(
 				`${E2E.baseURL}/index.php/apps/etherpad_nextcloud/api/v1/admin/health`,
 				{
@@ -126,11 +103,9 @@ test.describe('the session cookie and the Etherpad that reads it', () => {
 				body.checks?.some((c) => c.id === 'session_cookie'),
 				'the connection test should report on the session cookie',
 			).toBe(true)
-			// The dedicated field, not the prose. The line has several
-			// passing shapes and one of them fills the release from the
-			// probe the connection test itself just made — which is exactly
-			// the state this is meant to rule out, so matching the sentence
-			// would pass with nothing cached at all.
+			// The dedicated field, not the prose: one of the line's passing
+			// shapes fills the release from the connection test's own probe,
+			// so matching the sentence would pass with nothing cached.
 			expect(
 				body.session_cookie_release,
 				'the app should have cached a release of its own while opening the pad',

--- a/tests/e2e/specs/protected-session-cookie-httponly.spec.ts
+++ b/tests/e2e/specs/protected-session-cookie-httponly.spec.ts
@@ -118,13 +118,23 @@ test.describe('the session cookie and the Etherpad that reads it', () => {
 				},
 			)
 			expect(connectionTest.status(), await connectionTest.text()).toBe(200)
-			const checks = ((await connectionTest.json()) as { checks?: Array<{ id: string, label: string, detail: string }> }).checks ?? []
-			const sessionCookie = checks.find((c) => c.id === 'session_cookie')
-			expect(sessionCookie, 'the connection test should report on the session cookie').toBeDefined()
+			const body = (await connectionTest.json()) as {
+				session_cookie_release?: string,
+				checks?: Array<{ id: string }>,
+			}
 			expect(
-				`${sessionCookie!.label} ${sessionCookie!.detail}`,
-				'the app should name the release it cached for itself when opening the pad',
-			).toContain(release)
+				body.checks?.some((c) => c.id === 'session_cookie'),
+				'the connection test should report on the session cookie',
+			).toBe(true)
+			// The dedicated field, not the prose. The line has several
+			// passing shapes and one of them fills the release from the
+			// probe the connection test itself just made — which is exactly
+			// the state this is meant to rule out, so matching the sentence
+			// would pass with nothing cached at all.
+			expect(
+				body.session_cookie_release,
+				'the app should have cached a release of its own while opening the pad',
+			).toBe(release)
 		} finally {
 			await api.dispose()
 		}

--- a/tests/e2e/specs/protected-session-cookie-httponly.spec.ts
+++ b/tests/e2e/specs/protected-session-cookie-httponly.spec.ts
@@ -1,0 +1,73 @@
+/**
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * Copyright (c) 2026 Jacob Bühler
+ */
+import { test, expect, request as playwrightRequest } from '@playwright/test'
+import { E2E } from '../fixtures/env'
+import { basicAuthHeader, createPadAtPath, deleteViaDav } from '../fixtures/dav'
+import { uniquePadName } from '../fixtures/nextcloud'
+
+/**
+ * Up to Etherpad 2.7.3 the pad app reads `sessionID` itself, in the
+ * browser, so the cookie has to stay script-readable — `HttpOnly` there is
+ * not a hardening but a lockout from every protected pad. From 3.0.0 the
+ * server takes the session id out of the socket.io handshake and nothing
+ * on the page needs to see it.
+ *
+ * The app asks `/health` which one it is talking to. This spec asks the
+ * same question and holds the answer against the cookie that actually
+ * goes out, so one spec is right on both halves of the matrix — and the
+ * protected specs running beside it are what prove the pads still open.
+ */
+test.describe('the session cookie and the Etherpad that reads it', () => {
+	const padName = uniquePadName('httponly')
+
+	test.afterAll(async () => {
+		await deleteViaDav(padName).catch(() => {})
+	})
+
+	test('is kept from scripts exactly where Etherpad reads it server-side', async () => {
+		const etherpad = E2E.etherpadApi
+		test.skip(etherpad === null, 'E2E_ETHERPAD_URL / E2E_ETHERPAD_API_KEY not configured; Etherpad-side spec skipped.')
+
+		// `storageState` is inherited from the project inside a test, and a
+		// browser session here would authenticate as somebody else.
+		const api = await playwrightRequest.newContext({ storageState: { cookies: [], origins: [] } })
+
+		const health = await api.get(`${etherpad!.url}/health`)
+		expect(health.status()).toBe(200)
+		const release = String(((await health.json()) as { releaseId?: string }).releaseId ?? '')
+		expect(release, 'Etherpad /health should report a releaseId').toMatch(/^\d+\.\d+\.\d+/)
+		const readsItServerSide = Number(release.split('.')[0]) >= 3
+
+		await createPadAtPath(`/${padName}`, 'protected')
+
+		const opened = await api.post(
+			`${E2E.baseURL}/index.php/apps/etherpad_nextcloud/api/v1/pads/open`,
+			{
+				headers: { Authorization: basicAuthHeader(), 'OCS-APIRequest': 'true', Accept: 'application/json' },
+				form: { file: `/${padName}` },
+			},
+		)
+		expect(opened.status(), await opened.text()).toBe(200)
+
+		const setCookie = opened.headersArray()
+			.filter((h) => h.name.toLowerCase() === 'set-cookie')
+			.map((h) => h.value)
+			.find((value) => value.startsWith('sessionID='))
+		expect(setCookie, 'a protected open should set the Etherpad session cookie').toBeDefined()
+
+		// Secure and SameSite=None hold either way: the cookie has to reach a
+		// pad server on another host.
+		expect(setCookie).toContain('Secure')
+		expect(setCookie).toContain('SameSite=None')
+
+		if (readsItServerSide) {
+			expect(setCookie, `Etherpad ${release} reads the session server-side`).toContain('HttpOnly')
+		} else {
+			expect(setCookie, `Etherpad ${release} reads the session in the browser`).not.toContain('HttpOnly')
+		}
+
+		await api.dispose()
+	})
+})

--- a/tests/integration/e2e-protected-cookie-contract.sh
+++ b/tests/integration/e2e-protected-cookie-contract.sh
@@ -140,6 +140,10 @@ assert_cookie_contains "$SESSION_COOKIE_LINE" "secure" "Secure"
 assert_cookie_contains "$SESSION_COOKIE_LINE" "samesite=none" "SameSite=None"
 
 # HttpOnly is not a constant of this contract, it depends on the pad server.
+# The major-3 boundary below restates EtherpadReleasePolicy's
+# HTTP_ONLY_SINCE_MAJOR rather than importing it — a check that asked the app
+# what to expect would assert nothing. Moving the boundary means moving it
+# here, in the Playwright spec, and in docs/etherpad-integration.md.
 # Up to Etherpad 2.7.3 the pad app reads sessionID in the browser, so the
 # cookie has to stay script-readable; from 3.0.0 the server takes it out of
 # the socket.io handshake. Asking /health is how the app decides, so it is

--- a/tests/integration/e2e-protected-cookie-contract.sh
+++ b/tests/integration/e2e-protected-cookie-contract.sh
@@ -138,7 +138,29 @@ SESSION_COOKIE_LINE="$(printf '%s\n' "$SESSION_COOKIE_LINES" | sed -n '1p')"
 
 assert_cookie_contains "$SESSION_COOKIE_LINE" "secure" "Secure"
 assert_cookie_contains "$SESSION_COOKIE_LINE" "samesite=none" "SameSite=None"
-assert_cookie_not_contains "$SESSION_COOKIE_LINE" "httponly" "HttpOnly"
+
+# HttpOnly is not a constant of this contract, it depends on the pad server.
+# Up to Etherpad 2.7.3 the pad app reads sessionID in the browser, so the
+# cookie has to stay script-readable; from 3.0.0 the server takes it out of
+# the socket.io handshake. Asking /health is how the app decides, so it is
+# how this checks. No api key needed for it.
+PAD_URL="$(json_field "$OPEN_JSON" "pad_url" || true)"
+EP_ORIGIN="$(printf '%s' "$PAD_URL" | sed -n 's#^\(https\{0,1\}://[^/]*\).*#\1#p')"
+EP_RELEASE=""
+if [[ -n "$EP_ORIGIN" ]]; then
+	EP_RELEASE="$(curl -fsS --max-time 10 "${EP_ORIGIN}/health" 2>/dev/null \
+		| sed -n 's/.*"releaseId"[[:space:]]*:[[:space:]]*"\([0-9][0-9.]*\).*/\1/p' || true)"
+fi
+
+if [[ -z "$EP_RELEASE" ]]; then
+	# Not a failure: the pad server may be unreachable from here even though
+	# Nextcloud can reach it. Say so rather than asserting the wrong half.
+	echo "  note: could not read the Etherpad release from ${EP_ORIGIN:-<unknown>}/health; skipping the HttpOnly assertion" >&2
+elif [[ "${EP_RELEASE%%.*}" -ge 3 ]]; then
+	assert_cookie_contains "$SESSION_COOKIE_LINE" "httponly" "HttpOnly (Etherpad ${EP_RELEASE} reads the session server-side)"
+else
+	assert_cookie_not_contains "$SESSION_COOKIE_LINE" "httponly" "HttpOnly (Etherpad ${EP_RELEASE} reads the session in the browser)"
+fi
 
 echo "[3/4] CLEANUP trash ${INPUT_PATH}"
 TRASH_RES="$(nc_request_with_code POST "$API_BASE/trash" --data-urlencode "file=${INPUT_PATH}")"

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -22,6 +22,7 @@ $stubFiles = [
 	__DIR__ . '/stubs/OCP/AppFramework/Http/Attribute/PublicPage.php',
 	__DIR__ . '/stubs/OCP/AppFramework/Utility/ITimeFactory.php',
 	__DIR__ . '/stubs/OCP/ICache.php',
+	__DIR__ . '/stubs/OCP/IMemcache.php',
 	__DIR__ . '/stubs/OCP/ICacheFactory.php',
 	__DIR__ . '/stubs/OCP/BackgroundJob/TimedJob.php',
 	__DIR__ . '/stubs/OC/Security/CSRF/CsrfToken.php',

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -21,6 +21,8 @@ $stubFiles = [
 	__DIR__ . '/stubs/OCP/AppFramework/Http/Attribute/NoCSRFRequired.php',
 	__DIR__ . '/stubs/OCP/AppFramework/Http/Attribute/PublicPage.php',
 	__DIR__ . '/stubs/OCP/AppFramework/Utility/ITimeFactory.php',
+	__DIR__ . '/stubs/OCP/ICache.php',
+	__DIR__ . '/stubs/OCP/ICacheFactory.php',
 	__DIR__ . '/stubs/OCP/BackgroundJob/TimedJob.php',
 	__DIR__ . '/stubs/OC/Security/CSRF/CsrfToken.php',
 	__DIR__ . '/stubs/OC/Security/CSRF/CsrfTokenManager.php',

--- a/tests/phpunit/stubs/OCP/ICache.php
+++ b/tests/phpunit/stubs/OCP/ICache.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace OCP;
 
+/**
+ * Mirrors vendor/nextcloud/ocp/OCP/ICache.php. Deliberately without `add()`:
+ * that one lives on IMemcache, and a stub that lends it to ICache would hide
+ * exactly the type error Psalm is there to find.
+ */
 if (!interface_exists(ICache::class)) {
 	interface ICache {
 		public function get(string $key): mixed;
@@ -15,8 +20,5 @@ if (!interface_exists(ICache::class)) {
 		public function remove(string $key): bool;
 
 		public function clear(string $prefix = ''): bool;
-
-		/** Set a value only if the key is not taken. Atomic where the backend allows it. */
-		public function add(string $key, mixed $value, int $ttl = 0): bool;
 	}
 }

--- a/tests/phpunit/stubs/OCP/ICache.php
+++ b/tests/phpunit/stubs/OCP/ICache.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCP;
+
+if (!interface_exists(ICache::class)) {
+	interface ICache {
+		public function get(string $key): mixed;
+
+		public function set(string $key, mixed $value, int $ttl = 0): bool;
+
+		public function hasKey(string $key): bool;
+
+		public function remove(string $key): bool;
+
+		public function clear(string $prefix = ''): bool;
+
+		/** Set a value only if the key is not taken. Atomic where the backend allows it. */
+		public function add(string $key, mixed $value, int $ttl = 0): bool;
+	}
+}

--- a/tests/phpunit/stubs/OCP/ICacheFactory.php
+++ b/tests/phpunit/stubs/OCP/ICacheFactory.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCP;
+
+if (!interface_exists(ICacheFactory::class)) {
+	interface ICacheFactory {
+		/** Whether a memory cache is configured at all. */
+		public function isAvailable(): bool;
+
+		public function createDistributed(string $prefix = ''): ICache;
+
+		public function createLocal(string $prefix = ''): ICache;
+	}
+}

--- a/tests/phpunit/stubs/OCP/IMemcache.php
+++ b/tests/phpunit/stubs/OCP/IMemcache.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCP;
+
+if (!interface_exists(IMemcache::class)) {
+	interface IMemcache extends ICache {
+		/** Set a value only if the key is not taken. Atomic. */
+		public function add(string $key, mixed $value, int $ttl = 0): bool;
+
+		public function inc(string $key, int $step = 1): int|bool;
+
+		public function dec(string $key, int $step = 1): int|bool;
+
+		public function cas(string $key, mixed $old, mixed $new): bool;
+
+		public function cad(string $key, mixed $old): bool;
+	}
+}

--- a/tests/phpunit/unit/AdminControllerTest.php
+++ b/tests/phpunit/unit/AdminControllerTest.php
@@ -107,6 +107,7 @@ class AdminControllerTest extends TestCase {
 				123,
 				'https://pad-api.internal/api/1.3.0/listAllPads',
 				3,
+				'3.3.3',
 				new CookieDomainDecision(
 					'.example.tests',
 					CookieDomainDecision::STATUS_WARNING,
@@ -128,6 +129,9 @@ class AdminControllerTest extends TestCase {
 		$this->assertTrue((bool)$data['ok']);
 		$this->assertSame(72, $data['pad_count']);
 		$this->assertSame(3, $data['pending_delete_count']);
+		// The release the open path is going by, machine-readable, because
+		// it can differ from whatever this check just probed.
+		$this->assertSame('3.3.3', $data['session_cookie_release']);
 		$this->assertArrayNotHasKey('trashed_without_file_count', $data);
 		$this->assertSame('https://pad-api.internal/api/1.3.0/listAllPads', $data['target']);
 		// A protected-pads problem is reported beside the result, not as a

--- a/tests/phpunit/unit/EtherpadClientTest.php
+++ b/tests/phpunit/unit/EtherpadClientTest.php
@@ -224,6 +224,11 @@ class EtherpadClientTest extends TestCase {
 			'releaseId is empty' => ['{"status":"pass","releaseId":""}'],
 			'releaseId is not a version' => ['{"status":"pass","releaseId":"latest"}'],
 			'not an object' => ['[]'],
+			// The one an unanchored prefix match lets through. This is
+			// written to app config, read on every protected open and
+			// rendered to an admin.
+			'a version and then a megabyte' => ['{"status":"pass","releaseId":"3.3.3' . str_repeat('x', 1024) . '"}'],
+			'a version and then prose' => ['{"status":"pass","releaseId":"3.3.3 (nightly build of something)"}'],
 		];
 	}
 

--- a/tests/phpunit/unit/EtherpadClientTest.php
+++ b/tests/phpunit/unit/EtherpadClientTest.php
@@ -179,6 +179,23 @@ class EtherpadClientTest extends TestCase {
 		self::assertSame('GET', $captured['method']);
 		self::assertStringEndsWith('/health', (string)$captured['url']);
 		self::assertStringNotContainsString('apikey', (string)$captured['url']);
+		// Asked on the open path, and nothing depends on the answer, so a pad
+		// server that accepts the connection and then says nothing must not
+		// hold an open for the full request timeout.
+		self::assertSame(3, $captured['options']['timeout']);
+	}
+
+	/** The calls that do matter keep the full patience. */
+	public function testApiCallsKeepTheFullRequestTimeout(): void {
+		$captured = null;
+		$client = $this->clientWithResponse(
+			$this->response(200, '{"code":0,"data":{"groupID":"g.aaa"}}'),
+			$captured,
+		);
+
+		$client->createGroup();
+
+		self::assertSame(15, $captured['options']['timeout']);
 	}
 
 	public function testDetectsAReleaseWithASuffix(): void {

--- a/tests/phpunit/unit/EtherpadClientTest.php
+++ b/tests/phpunit/unit/EtherpadClientTest.php
@@ -175,7 +175,7 @@ class EtherpadClientTest extends TestCase {
 			$captured,
 		);
 
-		self::assertSame('3.3.3', $client->detectReleaseVersion());
+		self::assertSame('3.3.3', $client->detectReleaseVersion('https://pad.example.test'));
 		self::assertSame('GET', $captured['method']);
 		self::assertStringEndsWith('/health', (string)$captured['url']);
 		self::assertStringNotContainsString('apikey', (string)$captured['url']);
@@ -200,7 +200,7 @@ class EtherpadClientTest extends TestCase {
 
 	public function testDetectsAReleaseWithASuffix(): void {
 		$client = $this->clientWithResponse($this->response(200, '{"status":"pass","releaseId":"3.0.0-beta.1"}'));
-		self::assertSame('3.0.0-beta.1', $client->detectReleaseVersion());
+		self::assertSame('3.0.0-beta.1', $client->detectReleaseVersion('https://pad.example.test'));
 	}
 
 	/**
@@ -213,7 +213,7 @@ class EtherpadClientTest extends TestCase {
 	public function testRefusesAHealthAnswerItCannotRead(string $payload): void {
 		$client = $this->clientWithResponse($this->response(200, $payload));
 		$this->expectException(EtherpadClientException::class);
-		$client->detectReleaseVersion();
+		$client->detectReleaseVersion('https://pad.example.test');
 	}
 
 	/** @return array<string,array{string}> */

--- a/tests/phpunit/unit/EtherpadClientTest.php
+++ b/tests/phpunit/unit/EtherpadClientTest.php
@@ -163,6 +163,53 @@ class EtherpadClientTest extends TestCase {
 		];
 	}
 
+	/**
+	 * Measured: `/api` answers `{"currentVersion":"1.3.1"}` on both Etherpad
+	 * 2.7.3 and 3.3.3, so the API version cannot tell the two apart.
+	 * `/health` reports the release, and it needs no api key.
+	 */
+	public function testDetectsTheReleaseFromHealth(): void {
+		$captured = null;
+		$client = $this->clientWithResponse(
+			$this->response(200, '{"status":"pass","releaseId":"3.3.3"}'),
+			$captured,
+		);
+
+		self::assertSame('3.3.3', $client->detectReleaseVersion());
+		self::assertSame('GET', $captured['method']);
+		self::assertStringEndsWith('/health', (string)$captured['url']);
+		self::assertStringNotContainsString('apikey', (string)$captured['url']);
+	}
+
+	public function testDetectsAReleaseWithASuffix(): void {
+		$client = $this->clientWithResponse($this->response(200, '{"status":"pass","releaseId":"3.0.0-beta.1"}'));
+		self::assertSame('3.0.0-beta.1', $client->detectReleaseVersion());
+	}
+
+	/**
+	 * Refuses rather than guessing. The caller falls back to the last known
+	 * release, and without one to a cookie the browser can read.
+	 *
+	 * @param string $payload
+	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('provideUnreadableHealthAnswers')]
+	public function testRefusesAHealthAnswerItCannotRead(string $payload): void {
+		$client = $this->clientWithResponse($this->response(200, $payload));
+		$this->expectException(EtherpadClientException::class);
+		$client->detectReleaseVersion();
+	}
+
+	/** @return array<string,array{string}> */
+	public static function provideUnreadableHealthAnswers(): array {
+		return [
+			'no releaseId' => ['{"status":"pass"}'],
+			'releaseId is not a string' => ['{"status":"pass","releaseId":3}'],
+			'releaseId is empty' => ['{"status":"pass","releaseId":""}'],
+			'releaseId is not a version' => ['{"status":"pass","releaseId":"latest"}'],
+			'not an object' => ['[]'],
+		];
+	}
+
 	public function testApiCallThrowsOnNonZeroApiCode(): void {
 		$client = $this->clientWithResponse(
 			$this->response(200, '{"code":1,"message":"groupID does not exist"}')

--- a/tests/phpunit/unit/EtherpadHealthCheckServiceTest.php
+++ b/tests/phpunit/unit/EtherpadHealthCheckServiceTest.php
@@ -95,7 +95,7 @@ class EtherpadHealthCheckServiceTest extends TestCase {
 		}
 		// The protected-pads line is appended by the controller from
 		// $cookieDomain, so summary and payload cannot disagree about it.
-		$this->assertSame(['api', 'api_key', 'base_url'], array_keys($byId));
+		$this->assertSame(['api', 'api_key', 'base_url', 'session_cookie'], array_keys($byId));
 		$this->assertSame(HealthCheckItem::STATUS_OK, $byId['api']->status);
 	}
 
@@ -104,9 +104,16 @@ class EtherpadHealthCheckServiceTest extends TestCase {
 		EtherpadClient $etherpad,
 		PendingDeleteRetryService $pending,
 		string $nextcloudUrl = 'https://cloud.example.test',
+		string $httpOnlyOverride = 'auto',
 	): EtherpadHealthCheckService {
 		$urlGenerator = $this->createMock(IURLGenerator::class);
 		$urlGenerator->method('getBaseUrl')->willReturn($nextcloudUrl);
+		$config = $this->createMock(\OCP\IConfig::class);
+		$config->method('getAppValue')->willReturnCallback(
+			static fn (string $app, string $key, string $default = ''): string => $key === \OCA\EtherpadNextcloud\Service\EtherpadReleasePolicy::OVERRIDE_KEY
+				? $httpOnlyOverride
+				: $default
+		);
 		return new EtherpadHealthCheckService(
 			$etherpad,
 			$pending,
@@ -114,7 +121,70 @@ class EtherpadHealthCheckServiceTest extends TestCase {
 			new CookieDomainPolicy(),
 			$this->baseUrlCheck(),
 			$urlGenerator,
+			$config,
 		);
+	}
+
+	/**
+	 * The release decides whether the session cookie may be kept from
+	 * JavaScript, it is discovered rather than configured, and it lives in
+	 * an app value with no field of its own. Without a line here, a wrong
+	 * answer shows up only as "no protected pad opens".
+	 */
+	private function sessionCookieLine(EtherpadClient $etherpad, string $override = 'auto'): HealthCheckItem {
+		$result = $this->buildService($etherpad, $this->pendingCounts(0), httpOnlyOverride: $override)
+			->check($this->settings());
+		foreach ($result->checks as $item) {
+			if ($item->id === 'session_cookie') {
+				return $item;
+			}
+		}
+		self::fail('no session_cookie line in the health check');
+	}
+
+	public function testSessionCookieLineNamesTheReleaseThatAllowsHttpOnly(): void {
+		$etherpad = $this->createMock(EtherpadClient::class);
+		$etherpad->method('healthCheck')->willReturn(['pad_count' => 1]);
+		$etherpad->method('detectReleaseVersion')->willReturn('3.3.3');
+
+		$line = $this->sessionCookieLine($etherpad);
+		self::assertSame(HealthCheckItem::STATUS_OK, $line->status);
+		self::assertStringContainsString('3.3.3', $line->detail);
+		self::assertStringContainsString('HttpOnly', $line->detail);
+	}
+
+	public function testSessionCookieLineNamesTheReleaseThatNeedsAReadableCookie(): void {
+		$etherpad = $this->createMock(EtherpadClient::class);
+		$etherpad->method('healthCheck')->willReturn(['pad_count' => 1]);
+		$etherpad->method('detectReleaseVersion')->willReturn('2.7.3');
+
+		$line = $this->sessionCookieLine($etherpad);
+		self::assertSame(HealthCheckItem::STATUS_OK, $line->status);
+		self::assertStringContainsString('2.7.3', $line->detail);
+		self::assertStringContainsString('readable', $line->detail);
+	}
+
+	/** The case with no other signal at all: /health unreachable. */
+	public function testSessionCookieLineWarnsWhenTheReleaseCannotBeRead(): void {
+		$etherpad = $this->createMock(EtherpadClient::class);
+		$etherpad->method('healthCheck')->willReturn(['pad_count' => 1]);
+		$etherpad->method('detectReleaseVersion')
+			->willThrowException(new EtherpadClientException('Connection timed out'));
+
+		$line = $this->sessionCookieLine($etherpad);
+		self::assertSame(HealthCheckItem::STATUS_WARNING, $line->status);
+		self::assertSame('etherpad_api_host', $line->field);
+	}
+
+	/** A hand-set flag is worth saying out loud, especially the risky one. */
+	public function testSessionCookieLineSaysWhenTheFlagWasSetByHand(): void {
+		$etherpad = $this->createMock(EtherpadClient::class);
+		$etherpad->method('healthCheck')->willReturn(['pad_count' => 1]);
+		$etherpad->expects(self::never())->method('detectReleaseVersion');
+
+		$line = $this->sessionCookieLine($etherpad, 'yes');
+		self::assertSame(HealthCheckItem::STATUS_WARNING, $line->status);
+		self::assertStringContainsString('by hand', $line->detail);
 	}
 
 	/**
@@ -159,6 +229,7 @@ class EtherpadHealthCheckServiceTest extends TestCase {
 			new CookieDomainPolicy(),
 			$this->baseUrlCheck(),
 			$urlGenerator,
+			$this->createMock(\OCP\IConfig::class),
 			$ticks,
 		) extends EtherpadHealthCheckService {
 			/** @param list<float> $ticks */
@@ -169,9 +240,10 @@ class EtherpadHealthCheckServiceTest extends TestCase {
 				CookieDomainPolicy $cookieDomainPolicy,
 				BaseUrlReachabilityCheck $baseUrlCheck,
 				IURLGenerator $urlGenerator,
+				\OCP\IConfig $config,
 				private array $ticks,
 			) {
-				parent::__construct($etherpadClient, $pendingDeleteRetryService, $l10n, $cookieDomainPolicy, $baseUrlCheck, $urlGenerator);
+				parent::__construct($etherpadClient, $pendingDeleteRetryService, $l10n, $cookieDomainPolicy, $baseUrlCheck, $urlGenerator, $config);
 			}
 
 			protected function now(): float {

--- a/tests/phpunit/unit/EtherpadHealthCheckServiceTest.php
+++ b/tests/phpunit/unit/EtherpadHealthCheckServiceTest.php
@@ -105,7 +105,8 @@ class EtherpadHealthCheckServiceTest extends TestCase {
 		PendingDeleteRetryService $pending,
 		string $nextcloudUrl = 'https://cloud.example.test',
 		string $httpOnlyOverride = 'auto',
-		?bool $cookieIsHttpOnly = null,
+		string $knownRelease = '',
+		string $unrecognisedOverride = '',
 	): EtherpadHealthCheckService {
 		$urlGenerator = $this->createMock(IURLGenerator::class);
 		$urlGenerator->method('getBaseUrl')->willReturn($nextcloudUrl);
@@ -113,9 +114,12 @@ class EtherpadHealthCheckServiceTest extends TestCase {
 		// It answers from a cache, so it can disagree with the server.
 		$releasePolicy = $this->createMock(\OCA\EtherpadNextcloud\Service\EtherpadReleasePolicy::class);
 		$releasePolicy->method('overrideMode')->willReturn($httpOnlyOverride);
-		$releasePolicy->method('supportsHttpOnlySessionCookie')->willReturn(
-			$cookieIsHttpOnly ?? ($httpOnlyOverride === 'yes')
-		);
+		$releasePolicy->method('unrecognisedOverride')->willReturn($unrecognisedOverride);
+		// Read, never resolved: resolving would refresh the cache against
+		// the stored host and write to app config from a form that may not
+		// be saved.
+		$releasePolicy->expects(self::never())->method('supportsHttpOnlySessionCookie');
+		$releasePolicy->method('knownRelease')->willReturn($knownRelease);
 		return new EtherpadHealthCheckService(
 			$etherpad,
 			$pending,
@@ -136,13 +140,15 @@ class EtherpadHealthCheckServiceTest extends TestCase {
 	private function sessionCookieLine(
 		EtherpadClient $etherpad,
 		string $override = 'auto',
-		?bool $cookieIsHttpOnly = null,
+		string $knownRelease = '',
+		string $unrecognisedOverride = '',
 	): HealthCheckItem {
 		$result = $this->buildService(
 			$etherpad,
 			$this->pendingCounts(0),
 			httpOnlyOverride: $override,
-			cookieIsHttpOnly: $cookieIsHttpOnly,
+			knownRelease: $knownRelease,
+			unrecognisedOverride: $unrecognisedOverride,
 		)->check($this->settings());
 		foreach ($result->checks as $item) {
 			if ($item->id === 'session_cookie') {
@@ -157,7 +163,7 @@ class EtherpadHealthCheckServiceTest extends TestCase {
 		$etherpad->method('healthCheck')->willReturn(['pad_count' => 1]);
 		$etherpad->method('detectReleaseVersion')->willReturn('3.3.3');
 
-		$line = $this->sessionCookieLine($etherpad, cookieIsHttpOnly: true);
+		$line = $this->sessionCookieLine($etherpad, knownRelease: '3.3.3');
 		self::assertSame(HealthCheckItem::STATUS_OK, $line->status);
 		// The label, not the detail: the admin panel shows only the label
 		// for a passing line, so that is where the release has to be.
@@ -170,7 +176,7 @@ class EtherpadHealthCheckServiceTest extends TestCase {
 		$etherpad->method('healthCheck')->willReturn(['pad_count' => 1]);
 		$etherpad->method('detectReleaseVersion')->willReturn('2.7.3');
 
-		$line = $this->sessionCookieLine($etherpad, cookieIsHttpOnly: false);
+		$line = $this->sessionCookieLine($etherpad, knownRelease: '2.7.3');
 		self::assertSame(HealthCheckItem::STATUS_OK, $line->status);
 		self::assertStringContainsString('2.7.3', $line->label);
 		self::assertStringContainsString('readable', $line->label);
@@ -188,9 +194,10 @@ class EtherpadHealthCheckServiceTest extends TestCase {
 		$etherpad->method('healthCheck')->willReturn(['pad_count' => 1]);
 		$etherpad->method('detectReleaseVersion')->willReturn('2.7.3');
 
-		$line = $this->sessionCookieLine($etherpad, cookieIsHttpOnly: true);
+		$line = $this->sessionCookieLine($etherpad, knownRelease: '3.3.3');
 		self::assertSame(HealthCheckItem::STATUS_WARNING, $line->status);
 		self::assertStringContainsString('2.7.3', $line->detail);
+		self::assertStringContainsString('3.3.3', $line->detail);
 	}
 
 	/** The admin test is as patient as the calls beside it. */
@@ -202,11 +209,11 @@ class EtherpadHealthCheckServiceTest extends TestCase {
 			->with(self::anything(), EtherpadClient::REQUEST_TIMEOUT_SECONDS)
 			->willReturn('3.3.3');
 
-		self::assertSame(HealthCheckItem::STATUS_OK, $this->sessionCookieLine($etherpad, cookieIsHttpOnly: true)->status);
+		self::assertSame(HealthCheckItem::STATUS_OK, $this->sessionCookieLine($etherpad, knownRelease: '3.3.3')->status);
 	}
 
 	/** The case with no other signal at all: /health unreachable. */
-	public function testSessionCookieLineWarnsWhenTheReleaseCannotBeRead(): void {
+	public function testSessionCookieLineIsSkippedWhenTheReleaseCannotBeRead(): void {
 		$etherpad = $this->createMock(EtherpadClient::class);
 		$etherpad->method('healthCheck')->willReturn(['pad_count' => 1]);
 		$etherpad->method('detectReleaseVersion')
@@ -218,31 +225,11 @@ class EtherpadHealthCheckServiceTest extends TestCase {
 		// a hardening.
 		$line = $this->sessionCookieLine($etherpad);
 		self::assertSame(HealthCheckItem::STATUS_SKIPPED, $line->status);
-		// The field the rest of this class derives, so the line lands on
-		// whichever input actually supplied the address — here a separate
-		// API URL is configured.
-		self::assertSame('etherpad_api_host', $line->field);
-	}
-
-	/**
-	 * And with no separate API URL, on the field the admin actually filled
-	 * in. A hardcoded 'etherpad_api_host' would point them at an empty box.
-	 */
-	public function testSessionCookieLineFollowsTheFieldThatSuppliedTheAddress(): void {
-		$etherpad = $this->createMock(EtherpadClient::class);
-		$etherpad->method('healthCheck')->willReturn(['pad_count' => 1]);
-		$etherpad->method('detectReleaseVersion')
-			->willThrowException(new EtherpadClientException('Connection timed out'));
-
-		$result = $this->buildService($etherpad, $this->pendingCounts(0))
-			->check($this->settingsWithoutSeparateApiHost());
-		foreach ($result->checks as $item) {
-			if ($item->id === 'session_cookie') {
-				self::assertSame('etherpad_host', $item->field);
-				return;
-			}
-		}
-		self::fail('no session_cookie line in the health check');
+		// Its own slot. Sharing a field with the API lines means losing to
+		// them: the panel keeps the highest severity per field, and a
+		// passing `api` outranks a skip — so on the very deployment this
+		// branch describes, the line would render nowhere.
+		self::assertSame('etherpad_session_cookie', $line->field);
 	}
 
 	private function settingsWithoutSeparateApiHost(): ValidatedAdminSettings {
@@ -262,15 +249,49 @@ class EtherpadHealthCheckServiceTest extends TestCase {
 		);
 	}
 
-	/** A hand-set flag is worth saying out loud, especially the risky one. */
-	public function testSessionCookieLineSaysWhenTheFlagWasSetByHand(): void {
+	/**
+	 * The dangerous half of the override shouts, and says what the server
+	 * actually is so somebody who reached for it during an outage can see
+	 * whether they may put it back.
+	 */
+	public function testSessionCookieLineWarnsWhenHttpOnlyIsForcedOn(): void {
 		$etherpad = $this->createMock(EtherpadClient::class);
 		$etherpad->method('healthCheck')->willReturn(['pad_count' => 1]);
-		$etherpad->expects(self::never())->method('detectReleaseVersion');
+		$etherpad->method('detectReleaseVersion')->willReturn('2.7.3');
 
 		$line = $this->sessionCookieLine($etherpad, 'yes');
 		self::assertSame(HealthCheckItem::STATUS_WARNING, $line->status);
 		self::assertStringContainsString('by hand', $line->detail);
+		self::assertStringContainsString('2.7.3', $line->detail);
+	}
+
+	/**
+	 * The safe half does not. It gives up a hardening and is what this app
+	 * did before any of this — warning on it teaches an admin to ignore the
+	 * line that would have told them about the other one.
+	 */
+	public function testSessionCookieLineDoesNotWarnWhenHttpOnlyIsForcedOff(): void {
+		$etherpad = $this->createMock(EtherpadClient::class);
+		$etherpad->method('healthCheck')->willReturn(['pad_count' => 1]);
+		$etherpad->method('detectReleaseVersion')->willReturn('3.3.3');
+
+		$line = $this->sessionCookieLine($etherpad, 'no');
+		self::assertSame(HealthCheckItem::STATUS_OK, $line->status);
+		self::assertStringContainsString('3.3.3', $line->detail);
+	}
+
+	/**
+	 * `--value=true`, `--value=1`, `--value=off`: the words an admin reaches
+	 * for while pads are down. All of them silently mean auto, and the line
+	 * would otherwise confirm the automatic behaviour as fine.
+	 */
+	public function testSessionCookieLineNamesAnUnrecognisedOverride(): void {
+		$etherpad = $this->createMock(EtherpadClient::class);
+		$etherpad->method('healthCheck')->willReturn(['pad_count' => 1]);
+
+		$line = $this->sessionCookieLine($etherpad, unrecognisedOverride: 'true');
+		self::assertSame(HealthCheckItem::STATUS_WARNING, $line->status);
+		self::assertStringContainsString('true', $line->detail);
 	}
 
 	/**

--- a/tests/phpunit/unit/EtherpadHealthCheckServiceTest.php
+++ b/tests/phpunit/unit/EtherpadHealthCheckServiceTest.php
@@ -105,14 +105,16 @@ class EtherpadHealthCheckServiceTest extends TestCase {
 		PendingDeleteRetryService $pending,
 		string $nextcloudUrl = 'https://cloud.example.test',
 		string $httpOnlyOverride = 'auto',
+		?bool $cookieIsHttpOnly = null,
 	): EtherpadHealthCheckService {
 		$urlGenerator = $this->createMock(IURLGenerator::class);
 		$urlGenerator->method('getBaseUrl')->willReturn($nextcloudUrl);
-		$config = $this->createMock(\OCP\IConfig::class);
-		$config->method('getAppValue')->willReturnCallback(
-			static fn (string $app, string $key, string $default = ''): string => $key === \OCA\EtherpadNextcloud\Service\EtherpadReleasePolicy::OVERRIDE_KEY
-				? $httpOnlyOverride
-				: $default
+		// What the open path is doing, which is the thing this line reports.
+		// It answers from a cache, so it can disagree with the server.
+		$releasePolicy = $this->createMock(\OCA\EtherpadNextcloud\Service\EtherpadReleasePolicy::class);
+		$releasePolicy->method('overrideMode')->willReturn($httpOnlyOverride);
+		$releasePolicy->method('supportsHttpOnlySessionCookie')->willReturn(
+			$cookieIsHttpOnly ?? ($httpOnlyOverride === 'yes')
 		);
 		return new EtherpadHealthCheckService(
 			$etherpad,
@@ -121,7 +123,7 @@ class EtherpadHealthCheckServiceTest extends TestCase {
 			new CookieDomainPolicy(),
 			$this->baseUrlCheck(),
 			$urlGenerator,
-			$config,
+			$releasePolicy,
 		);
 	}
 
@@ -131,9 +133,17 @@ class EtherpadHealthCheckServiceTest extends TestCase {
 	 * an app value with no field of its own. Without a line here, a wrong
 	 * answer shows up only as "no protected pad opens".
 	 */
-	private function sessionCookieLine(EtherpadClient $etherpad, string $override = 'auto'): HealthCheckItem {
-		$result = $this->buildService($etherpad, $this->pendingCounts(0), httpOnlyOverride: $override)
-			->check($this->settings());
+	private function sessionCookieLine(
+		EtherpadClient $etherpad,
+		string $override = 'auto',
+		?bool $cookieIsHttpOnly = null,
+	): HealthCheckItem {
+		$result = $this->buildService(
+			$etherpad,
+			$this->pendingCounts(0),
+			httpOnlyOverride: $override,
+			cookieIsHttpOnly: $cookieIsHttpOnly,
+		)->check($this->settings());
 		foreach ($result->checks as $item) {
 			if ($item->id === 'session_cookie') {
 				return $item;
@@ -147,10 +157,12 @@ class EtherpadHealthCheckServiceTest extends TestCase {
 		$etherpad->method('healthCheck')->willReturn(['pad_count' => 1]);
 		$etherpad->method('detectReleaseVersion')->willReturn('3.3.3');
 
-		$line = $this->sessionCookieLine($etherpad);
+		$line = $this->sessionCookieLine($etherpad, cookieIsHttpOnly: true);
 		self::assertSame(HealthCheckItem::STATUS_OK, $line->status);
-		self::assertStringContainsString('3.3.3', $line->detail);
-		self::assertStringContainsString('HttpOnly', $line->detail);
+		// The label, not the detail: the admin panel shows only the label
+		// for a passing line, so that is where the release has to be.
+		self::assertStringContainsString('3.3.3', $line->label);
+		self::assertSame('etherpad_session_cookie', $line->field);
 	}
 
 	public function testSessionCookieLineNamesTheReleaseThatNeedsAReadableCookie(): void {
@@ -158,10 +170,39 @@ class EtherpadHealthCheckServiceTest extends TestCase {
 		$etherpad->method('healthCheck')->willReturn(['pad_count' => 1]);
 		$etherpad->method('detectReleaseVersion')->willReturn('2.7.3');
 
-		$line = $this->sessionCookieLine($etherpad);
+		$line = $this->sessionCookieLine($etherpad, cookieIsHttpOnly: false);
 		self::assertSame(HealthCheckItem::STATUS_OK, $line->status);
+		self::assertStringContainsString('2.7.3', $line->label);
+		self::assertStringContainsString('readable', $line->label);
+	}
+
+	/**
+	 * The moment this line exists for: the open path answers from a cached
+	 * release, so right after a downgrade it is still sending an HttpOnly
+	 * cookie to a pad server that cannot read it. Reporting what this host
+	 * says now, and calling it OK, would state the opposite of the lockout
+	 * the admin came here to explain.
+	 */
+	public function testSessionCookieLineWarnsWhenTheCookieDisagreesWithTheServer(): void {
+		$etherpad = $this->createMock(EtherpadClient::class);
+		$etherpad->method('healthCheck')->willReturn(['pad_count' => 1]);
+		$etherpad->method('detectReleaseVersion')->willReturn('2.7.3');
+
+		$line = $this->sessionCookieLine($etherpad, cookieIsHttpOnly: true);
+		self::assertSame(HealthCheckItem::STATUS_WARNING, $line->status);
 		self::assertStringContainsString('2.7.3', $line->detail);
-		self::assertStringContainsString('readable', $line->detail);
+	}
+
+	/** The admin test is as patient as the calls beside it. */
+	public function testSessionCookieLineGivesThePadServerTheFullTimeout(): void {
+		$etherpad = $this->createMock(EtherpadClient::class);
+		$etherpad->method('healthCheck')->willReturn(['pad_count' => 1]);
+		$etherpad->expects(self::once())
+			->method('detectReleaseVersion')
+			->with(self::anything(), EtherpadClient::REQUEST_TIMEOUT_SECONDS)
+			->willReturn('3.3.3');
+
+		self::assertSame(HealthCheckItem::STATUS_OK, $this->sessionCookieLine($etherpad, cookieIsHttpOnly: true)->status);
 	}
 
 	/** The case with no other signal at all: /health unreachable. */
@@ -171,9 +212,54 @@ class EtherpadHealthCheckServiceTest extends TestCase {
 		$etherpad->method('detectReleaseVersion')
 			->willThrowException(new EtherpadClientException('Connection timed out'));
 
+		// Not a warning: the cookie stays readable, which is what every
+		// Etherpad before 3.0 needs anyway. A pad server without /health, or
+		// a proxy that routes /api and not /health, works and merely misses
+		// a hardening.
 		$line = $this->sessionCookieLine($etherpad);
-		self::assertSame(HealthCheckItem::STATUS_WARNING, $line->status);
+		self::assertSame(HealthCheckItem::STATUS_SKIPPED, $line->status);
+		// The field the rest of this class derives, so the line lands on
+		// whichever input actually supplied the address — here a separate
+		// API URL is configured.
 		self::assertSame('etherpad_api_host', $line->field);
+	}
+
+	/**
+	 * And with no separate API URL, on the field the admin actually filled
+	 * in. A hardcoded 'etherpad_api_host' would point them at an empty box.
+	 */
+	public function testSessionCookieLineFollowsTheFieldThatSuppliedTheAddress(): void {
+		$etherpad = $this->createMock(EtherpadClient::class);
+		$etherpad->method('healthCheck')->willReturn(['pad_count' => 1]);
+		$etherpad->method('detectReleaseVersion')
+			->willThrowException(new EtherpadClientException('Connection timed out'));
+
+		$result = $this->buildService($etherpad, $this->pendingCounts(0))
+			->check($this->settingsWithoutSeparateApiHost());
+		foreach ($result->checks as $item) {
+			if ($item->id === 'session_cookie') {
+				self::assertSame('etherpad_host', $item->field);
+				return;
+			}
+		}
+		self::fail('no session_cookie line in the health check');
+	}
+
+	private function settingsWithoutSeparateApiHost(): ValidatedAdminSettings {
+		return new ValidatedAdminSettings(
+			'https://pad.example.test',
+			'https://pad.example.test',
+			'.example.test',
+			'key',
+			'key',
+			'1.3.0',
+			120,
+			true,
+			true,
+			'',
+			'',
+			true,
+		);
 	}
 
 	/** A hand-set flag is worth saying out loud, especially the risky one. */
@@ -229,7 +315,7 @@ class EtherpadHealthCheckServiceTest extends TestCase {
 			new CookieDomainPolicy(),
 			$this->baseUrlCheck(),
 			$urlGenerator,
-			$this->createMock(\OCP\IConfig::class),
+			$this->createMock(\OCA\EtherpadNextcloud\Service\EtherpadReleasePolicy::class),
 			$ticks,
 		) extends EtherpadHealthCheckService {
 			/** @param list<float> $ticks */
@@ -240,10 +326,10 @@ class EtherpadHealthCheckServiceTest extends TestCase {
 				CookieDomainPolicy $cookieDomainPolicy,
 				BaseUrlReachabilityCheck $baseUrlCheck,
 				IURLGenerator $urlGenerator,
-				\OCP\IConfig $config,
+				\OCA\EtherpadNextcloud\Service\EtherpadReleasePolicy $releasePolicy,
 				private array $ticks,
 			) {
-				parent::__construct($etherpadClient, $pendingDeleteRetryService, $l10n, $cookieDomainPolicy, $baseUrlCheck, $urlGenerator, $config);
+				parent::__construct($etherpadClient, $pendingDeleteRetryService, $l10n, $cookieDomainPolicy, $baseUrlCheck, $urlGenerator, $releasePolicy);
 			}
 
 			protected function now(): float {

--- a/tests/phpunit/unit/EtherpadHealthCheckServiceTest.php
+++ b/tests/phpunit/unit/EtherpadHealthCheckServiceTest.php
@@ -107,9 +107,14 @@ class EtherpadHealthCheckServiceTest extends TestCase {
 		string $httpOnlyOverride = 'auto',
 		string $knownRelease = '',
 		string $unrecognisedOverride = '',
+		string $configuredApiHost = 'https://pad-api.example.test',
 	): EtherpadHealthCheckService {
 		$urlGenerator = $this->createMock(IURLGenerator::class);
 		$urlGenerator->method('getBaseUrl')->willReturn($nextcloudUrl);
+		// The stored API host. The session-cookie line compares it with the
+		// submitted one, because a form being typed says nothing about what
+		// pads are doing right now.
+		$etherpad->method('getApiHost')->willReturn($configuredApiHost);
 		// What the open path is doing, which is the thing this line reports.
 		// It answers from a cache, so it can disagree with the server.
 		$releasePolicy = $this->createMock(\OCA\EtherpadNextcloud\Service\EtherpadReleasePolicy::class);
@@ -142,6 +147,7 @@ class EtherpadHealthCheckServiceTest extends TestCase {
 		string $override = 'auto',
 		string $knownRelease = '',
 		string $unrecognisedOverride = '',
+		string $configuredApiHost = 'https://pad-api.example.test',
 	): HealthCheckItem {
 		$result = $this->buildService(
 			$etherpad,
@@ -149,6 +155,7 @@ class EtherpadHealthCheckServiceTest extends TestCase {
 			httpOnlyOverride: $override,
 			knownRelease: $knownRelease,
 			unrecognisedOverride: $unrecognisedOverride,
+			configuredApiHost: $configuredApiHost,
 		)->check($this->settings());
 		foreach ($result->checks as $item) {
 			if ($item->id === 'session_cookie') {
@@ -247,6 +254,46 @@ class EtherpadHealthCheckServiceTest extends TestCase {
 			'',
 			true,
 		);
+	}
+
+	/**
+	 * Typing a new address and pressing Test is not a lockout. Pads are
+	 * still going to the saved server, and comparing a probe of the typed
+	 * address against what they are doing would read every planned
+	 * migration as one.
+	 */
+	public function testSessionCookieLineDoesNotCallAnUnsavedAddressALockout(): void {
+		$etherpad = $this->createMock(EtherpadClient::class);
+		$etherpad->method('healthCheck')->willReturn(['pad_count' => 1]);
+		$etherpad->method('detectReleaseVersion')->willReturn('2.7.3');
+
+		// Saved: a different server, which is still an Etherpad 3 as far as
+		// the open path is concerned.
+		$line = $this->sessionCookieLine(
+			$etherpad,
+			knownRelease: '3.3.3',
+			configuredApiHost: 'https://old-api.example.test',
+		);
+
+		self::assertSame(HealthCheckItem::STATUS_OK, $line->status);
+		self::assertStringContainsString('2.7.3', $line->label);
+		self::assertStringContainsString('save', $line->detail);
+	}
+
+	/**
+	 * DNS, a TLS mismatch, a 404 from a proxy that does not route /health
+	 * and proxy auth are four different fixes. A fixed sentence points at
+	 * none of them, and the class already knows this vocabulary.
+	 */
+	public function testSessionCookieLineCarriesTheReasonTheProbeFailed(): void {
+		$etherpad = $this->createMock(EtherpadClient::class);
+		$etherpad->method('healthCheck')->willReturn(['pad_count' => 1]);
+		$etherpad->method('detectReleaseVersion')
+			->willThrowException(new EtherpadClientException('cURL error 6: Could not resolve host: pad.example.test'));
+
+		$line = $this->sessionCookieLine($etherpad);
+		self::assertSame(HealthCheckItem::STATUS_SKIPPED, $line->status);
+		self::assertStringContainsString('Could not resolve host', $line->detail);
 	}
 
 	/**

--- a/tests/phpunit/unit/EtherpadReleasePolicyTest.php
+++ b/tests/phpunit/unit/EtherpadReleasePolicyTest.php
@@ -25,10 +25,12 @@ class EtherpadReleasePolicyTest extends TestCase {
 	/** App config that actually remembers what was written to it. */
 	private \ArrayObject $stored;
 	private int $now = 1_700_000_000;
+	private \OCP\ICacheFactory $cacheFactory;
 
 	protected function setUp(): void {
 		parent::setUp();
 		$this->stored = new \ArrayObject();
+		$this->cacheFactory = $this->noCache();
 	}
 
 	public function testEtherpadThreeCanKeepTheCookieFromScripts(): void {
@@ -129,6 +131,10 @@ class EtherpadReleasePolicyTest extends TestCase {
 	 * stamp. Claiming the check first means one of them asks.
 	 */
 	public function testConcurrentOpensDoNotEachProbe(): void {
+		// The claim only works where something is actually shared between
+		// workers: Nextcloud loads app config once per request, so a
+		// timestamp written here is invisible to a request already running.
+		$this->cacheFactory = $this->sharedCache();
 		$this->store(host: 'https://pad.example.test', release: '3.3.3', checkedAt: $this->now - 3601);
 		$client = $this->createMock(EtherpadClient::class);
 		$client->method('getApiHost')->willReturn('https://pad.example.test');
@@ -139,6 +145,21 @@ class EtherpadReleasePolicyTest extends TestCase {
 				return '3.3.3';
 			});
 
+		self::assertTrue($this->policy($client)->supportsHttpOnlySessionCookie());
+	}
+
+	/**
+	 * Nothing to coordinate with is not a reason to skip the check: a
+	 * single-node instance without a memory cache has one worker per open.
+	 */
+	public function testWithoutAMemoryCacheTheCheckStillHappens(): void {
+		$this->cacheFactory = $this->noCache();
+		$client = $this->createMock(EtherpadClient::class);
+		$client->method('getApiHost')->willReturn('https://pad.example.test');
+		$client->expects(self::exactly(2))->method('detectReleaseVersion')->willReturn('3.3.3');
+
+		self::assertTrue($this->policy($client)->supportsHttpOnlySessionCookie());
+		$this->stored['etherpad_release_checked_at'] = (string)($this->now - 3601);
 		self::assertTrue($this->policy($client)->supportsHttpOnlySessionCookie());
 	}
 
@@ -265,6 +286,42 @@ class EtherpadReleasePolicyTest extends TestCase {
 		$timeFactory = $this->createMock(ITimeFactory::class);
 		$timeFactory->method('getTime')->willReturnCallback(fn (): int => $this->now);
 
-		return new EtherpadReleasePolicy($client, $config, $timeFactory, $this->createMock(LoggerInterface::class));
+		return new EtherpadReleasePolicy(
+			$client,
+			$config,
+			$timeFactory,
+			$this->cacheFactory,
+			$this->createMock(LoggerInterface::class),
+		);
+	}
+
+	/**
+	 * A distributed cache shared between the policies a test builds, the way
+	 * one is shared between workers. Without a real one the claim is a
+	 * no-op, which is what a single-node instance gets.
+	 */
+	private function sharedCache(): \OCP\ICacheFactory {
+		$held = new \ArrayObject();
+		$cache = $this->createMock(\OCP\ICache::class);
+		$cache->method('add')->willReturnCallback(
+			static function (string $key) use ($held): bool {
+				if (isset($held[$key])) {
+					return false;
+				}
+				$held[$key] = true;
+				return true;
+			}
+		);
+		$factory = $this->createMock(\OCP\ICacheFactory::class);
+		$factory->method('isAvailable')->willReturn(true);
+		$factory->method('createDistributed')->willReturn($cache);
+		return $factory;
+	}
+
+	/** No memory cache: one worker per open, nothing to coordinate with. */
+	private function noCache(): \OCP\ICacheFactory {
+		$factory = $this->createMock(\OCP\ICacheFactory::class);
+		$factory->method('isAvailable')->willReturn(false);
+		return $factory;
 	}
 }

--- a/tests/phpunit/unit/EtherpadReleasePolicyTest.php
+++ b/tests/phpunit/unit/EtherpadReleasePolicyTest.php
@@ -56,9 +56,97 @@ class EtherpadReleasePolicyTest extends TestCase {
 
 	/** A blip does not undo what was already known about the pad server. */
 	public function testAFailedCheckKeepsTheLastKnownRelease(): void {
-		$this->store(host: 'https://pad.example.test', release: '3.3.3', checkedAt: 0);
+		$this->store(host: 'https://pad.example.test', release: '3.3.3', checkedAt: $this->now - 3601);
 
 		self::assertTrue($this->policy($this->failing())->supportsHttpOnlySessionCookie());
+	}
+
+	/**
+	 * But not forever. The TTL is justified by the cache turning over, and
+	 * on this path it never did: an admin moving back to an Etherpad 2 whose
+	 * `/health` cannot be reached would have had every protected pad locked
+	 * out for good, asked once a minute.
+	 */
+	public function testAReleaseNothingHasConfirmedForHoursStopsCounting(): void {
+		$this->store(host: 'https://pad.example.test', release: '3.3.3', checkedAt: $this->now - 6 * 3600);
+
+		self::assertFalse($this->policy($this->failing())->supportsHttpOnlySessionCookie());
+	}
+
+	/**
+	 * A clock that jumps backwards leaves a stamp ahead of now, and a
+	 * negative age is younger than every window there is — the cache would
+	 * freeze until real time caught up.
+	 */
+	public function testAStampFromTheFutureIsNotTreatedAsFresh(): void {
+		$this->store(host: 'https://pad.example.test', release: '3.3.3', checkedAt: $this->now + 7200);
+		$client = $this->answering('2.7.3');
+		$client->expects(self::once())->method('detectReleaseVersion')->willReturn('2.7.3');
+
+		self::assertFalse($this->policy($client)->supportsHttpOnlySessionCookie());
+	}
+
+	/**
+	 * The failure mode of getting the flag wrong is total, so it does not
+	 * rest on detection alone.
+	 */
+	public function testAnAdminCanForceTheCookieReadable(): void {
+		$this->stored[EtherpadReleasePolicy::OVERRIDE_KEY] = 'no';
+		$client = $this->createMock(EtherpadClient::class);
+		$client->expects(self::never())->method('detectReleaseVersion');
+
+		self::assertFalse($this->policy($client)->supportsHttpOnlySessionCookie());
+	}
+
+	public function testAnAdminCanForceTheCookieHttpOnly(): void {
+		$this->stored[EtherpadReleasePolicy::OVERRIDE_KEY] = 'yes';
+		$client = $this->createMock(EtherpadClient::class);
+		$client->expects(self::never())->method('detectReleaseVersion');
+
+		self::assertTrue($this->policy($client)->supportsHttpOnlySessionCookie());
+	}
+
+	public function testAnythingElseMeansDetect(): void {
+		$this->stored[EtherpadReleasePolicy::OVERRIDE_KEY] = 'auto';
+
+		self::assertTrue($this->policy($this->answering('3.3.3'))->supportsHttpOnlySessionCookie());
+	}
+
+	/**
+	 * The class promises never to fail an open. `getApiHost()` throws when
+	 * no host is configured at all, and it sits outside the detection call.
+	 */
+	public function testAnUnconfiguredHostIsAnAnswerAndNotAnException(): void {
+		$client = $this->createMock(EtherpadClient::class);
+		$client->method('getApiHost')
+			->willThrowException(new EtherpadClientException('Etherpad host is not configured.'));
+
+		self::assertFalse($this->policy($client)->supportsHttpOnlySessionCookie());
+	}
+
+	/**
+	 * At the moment the hour turns, every open in flight sees the same stale
+	 * stamp. Claiming the check first means one of them asks.
+	 */
+	public function testConcurrentOpensDoNotEachProbe(): void {
+		$this->store(host: 'https://pad.example.test', release: '3.3.3', checkedAt: $this->now - 3601);
+		$client = $this->createMock(EtherpadClient::class);
+		$client->method('getApiHost')->willReturn('https://pad.example.test');
+		$client->expects(self::once())->method('detectReleaseVersion')
+			->willReturnCallback(function () use (&$client): string {
+				// What a second request arriving mid-flight would see.
+				self::assertTrue($this->policy($client)->supportsHttpOnlySessionCookie());
+				return '3.3.3';
+			});
+
+		self::assertTrue($this->policy($client)->supportsHttpOnlySessionCookie());
+	}
+
+	/** A release with a suffix is still a 3. */
+	public function testAPreReleaseOfAMajorCountsAsThatMajor(): void {
+		self::assertTrue(EtherpadReleasePolicy::allowsHttpOnly('3.0.0-beta.1'));
+		self::assertFalse(EtherpadReleasePolicy::allowsHttpOnly('2.9.9-rc.1'));
+		self::assertFalse(EtherpadReleasePolicy::allowsHttpOnly(''));
 	}
 
 	/** This runs on the open path; a fresh answer is not asked for twice. */

--- a/tests/phpunit/unit/EtherpadReleasePolicyTest.php
+++ b/tests/phpunit/unit/EtherpadReleasePolicyTest.php
@@ -26,10 +26,12 @@ class EtherpadReleasePolicyTest extends TestCase {
 	private \ArrayObject $stored;
 	private int $now = 1_700_000_000;
 	private \OCP\ICacheFactory $cacheFactory;
+	private \ArrayObject $claims;
 
 	protected function setUp(): void {
 		parent::setUp();
 		$this->stored = new \ArrayObject();
+		$this->claims = new \ArrayObject();
 		$this->cacheFactory = $this->noCache();
 	}
 
@@ -170,6 +172,56 @@ class EtherpadReleasePolicyTest extends TestCase {
 				return '3.3.3';
 			});
 
+		self::assertTrue($this->policy($client)->supportsHttpOnlySessionCookie());
+	}
+
+	/**
+	 * A cache backend that cannot claim atomically is the same situation as
+	 * no cache: `add()` is on IMemcache, and createDistributed() only
+	 * promises an ICache.
+	 */
+	public function testACacheThatCannotClaimDoesNotBlockTheCheck(): void {
+		$factory = $this->createMock(\OCP\ICacheFactory::class);
+		$factory->method('isAvailable')->willReturn(true);
+		$factory->method('createDistributed')->willReturn($this->createMock(\OCP\ICache::class));
+		$this->cacheFactory = $factory;
+
+		$client = $this->createMock(EtherpadClient::class);
+		$client->method('getApiHost')->willReturn('https://pad.example.test');
+		$client->expects(self::once())->method('detectReleaseVersion')->willReturn('3.3.3');
+
+		self::assertTrue($this->policy($client)->supportsHttpOnlySessionCookie());
+	}
+
+	/**
+	 * A claim taken for one pad server must not turn away the first check of
+	 * the next one — a repointing would otherwise start with a minute of
+	 * not knowing.
+	 */
+	public function testAClaimForOneHostDoesNotBlockAnother(): void {
+		$this->cacheFactory = $this->sharedCache();
+		$this->store(host: 'https://old.pad.test', release: '3.3.3', checkedAt: $this->now - 3601);
+
+		$old = $this->createMock(EtherpadClient::class);
+		$old->method('getApiHost')->willReturn('https://old.pad.test');
+		$old->method('detectReleaseVersion')->willThrowException(new EtherpadClientException('down'));
+		self::assertTrue($this->policy($old)->supportsHttpOnlySessionCookie());
+
+		$new = $this->createMock(EtherpadClient::class);
+		$new->method('getApiHost')->willReturn('https://new.pad.test');
+		$new->expects(self::once())->method('detectReleaseVersion')->willReturn('3.3.3');
+		self::assertTrue($this->policy($new)->supportsHttpOnlySessionCookie());
+	}
+
+	/** And a claim is given back once the answer is in, not held for a minute. */
+	public function testASuccessfulCheckReleasesItsClaim(): void {
+		$this->cacheFactory = $this->sharedCache();
+		$client = $this->createMock(EtherpadClient::class);
+		$client->method('getApiHost')->willReturn('https://pad.example.test');
+		$client->expects(self::exactly(2))->method('detectReleaseVersion')->willReturn('3.3.3');
+
+		self::assertTrue($this->policy($client)->supportsHttpOnlySessionCookie());
+		$this->stored['etherpad_release_checked_at'] = (string)($this->now - 3601);
 		self::assertTrue($this->policy($client)->supportsHttpOnlySessionCookie());
 	}
 
@@ -326,14 +378,22 @@ class EtherpadReleasePolicyTest extends TestCase {
 	 * no-op, which is what a single-node instance gets.
 	 */
 	private function sharedCache(): \OCP\ICacheFactory {
-		$held = new \ArrayObject();
-		$cache = $this->createMock(\OCP\ICache::class);
+		$held = $this->claims;
+		// IMemcache, not ICache: `add()` is declared there, and the policy
+		// asks for it rather than assuming createDistributed() returns one.
+		$cache = $this->createMock(\OCP\IMemcache::class);
 		$cache->method('add')->willReturnCallback(
 			static function (string $key) use ($held): bool {
 				if (isset($held[$key])) {
 					return false;
 				}
 				$held[$key] = true;
+				return true;
+			}
+		);
+		$cache->method('remove')->willReturnCallback(
+			static function (string $key) use ($held): bool {
+				unset($held[$key]);
 				return true;
 			}
 		);

--- a/tests/phpunit/unit/EtherpadReleasePolicyTest.php
+++ b/tests/phpunit/unit/EtherpadReleasePolicyTest.php
@@ -27,6 +27,7 @@ class EtherpadReleasePolicyTest extends TestCase {
 	private int $now = 1_700_000_000;
 	private \OCP\ICacheFactory $cacheFactory;
 	private \ArrayObject $claims;
+	private ?LoggerInterface $logger = null;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -352,6 +353,59 @@ class EtherpadReleasePolicyTest extends TestCase {
 		self::assertArrayNotHasKey('etherpad_release_state', (array)$this->stored);
 	}
 
+	/**
+	 * A success must not clear the failure stamp. It is the one value here
+	 * that is not read per host, so clearing it wipes a backoff another
+	 * host's failing check just took — and without a memcache that host's
+	 * next opens each wait out the health timeout again.
+	 */
+	public function testASuccessLeavesAnotherHostsBackoffAlone(): void {
+		$this->stored['etherpad_release_failed'] = (string)json_encode([
+			'host' => 'https://other.pad.test',
+			'at' => $this->now,
+		]);
+
+		$client = $this->createMock(EtherpadClient::class);
+		$client->method('getApiHost')->willReturn('https://pad.example.test');
+		$client->method('detectReleaseVersion')->willReturn('3.3.3');
+		self::assertTrue($this->policy($client)->supportsHttpOnlySessionCookie());
+
+		$other = $this->createMock(EtherpadClient::class);
+		$other->method('getApiHost')->willReturn('https://other.pad.test');
+		$other->expects(self::never())->method('detectReleaseVersion');
+		self::assertFalse($this->policy($other)->supportsHttpOnlySessionCookie());
+	}
+
+	/**
+	 * `--value=true` is worth a line: it is an escape hatch reached for
+	 * during an outage, and it silently means auto.
+	 */
+	public function testAnUnrecognisedOverrideIsLogged(): void {
+		$this->stored[EtherpadReleasePolicy::OVERRIDE_KEY] = 'true';
+		$logger = $this->createMock(LoggerInterface::class);
+		$logger->expects(self::once())
+			->method('warning')
+			->with(self::stringContains('unrecognised'), self::anything());
+		$this->logger = $logger;
+
+		$this->policy($this->answering('3.3.3'))->supportsHttpOnlySessionCookie();
+	}
+
+	/** But this is read on every open, so once an hour, not a hundred times. */
+	public function testAnUnrecognisedOverrideIsNotLoggedOnEveryOpen(): void {
+		$this->stored[EtherpadReleasePolicy::OVERRIDE_KEY] = 'true';
+		$logger = $this->createMock(LoggerInterface::class);
+		$logger->expects(self::once())->method('warning');
+		$this->logger = $logger;
+
+		$client = $this->answering('3.3.3');
+		$this->policy($client)->supportsHttpOnlySessionCookie();
+		$this->now += 60;
+		$this->policy($client)->supportsHttpOnlySessionCookie();
+		$this->now += 600;
+		$this->policy($client)->supportsHttpOnlySessionCookie();
+	}
+
 	/** A release with a suffix is still a 3. */
 	public function testAPreReleaseOfAMajorCountsAsThatMajor(): void {
 		self::assertTrue(EtherpadReleasePolicy::allowsHttpOnly('3.0.0-beta.1'));
@@ -491,7 +545,7 @@ class EtherpadReleasePolicyTest extends TestCase {
 			$config,
 			$timeFactory,
 			$this->cacheFactory,
-			$this->createMock(LoggerInterface::class),
+			$this->logger ?? $this->createMock(LoggerInterface::class),
 		);
 	}
 

--- a/tests/phpunit/unit/EtherpadReleasePolicyTest.php
+++ b/tests/phpunit/unit/EtherpadReleasePolicyTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * Copyright (c) 2026 Jacob Bühler
+ */
+
+namespace OCA\EtherpadNextcloud\Tests\Unit;
+
+use OCA\EtherpadNextcloud\Exception\EtherpadClientException;
+use OCA\EtherpadNextcloud\Service\EtherpadClient;
+use OCA\EtherpadNextcloud\Service\EtherpadReleasePolicy;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\IConfig;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Up to Etherpad 2.7.3 the pad app reads `sessionID` in the browser, so an
+ * HttpOnly cookie locks the user out of every protected pad. From 3.0.0 the
+ * server reads it out of the socket.io handshake instead.
+ */
+class EtherpadReleasePolicyTest extends TestCase {
+	public function testEtherpadThreeCanKeepTheCookieFromScripts(): void {
+		$client = $this->createMock(EtherpadClient::class);
+		$client->method('detectReleaseVersion')->willReturn('3.3.3');
+
+		self::assertTrue($this->policy($client, $this->config())->supportsHttpOnlySessionCookie());
+	}
+
+	public function testEtherpadTwoStillNeedsAReadableCookie(): void {
+		$client = $this->createMock(EtherpadClient::class);
+		$client->method('detectReleaseVersion')->willReturn('2.7.3');
+
+		self::assertFalse($this->policy($client, $this->config())->supportsHttpOnlySessionCookie());
+	}
+
+	/** The boundary itself, from both sides. */
+	public function testTheBoundaryIsThreeZeroZero(): void {
+		$before = $this->createMock(EtherpadClient::class);
+		$before->method('detectReleaseVersion')->willReturn('2.9.9');
+		self::assertFalse($this->policy($before, $this->config())->supportsHttpOnlySessionCookie());
+
+		$exactly = $this->createMock(EtherpadClient::class);
+		$exactly->method('detectReleaseVersion')->willReturn('3.0.0');
+		self::assertTrue($this->policy($exactly, $this->config())->supportsHttpOnlySessionCookie());
+	}
+
+	/**
+	 * No answer is not a licence to harden: a wrong `true` costs every
+	 * protected pad on the instance, a wrong `false` costs a hardening.
+	 */
+	public function testAnUnreachableEtherpadKeepsTheCookieReadable(): void {
+		$client = $this->createMock(EtherpadClient::class);
+		$client->method('detectReleaseVersion')
+			->willThrowException(new EtherpadClientException('Connection timed out'));
+
+		self::assertFalse($this->policy($client, $this->config())->supportsHttpOnlySessionCookie());
+	}
+
+	/** A blip does not undo what was already known about the pad server. */
+	public function testAFailedCheckKeepsTheLastKnownRelease(): void {
+		$client = $this->createMock(EtherpadClient::class);
+		$client->method('detectReleaseVersion')
+			->willThrowException(new EtherpadClientException('Connection timed out'));
+
+		$config = $this->config(['etherpad_release_version' => '3.3.3', 'etherpad_release_checked_at' => '0']);
+
+		self::assertTrue($this->policy($client, $config)->supportsHttpOnlySessionCookie());
+	}
+
+	/** This runs on the open path; a fresh answer is not asked for twice. */
+	public function testAFreshAnswerIsNotAskedForAgain(): void {
+		$client = $this->createMock(EtherpadClient::class);
+		$client->expects(self::never())->method('detectReleaseVersion');
+
+		$config = $this->config([
+			'etherpad_release_version' => '3.3.3',
+			'etherpad_release_checked_at' => (string)(1_700_000_000 - 60),
+		]);
+
+		self::assertTrue($this->policy($client, $config)->supportsHttpOnlySessionCookie());
+	}
+
+	/**
+	 * And a stale one is. The downgrade is why: an Etherpad that goes back
+	 * to 2.x would otherwise keep being sent a cookie its pad app cannot
+	 * read.
+	 */
+	public function testAStaleAnswerIsCheckedAgain(): void {
+		$client = $this->createMock(EtherpadClient::class);
+		$client->expects(self::once())->method('detectReleaseVersion')->willReturn('2.7.3');
+
+		$config = $this->config([
+			'etherpad_release_version' => '3.3.3',
+			'etherpad_release_checked_at' => (string)(1_700_000_000 - 3601),
+		]);
+
+		self::assertFalse($this->policy($client, $config)->supportsHttpOnlySessionCookie());
+	}
+
+	/** @param array<string,string> $stored */
+	private function config(array $stored = []): IConfig {
+		$config = $this->createMock(IConfig::class);
+		$config->method('getAppValue')->willReturnCallback(
+			static fn (string $app, string $key, string $default = ''): string => $stored[$key] ?? $default
+		);
+		$config->method('setAppValue')->willReturnCallback(
+			static function (string $app, string $key, string $value) use (&$stored): void {
+				$stored[$key] = $value;
+			}
+		);
+		return $config;
+	}
+
+	private function policy(EtherpadClient $client, IConfig $config): EtherpadReleasePolicy {
+		$timeFactory = $this->createMock(ITimeFactory::class);
+		$timeFactory->method('getTime')->willReturn(1_700_000_000);
+		return new EtherpadReleasePolicy($client, $config, $timeFactory, $this->createMock(LoggerInterface::class));
+	}
+}

--- a/tests/phpunit/unit/EtherpadReleasePolicyTest.php
+++ b/tests/phpunit/unit/EtherpadReleasePolicyTest.php
@@ -335,6 +335,23 @@ class EtherpadReleasePolicyTest extends TestCase {
 		self::assertSame('', $policy->knownRelease('https://other.pad.test'));
 	}
 
+	/**
+	 * An encoding failure must not read as a successful write. `''` decodes
+	 * to no record at all, so nothing would ever be cached and nothing
+	 * would ever back off — every protected open probing /health again,
+	 * with the write reporting success.
+	 */
+	public function testAnEncodingFailureIsAnErrorAndNotAnEmptyRecord(): void {
+		$client = $this->createMock(EtherpadClient::class);
+		// Invalid UTF-8 in the host, which is the one field that is not
+		// regex-validated ASCII by the time it gets here.
+		$client->method('getApiHost')->willReturn("https://pad.example.test/\xB1\x31");
+		$client->method('detectReleaseVersion')->willReturn('3.3.3');
+
+		self::assertFalse($this->policy($client)->supportsHttpOnlySessionCookie());
+		self::assertArrayNotHasKey('etherpad_release_state', (array)$this->stored);
+	}
+
 	/** A release with a suffix is still a 3. */
 	public function testAPreReleaseOfAMajorCountsAsThatMajor(): void {
 		self::assertTrue(EtherpadReleasePolicy::allowsHttpOnly('3.0.0-beta.1'));

--- a/tests/phpunit/unit/EtherpadReleasePolicyTest.php
+++ b/tests/phpunit/unit/EtherpadReleasePolicyTest.php
@@ -284,6 +284,57 @@ class EtherpadReleasePolicyTest extends TestCase {
 		self::assertTrue($this->policy($client)->supportsHttpOnlySessionCookie());
 	}
 
+	/**
+	 * A worker whose check times out cannot see the success another worker
+	 * wrote while it was waiting — Nextcloud loads app config once per
+	 * request. When the failure path wrote the whole record back, that put
+	 * the pre-downgrade release in front of the fresh one, with a
+	 * fresh-looking timestamp: an hour of HttpOnly against an Etherpad 2.
+	 */
+	public function testAFailedCheckDoesNotPutAStaleReleaseBack(): void {
+		$this->store(host: 'https://pad.example.test', release: '3.3.3', checkedAt: $this->now - 3601);
+
+		$slow = $this->createMock(EtherpadClient::class);
+		$slow->method('getApiHost')->willReturn('https://pad.example.test');
+		$slow->method('detectReleaseVersion')->willReturnCallback(function (): string {
+			// While this one waits, another worker detects the downgrade.
+			$this->store(host: 'https://pad.example.test', release: '2.7.3', checkedAt: $this->now);
+			throw new EtherpadClientException('Connection timed out');
+		});
+
+		// It reports what it had, which is fine — it is what it knew.
+		self::assertTrue($this->policy($slow)->supportsHttpOnlySessionCookie());
+
+		// But it must not have overwritten the newer answer.
+		$next = $this->createMock(EtherpadClient::class);
+		$next->method('getApiHost')->willReturn('https://pad.example.test');
+		$next->expects(self::never())->method('detectReleaseVersion');
+		self::assertFalse($this->policy($next)->supportsHttpOnlySessionCookie());
+	}
+
+	/**
+	 * `knownRelease()` is what the admin panel reports as "what pads are
+	 * being sent". It has to answer the same way the open path decides, or
+	 * it reports the opposite of what is going out.
+	 */
+	public function testKnownReleaseForgetsAnAnswerTheOpenPathHasStoppedTrusting(): void {
+		$this->store(host: 'https://pad.example.test', release: '3.3.3', checkedAt: $this->now - 7 * 3600);
+		$client = $this->createMock(EtherpadClient::class);
+		$client->method('getApiHost')->willReturn('https://pad.example.test');
+
+		self::assertSame('', $this->policy($client)->knownRelease());
+	}
+
+	public function testKnownReleaseAnswersAboutTheHostItIsAsked(): void {
+		$this->store(host: 'https://pad.example.test', release: '3.3.3', checkedAt: $this->now);
+		$client = $this->createMock(EtherpadClient::class);
+		$client->method('getApiHost')->willReturn('https://pad.example.test');
+
+		$policy = $this->policy($client);
+		self::assertSame('3.3.3', $policy->knownRelease('https://pad.example.test'));
+		self::assertSame('', $policy->knownRelease('https://other.pad.test'));
+	}
+
 	/** A release with a suffix is still a 3. */
 	public function testAPreReleaseOfAMajorCountsAsThatMajor(): void {
 		self::assertTrue(EtherpadReleasePolicy::allowsHttpOnly('3.0.0-beta.1'));
@@ -371,13 +422,15 @@ class EtherpadReleasePolicyTest extends TestCase {
 		self::assertFalse($this->policy($client)->supportsHttpOnlySessionCookie());
 	}
 
-	private function store(string $host, string $release, int $checkedAt, int $failedAt = 0): void {
+	private function store(string $host, string $release, int $checkedAt, ?int $failedAt = null): void {
 		$this->stored['etherpad_release_state'] = (string)json_encode([
 			'host' => $host,
 			'release' => $release,
 			'checkedAt' => $checkedAt,
-			'failedAt' => $failedAt,
 		]);
+		if ($failedAt !== null) {
+			$this->stored['etherpad_release_failed'] = (string)json_encode(['host' => $host, 'at' => $failedAt]);
+		}
 	}
 
 	/** @return array{host?:string,release?:string,checkedAt?:int,failedAt?:int} */

--- a/tests/phpunit/unit/EtherpadReleasePolicyTest.php
+++ b/tests/phpunit/unit/EtherpadReleasePolicyTest.php
@@ -115,6 +115,31 @@ class EtherpadReleasePolicyTest extends TestCase {
 	}
 
 	/**
+	 * The override is read before anything else, and on many requests it is
+	 * the first app-config read there is — so a database blip there would
+	 * escape a predicate that promises it cannot fail an open.
+	 */
+	public function testAConfigReadThatFailsIsAnAnswerAndNotAnException(): void {
+		$client = $this->createMock(EtherpadClient::class);
+		$client->method('getApiHost')->willReturn('https://pad.example.test');
+
+		$config = $this->createMock(IConfig::class);
+		$config->method('getAppValue')->willThrowException(new \RuntimeException('database has gone away'));
+		$timeFactory = $this->createMock(ITimeFactory::class);
+		$timeFactory->method('getTime')->willReturn($this->now);
+
+		$policy = new EtherpadReleasePolicy(
+			$client,
+			$config,
+			$timeFactory,
+			$this->noCache(),
+			$this->createMock(LoggerInterface::class),
+		);
+
+		self::assertFalse($policy->supportsHttpOnlySessionCookie());
+	}
+
+	/**
 	 * The class promises never to fail an open. `getApiHost()` throws when
 	 * no host is configured at all, and it sits outside the detection call.
 	 */

--- a/tests/phpunit/unit/EtherpadReleasePolicyTest.php
+++ b/tests/phpunit/unit/EtherpadReleasePolicyTest.php
@@ -22,29 +22,28 @@ use Psr\Log\LoggerInterface;
  * server reads it out of the socket.io handshake instead.
  */
 class EtherpadReleasePolicyTest extends TestCase {
-	public function testEtherpadThreeCanKeepTheCookieFromScripts(): void {
-		$client = $this->createMock(EtherpadClient::class);
-		$client->method('detectReleaseVersion')->willReturn('3.3.3');
+	/** App config that actually remembers what was written to it. */
+	private \ArrayObject $stored;
+	private int $now = 1_700_000_000;
 
-		self::assertTrue($this->policy($client, $this->config())->supportsHttpOnlySessionCookie());
+	protected function setUp(): void {
+		parent::setUp();
+		$this->stored = new \ArrayObject();
+	}
+
+	public function testEtherpadThreeCanKeepTheCookieFromScripts(): void {
+		self::assertTrue($this->policy($this->answering('3.3.3'))->supportsHttpOnlySessionCookie());
 	}
 
 	public function testEtherpadTwoStillNeedsAReadableCookie(): void {
-		$client = $this->createMock(EtherpadClient::class);
-		$client->method('detectReleaseVersion')->willReturn('2.7.3');
-
-		self::assertFalse($this->policy($client, $this->config())->supportsHttpOnlySessionCookie());
+		self::assertFalse($this->policy($this->answering('2.7.3'))->supportsHttpOnlySessionCookie());
 	}
 
 	/** The boundary itself, from both sides. */
 	public function testTheBoundaryIsThreeZeroZero(): void {
-		$before = $this->createMock(EtherpadClient::class);
-		$before->method('detectReleaseVersion')->willReturn('2.9.9');
-		self::assertFalse($this->policy($before, $this->config())->supportsHttpOnlySessionCookie());
-
-		$exactly = $this->createMock(EtherpadClient::class);
-		$exactly->method('detectReleaseVersion')->willReturn('3.0.0');
-		self::assertTrue($this->policy($exactly, $this->config())->supportsHttpOnlySessionCookie());
+		self::assertFalse($this->policy($this->answering('2.9.9'))->supportsHttpOnlySessionCookie());
+		$this->stored = new \ArrayObject();
+		self::assertTrue($this->policy($this->answering('3.0.0'))->supportsHttpOnlySessionCookie());
 	}
 
 	/**
@@ -52,35 +51,24 @@ class EtherpadReleasePolicyTest extends TestCase {
 	 * protected pad on the instance, a wrong `false` costs a hardening.
 	 */
 	public function testAnUnreachableEtherpadKeepsTheCookieReadable(): void {
-		$client = $this->createMock(EtherpadClient::class);
-		$client->method('detectReleaseVersion')
-			->willThrowException(new EtherpadClientException('Connection timed out'));
-
-		self::assertFalse($this->policy($client, $this->config())->supportsHttpOnlySessionCookie());
+		self::assertFalse($this->policy($this->failing())->supportsHttpOnlySessionCookie());
 	}
 
 	/** A blip does not undo what was already known about the pad server. */
 	public function testAFailedCheckKeepsTheLastKnownRelease(): void {
-		$client = $this->createMock(EtherpadClient::class);
-		$client->method('detectReleaseVersion')
-			->willThrowException(new EtherpadClientException('Connection timed out'));
+		$this->store(host: 'https://pad.example.test', release: '3.3.3', checkedAt: 0);
 
-		$config = $this->config(['etherpad_release_version' => '3.3.3', 'etherpad_release_checked_at' => '0']);
-
-		self::assertTrue($this->policy($client, $config)->supportsHttpOnlySessionCookie());
+		self::assertTrue($this->policy($this->failing())->supportsHttpOnlySessionCookie());
 	}
 
 	/** This runs on the open path; a fresh answer is not asked for twice. */
 	public function testAFreshAnswerIsNotAskedForAgain(): void {
+		$this->store(host: 'https://pad.example.test', release: '3.3.3', checkedAt: $this->now - 60);
 		$client = $this->createMock(EtherpadClient::class);
+		$client->method('getApiHost')->willReturn('https://pad.example.test');
 		$client->expects(self::never())->method('detectReleaseVersion');
 
-		$config = $this->config([
-			'etherpad_release_version' => '3.3.3',
-			'etherpad_release_checked_at' => (string)(1_700_000_000 - 60),
-		]);
-
-		self::assertTrue($this->policy($client, $config)->supportsHttpOnlySessionCookie());
+		self::assertTrue($this->policy($client)->supportsHttpOnlySessionCookie());
 	}
 
 	/**
@@ -89,34 +77,106 @@ class EtherpadReleasePolicyTest extends TestCase {
 	 * read.
 	 */
 	public function testAStaleAnswerIsCheckedAgain(): void {
-		$client = $this->createMock(EtherpadClient::class);
+		$this->store(host: 'https://pad.example.test', release: '3.3.3', checkedAt: $this->now - 3601);
+		$client = $this->answering('2.7.3');
 		$client->expects(self::once())->method('detectReleaseVersion')->willReturn('2.7.3');
 
-		$config = $this->config([
-			'etherpad_release_version' => '3.3.3',
-			'etherpad_release_checked_at' => (string)(1_700_000_000 - 3601),
-		]);
-
-		self::assertFalse($this->policy($client, $config)->supportsHttpOnlySessionCookie());
+		self::assertFalse($this->policy($client)->supportsHttpOnlySessionCookie());
 	}
 
-	/** @param array<string,string> $stored */
-	private function config(array $stored = []): IConfig {
+	/**
+	 * A pad server that accepts the connection and then says nothing costs
+	 * every open the health timeout. The failure path returned the last
+	 * known release but recorded nothing, so the next open started over.
+	 */
+	public function testAFailedCheckIsNotRepeatedOnTheNextOpen(): void {
+		$client = $this->createMock(EtherpadClient::class);
+		$client->method('getApiHost')->willReturn('https://pad.example.test');
+		$client->expects(self::once())
+			->method('detectReleaseVersion')
+			->willThrowException(new EtherpadClientException('Connection timed out'));
+
+		$policy = $this->policy($client);
+		self::assertFalse($policy->supportsHttpOnlySessionCookie());
+		$this->now += 30;
+		self::assertFalse($policy->supportsHttpOnlySessionCookie());
+	}
+
+	/** The backoff is a minute, not an hour: a failure told us nothing. */
+	public function testAFailedCheckIsRetriedAfterTheBackoff(): void {
+		$client = $this->createMock(EtherpadClient::class);
+		$client->method('getApiHost')->willReturn('https://pad.example.test');
+		$client->expects(self::exactly(2))
+			->method('detectReleaseVersion')
+			->willReturnOnConsecutiveCalls(
+				self::throwException(new EtherpadClientException('Connection timed out')),
+				'3.3.3',
+			);
+
+		$policy = $this->policy($client);
+		self::assertFalse($policy->supportsHttpOnlySessionCookie());
+		$this->now += 61;
+		self::assertTrue($policy->supportsHttpOnlySessionCookie());
+	}
+
+	/**
+	 * What one pad server says about itself is not true of the next one. An
+	 * admin repointing the app from an Etherpad 3 to an Etherpad 2 must not
+	 * have it sent a cookie its pad app cannot read.
+	 */
+	public function testARepointedHostDoesNotInheritTheOldOnesRelease(): void {
+		$this->store(host: 'https://old.pad.test', release: '3.3.3', checkedAt: $this->now);
+		$client = $this->answering('2.7.3');
+		$client->method('getApiHost')->willReturn('https://new.pad.test');
+
+		self::assertFalse($this->policy($client)->supportsHttpOnlySessionCookie());
+	}
+
+	/** And not even when the new host cannot be reached at all. */
+	public function testARepointedHostThatCannotBeReachedIsUnknown(): void {
+		$this->store(host: 'https://old.pad.test', release: '3.3.3', checkedAt: $this->now);
+		$client = $this->failing();
+		$client->method('getApiHost')->willReturn('https://new.pad.test');
+
+		self::assertFalse($this->policy($client)->supportsHttpOnlySessionCookie());
+	}
+
+	private function store(string $host, string $release, int $checkedAt): void {
+		$this->stored['etherpad_release_host'] = $host;
+		$this->stored['etherpad_release_version'] = $release;
+		$this->stored['etherpad_release_checked_at'] = (string)$checkedAt;
+	}
+
+	private function answering(string $release): EtherpadClient {
+		$client = $this->createMock(EtherpadClient::class);
+		$client->method('getApiHost')->willReturn('https://pad.example.test');
+		$client->method('detectReleaseVersion')->willReturn($release);
+		return $client;
+	}
+
+	private function failing(): EtherpadClient {
+		$client = $this->createMock(EtherpadClient::class);
+		$client->method('getApiHost')->willReturn('https://pad.example.test');
+		$client->method('detectReleaseVersion')
+			->willThrowException(new EtherpadClientException('Connection timed out'));
+		return $client;
+	}
+
+	private function policy(EtherpadClient $client): EtherpadReleasePolicy {
+		$stored = $this->stored;
 		$config = $this->createMock(IConfig::class);
 		$config->method('getAppValue')->willReturnCallback(
-			static fn (string $app, string $key, string $default = ''): string => $stored[$key] ?? $default
+			static fn (string $app, string $key, string $default = ''): string => (string)($stored[$key] ?? $default)
 		);
 		$config->method('setAppValue')->willReturnCallback(
-			static function (string $app, string $key, string $value) use (&$stored): void {
+			static function (string $app, string $key, string $value) use ($stored): void {
 				$stored[$key] = $value;
 			}
 		);
-		return $config;
-	}
 
-	private function policy(EtherpadClient $client, IConfig $config): EtherpadReleasePolicy {
 		$timeFactory = $this->createMock(ITimeFactory::class);
-		$timeFactory->method('getTime')->willReturn(1_700_000_000);
+		$timeFactory->method('getTime')->willReturnCallback(fn (): int => $this->now);
+
 		return new EtherpadReleasePolicy($client, $config, $timeFactory, $this->createMock(LoggerInterface::class));
 	}
 }

--- a/tests/phpunit/unit/EtherpadReleasePolicyTest.php
+++ b/tests/phpunit/unit/EtherpadReleasePolicyTest.php
@@ -221,7 +221,7 @@ class EtherpadReleasePolicyTest extends TestCase {
 		$client->expects(self::exactly(2))->method('detectReleaseVersion')->willReturn('3.3.3');
 
 		self::assertTrue($this->policy($client)->supportsHttpOnlySessionCookie());
-		$this->stored['etherpad_release_checked_at'] = (string)($this->now - 3601);
+		$this->store(host: 'https://pad.example.test', release: '3.3.3', checkedAt: $this->now - 3601);
 		self::assertTrue($this->policy($client)->supportsHttpOnlySessionCookie());
 	}
 
@@ -236,7 +236,51 @@ class EtherpadReleasePolicyTest extends TestCase {
 		$client->expects(self::exactly(2))->method('detectReleaseVersion')->willReturn('3.3.3');
 
 		self::assertTrue($this->policy($client)->supportsHttpOnlySessionCookie());
-		$this->stored['etherpad_release_checked_at'] = (string)($this->now - 3601);
+		$this->store(host: 'https://pad.example.test', release: '3.3.3', checkedAt: $this->now - 3601);
+		self::assertTrue($this->policy($client)->supportsHttpOnlySessionCookie());
+	}
+
+	/**
+	 * A check for the host configured a moment ago can finish after the app
+	 * has been repointed. Its write must not file the old server's release
+	 * under the new server's name — which for an Etherpad 2 would mean an
+	 * HttpOnly cookie and no protected pad opening for an hour.
+	 *
+	 * Neither ordering nor a re-read can prevent the write: Nextcloud loads
+	 * app config once per request, so the late writer never sees the
+	 * repointing. What prevents the damage is that the record says which
+	 * host it is about.
+	 */
+	public function testAProbeThatFinishesAfterARepointingIsNotTrusted(): void {
+		$old = $this->createMock(EtherpadClient::class);
+		$old->method('getApiHost')->willReturn('https://old.pad.test');
+		$old->method('detectReleaseVersion')->willReturnCallback(function (): string {
+			// While this probe is in flight, another request repoints the
+			// app and records what the new server says.
+			$this->store(host: 'https://new.pad.test', release: '2.7.3', checkedAt: $this->now);
+			return '3.3.3';
+		});
+
+		// The old host's probe lands last and wins the write.
+		self::assertTrue($this->policy($old)->supportsHttpOnlySessionCookie());
+		self::assertSame('https://old.pad.test', $this->storedState()['host'] ?? '');
+
+		// The next open is against the new host, and must not inherit it.
+		$new = $this->createMock(EtherpadClient::class);
+		$new->method('getApiHost')->willReturn('https://new.pad.test');
+		$new->expects(self::once())->method('detectReleaseVersion')->willReturn('2.7.3');
+		self::assertFalse($this->policy($new)->supportsHttpOnlySessionCookie());
+	}
+
+	/** The host asked is the host the answer is filed under. */
+	public function testTheProbeIsPointedAtTheHostItIsFiledUnder(): void {
+		$client = $this->createMock(EtherpadClient::class);
+		$client->method('getApiHost')->willReturn('https://pad.example.test');
+		$client->expects(self::once())
+			->method('detectReleaseVersion')
+			->with('https://pad.example.test')
+			->willReturn('3.3.3');
+
 		self::assertTrue($this->policy($client)->supportsHttpOnlySessionCookie());
 	}
 
@@ -327,10 +371,19 @@ class EtherpadReleasePolicyTest extends TestCase {
 		self::assertFalse($this->policy($client)->supportsHttpOnlySessionCookie());
 	}
 
-	private function store(string $host, string $release, int $checkedAt): void {
-		$this->stored['etherpad_release_host'] = $host;
-		$this->stored['etherpad_release_version'] = $release;
-		$this->stored['etherpad_release_checked_at'] = (string)$checkedAt;
+	private function store(string $host, string $release, int $checkedAt, int $failedAt = 0): void {
+		$this->stored['etherpad_release_state'] = (string)json_encode([
+			'host' => $host,
+			'release' => $release,
+			'checkedAt' => $checkedAt,
+			'failedAt' => $failedAt,
+		]);
+	}
+
+	/** @return array{host?:string,release?:string,checkedAt?:int,failedAt?:int} */
+	private function storedState(): array {
+		$decoded = json_decode((string)($this->stored['etherpad_release_state'] ?? ''), true);
+		return is_array($decoded) ? $decoded : [];
 	}
 
 	private function answering(string $release): EtherpadClient {

--- a/tests/phpunit/unit/PadSessionServiceTest.php
+++ b/tests/phpunit/unit/PadSessionServiceTest.php
@@ -25,16 +25,20 @@ class PadSessionServiceTest extends TestCase {
 		IConfig $config,
 		string $nextcloudUrl = 'https://cloud.example.test',
 		?string $incomingSessionCookie = null,
+		bool $httpOnlySupported = false,
 	): PadSessionService {
 		$urlGenerator = $this->createMock(IURLGenerator::class);
 		$urlGenerator->method('getBaseUrl')->willReturn($nextcloudUrl);
 		$request = $this->createMock(IRequest::class);
 		$request->method('getCookie')->with('sessionID')->willReturn($incomingSessionCookie);
+		$releasePolicy = $this->createMock(\OCA\EtherpadNextcloud\Service\EtherpadReleasePolicy::class);
+		$releasePolicy->method('supportsHttpOnlySessionCookie')->willReturn($httpOnlySupported);
 		return new PadSessionService(
 			$etherpadClient,
 			$config,
 			$urlGenerator,
 			new CookieDomainPolicy(),
+			$releasePolicy,
 			$request,
 			$this->createMock(LoggerInterface::class),
 		);
@@ -61,6 +65,7 @@ class PadSessionServiceTest extends TestCase {
 		?string $incoming = null,
 		string $groupId = 'g.ABCDEFGHIJKLMNOP',
 		bool $listingFails = false,
+		bool $httpOnlySupported = false,
 	): array {
 		$etherpadClient = $this->createMock(EtherpadClient::class);
 		$etherpadClient->method('createSession')->willReturn($this->sid('new'));
@@ -78,9 +83,29 @@ class PadSessionServiceTest extends TestCase {
 			$this->createMock(IConfig::class),
 			'https://cloud.example.test',
 			$incoming,
+			$httpOnlySupported,
 		);
 
 		return $service->createProtectedOpenContext('admin', 'Admin', $groupId . '$pad-1')['cookie'];
+	}
+
+	/**
+	 * The pad app up to Etherpad 2.7.3 reads `sessionID` itself, in the
+	 * browser. HttpOnly there is not a hardening, it is a lockout.
+	 */
+	public function testLeavesTheCookieReadableForAnEtherpadThatReadsItInTheBrowser(): void {
+		$cookie = $this->openContextCookie([], null, httpOnlySupported: false);
+		$this->assertFalse($cookie['http_only']);
+	}
+
+	/**
+	 * From 3.0.0 the session id comes out of the socket.io handshake on the
+	 * server, so nothing on the page needs to see it — and a script that
+	 * gets onto the page cannot take it.
+	 */
+	public function testKeepsTheCookieFromScriptsWhereEtherpadReadsItServerSide(): void {
+		$cookie = $this->openContextCookie([], null, httpOnlySupported: true);
+		$this->assertTrue($cookie['http_only']);
 	}
 
 	public function testWritesOnlyTheNewSessionWhenTheBrowserSentNone(): void {
@@ -304,6 +329,7 @@ class PadSessionServiceTest extends TestCase {
 			$this->createMock(IConfig::class),
 			$urlGenerator,
 			new CookieDomainPolicy(),
+			$this->createMock(\OCA\EtherpadNextcloud\Service\EtherpadReleasePolicy::class),
 			$request,
 			$logger,
 		);


### PR DESCRIPTION
Etherpad's session cookie has been script-readable since this app existed, and it had to be: up to 2.7.3 the pad app reads `sessionID` itself, in the browser, with `Cookies.get`. `HttpOnly` there is not a hardening but a lockout from every protected pad. From 3.0.0 the server takes the session id out of the socket.io handshake instead, and nothing on the page needs to see it – so a script that gets onto the page cannot take it either.

The app now finds out which one it is talking to, and sets the flag accordingly.

### Measured, at the boundary rather than around it

With `HttpOnly` forced on, `pad-author-display-name` – the one spec that drives Etherpad's own toolbar two frames deep – fails on **2.7.3**: the pad loads and never becomes usable. On **3.0.0** and **3.3.3** it passes. `EP_VERSION` takes a full tag, so `EP_VERSION=3.0.0 tests/e2e/docker/up.sh` reproduces the middle one.

That matters because 3.0.0 is the constant. Testing 2 and 3 alone would have left the boundary itself unmeasured, and a fail-safe does not help there: the release is *known*, so "unknown means no" never fires.

The other `protected-*` specs cannot see any of this. They work at request level, where nothing ever needs to read the cookie from JavaScript, and they pass either way – which is why a first counter-check with `--filter protected` came back green against a deliberately broken flag.

### `/health`, because `/api` cannot answer it

Measured on both: `/api` reports `currentVersion: 1.3.1` on 2.7.3 *and* 3.3.3. It cannot tell the two apart. `/health` reports a `releaseId`, needs no api key, and that is what `EtherpadReleasePolicy` asks.

Compared by major. The rule has to be restatable in TypeScript and in bash for the two test layers, and PHP sorts `3.0.0-beta.1` below `3.0.0` while any reading of it there calls it a 3. What actually changed between those releases was the major.

### Caching, and the ways it can be wrong

The answer is cached for an hour. The hour is about the *downgrade*: 2 → 3 with a stale cache only misses a hardening, while 3 → 2 would send a cookie the pad app cannot read.

- **It expires.** A release nothing has confirmed for six hours stops counting. Without that, an admin moving back to an Etherpad 2 whose `/health` is unreachable – behind proxy auth, or simply not routed – would have had every protected pad locked out for good, asked once a minute.
- **It is kept against the host it was read from.** What one pad server says about itself is not true of the next one.
- **A failed check is left alone for a minute.** Otherwise a pad server that accepts the connection and then says nothing costs every open the health timeout, for as long as it stays that way.
- **Concurrent opens do not each ask.** The check is claimed through the distributed cache, because Nextcloud loads app config once per request – a timestamp written there is invisible to a request already running. Claimed per host and released once the answer is written. No memory cache means one worker per open and nothing to coordinate with, so the check goes ahead.
- **A clock that jumps backwards is not freshness.** A stamp from the future is no age at all – and no age means check again, not "hours stale", which would wipe a cache seconds old and log that it was hours old.
- **Not knowing means a readable cookie.** Being wrong that way costs a hardening. The other way costs every protected pad on the instance.

`/health` gets three seconds on the open path, where nothing depends on its answer. The admin connection test gets the full fifteen, because a slow but healthy pad server is not a misconfiguration of this app.

### An escape hatch, and somewhere to look

The failure mode of getting this wrong is total, so it does not rest on detection alone. `etherpad_http_only_session_cookie` takes `auto` (default), `yes` or `no`:

```bash
occ config:app:set etherpad_nextcloud etherpad_http_only_session_cookie --value=no
```

Anything else – `true`, `1`, `off` – is ignored with a log warning rather than silently read as `auto`, because those are the words someone reaches for while pads are down.

The connection test has a line of its own showing which release was found and what the cookie will be. It **reads** the open path's answer rather than resolving it: resolving would refresh an expired cache, which means probing the *stored* host and writing three app values, so testing an unsaved form would teach the open path something – and against a host that has gone away it would park real pad opens in the failure backoff because somebody pressed a button.

It also asks the submitted host separately, and says so when the two disagree. That disagreement is exactly what a downgrade looks like from the outside, and reporting only a fresh probe would have called the moment of the lockout "OK".

The two override values do not look alike: `yes` below 3.0 breaks every protected pad and warns; `no` gives up a hardening and does not, because warning on it teaches an admin to ignore the line that would have told them about the other one. Both name the release, so someone who reached for the escape hatch during an outage can see whether they may put it back.

### Tests

`tests/integration/e2e-protected-cookie-contract.sh` asserted that the cookie must *not* be `HttpOnly` – the regression net for the invariant this change replaces. It now reads the release from `/health` (reachable via the `pad_url` in the open response) and expects `HttpOnly` exactly when the pad server is a 3, skipping with a note when `/health` cannot be reached from where the script runs.

The new `protected-session-cookie-httponly` spec holds the emitted `Set-Cookie` against the release. Its negative half – the Etherpad 2 branch, three of the four CI matrix jobs – would otherwise pass on any absence of the flag, including detection being broken end to end: the spec asks `/health` from the runner's network, while the app asks from inside the container against its own api host. So it also asks the connection test to name the release the app **cached** while opening the pad above, which is only possible if the whole path ran.

The major-3 boundary is restated in the spec, in the bash contract and in the docs rather than imported from `HTTP_ONLY_SINCE_MAJOR`. A test that derives its expectation from the thing under test asserts nothing – but each copy now names the constant, so moving it is greppable.

PHPUnit 732 / 2624 assertions, Psalm `--no-cache` clean, Playwright 30 passed / 1 skipped against **both** Etherpad 2.7.3 and 3.3.3.

### Not in here

The override is an app value, not a field on the settings page – that is a validator, a repository, a DTO and a Vue form, and the form's shape deserves its own decision. It is also what would make one thing testable in CI that is currently a documented manual check: what a wrong flag costs is a property of Etherpad rather than of this app, and reproducing it needs `occ` from inside the suite or the override in the form. The recipe is in the spec's docblock.
