### PR TITLE
Stop sending the Etherpad session cookie to other sites

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -184,7 +184,7 @@ Primary flow (native viewer when available):
 - We intentionally use explicit attributes required for Etherpad iframe sessions across subdomains:
   - `Domain`
   - `Secure`
-  - `SameSite=None`
+  - `SameSite=Lax`
 - Domain source:
   - explicit `etherpad_cookie_domain` app setting when configured
   - otherwise derived from `etherpad_host` with label-aware fallback rules

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -184,7 +184,7 @@ Primary flow (native viewer when available):
 - We intentionally use explicit attributes required for Etherpad iframe sessions across subdomains:
   - `Domain`
   - `Secure`
-  - `SameSite=Lax`
+  - `SameSite=Lax`, or `None` where `etherpad_session_cookie_samesite` says so
 - Domain source:
   - explicit `etherpad_cookie_domain` app setting when configured
   - otherwise derived from `etherpad_host` with label-aware fallback rules

--- a/docs/etherpad-integration.md
+++ b/docs/etherpad-integration.md
@@ -209,16 +209,33 @@ subresource, `Lax` covers it, and a foreign page that frames a pad URL gets
 no session cookie with it: the pad renders unauthenticated instead of as the
 visiting user.
 
-There is no `None` case. The embed routes (`trusted_embed_origins`) look
-like one and are not: they are `NoAdminRequired`, so they need a Nextcloud
-session, and Nextcloud pins its own session cookie to `Lax` on every
-supported version. A cross-site embed is unauthenticated before Etherpad is
-ever reached, so widening this cookie would buy a flow that does not work.
-An embed origin under the same registrable domain – `portal.example.org`
-framing `cloud.example.org` – is same-site throughout and unaffected.
+`Strict` is deliberately not used: it would also withhold the cookie from a
+top-level navigation, so a pad link in an email would open unauthenticated.
 
-Public shares are `PublicPage` but add no `frame-ancestors`, so Nextcloud's
-default `'self'` keeps them from being framed elsewhere.
+`None` exists as an opt-in and is never inferred:
+
+```bash
+occ config:app:set etherpad_nextcloud etherpad_session_cookie_samesite --value=none
+```
+
+It is needed by one deployment: a foreign site framing the embed routes.
+Those routes are `NoAdminRequired`, so they need an authenticated Nextcloud
+request – and Nextcloud sends its own session cookie as `Lax`, so a
+cross-site frame is not logged in through it. What makes such an embed work
+anyway is authentication that does not travel in a cookie: a proxy-injected
+`REMOTE_USER`, Kerberos, or SAML in environment mode. That is not something
+this app can detect, so an admin who runs it says so. The connection test
+warns while the setting is on, and names what Nextcloud's own cookie does.
+
+An embed origin under the same registrable domain – `portal.example.org`
+framing `cloud.example.org` – is same-site throughout and needs none of
+this.
+
+A writable protected public share does mint a session, and its page carries
+no `frame-ancestors` of its own – but any installed app may add one through
+`AddContentSecurityPolicyEvent`, which Nextcloud merges into every response.
+`Lax` is the safer value there for exactly that reason, rather than a
+guarantee that such a page can never be framed.
 
 ### `HttpOnly` and the Etherpad release
 
@@ -251,6 +268,7 @@ App config keys, none of them meant to be edited by hand except the first:
 | `etherpad_http_only_session_cookie` | Exactly `auto` (default), `yes` or `no` – anything else is ignored, with one warning per hour in the log and a line in the connection test. The escape hatch when detection is wrong. `yes` against an Etherpad below 3.0 stops every protected pad from opening. |
 | `etherpad_http_only_override_warned_at` | when the warning above was last written, so it is one line an hour rather than one per pad open |
 | `etherpad_release_failed` | JSON: when a check last failed, and for which host. Its own value, because a failure has nothing to say about the release – folding the two together made every failure overwrite the record. |
+| `etherpad_session_cookie_samesite` | `lax` (default) or `none`. Only for a cross-site embed behind cookie-independent authentication – see above. |
 | `etherpad_release_state` | JSON: the detected release, the API host it was read from, when it was last confirmed, and when a check last failed. One value on purpose – a check that finishes after the app has been repointed can only write a record that says which server it is about, and the next reader discards it. |
 
 ```bash

--- a/docs/etherpad-integration.md
+++ b/docs/etherpad-integration.md
@@ -229,7 +229,9 @@ warns while the setting is on, and names what Nextcloud's own cookie does.
 
 An embed origin under the same registrable domain – `portal.example.org`
 framing `cloud.example.org` – is same-site throughout and needs none of
-this.
+this. The connection test names any trusted embed origin the session cookie
+domain does not reach, because that is the configuration that otherwise
+fails in silence: the embedded pad gets no session and nothing says why.
 
 A writable protected public share does mint a session, and its page carries
 no `frame-ancestors` of its own – but any installed app may add one through
@@ -261,14 +263,16 @@ The connection test in the admin settings shows which release was found and
 what the cookie will be, and warns when the two have drifted apart — which
 is what a downgrade looks like from the outside.
 
-App config keys, none of them meant to be edited by hand except the first:
+App config keys. `etherpad_http_only_session_cookie` and
+`etherpad_session_cookie_samesite` are the two an admin sets; the rest is
+this app's own bookkeeping:
 
 | key | meaning |
 | --- | --- |
 | `etherpad_http_only_session_cookie` | Exactly `auto` (default), `yes` or `no` – anything else is ignored, with one warning per hour in the log and a line in the connection test. The escape hatch when detection is wrong. `yes` against an Etherpad below 3.0 stops every protected pad from opening. |
 | `etherpad_http_only_override_warned_at` | when the warning above was last written, so it is one line an hour rather than one per pad open |
 | `etherpad_release_failed` | JSON: when a check last failed, and for which host. Its own value, because a failure has nothing to say about the release – folding the two together made every failure overwrite the record. |
-| `etherpad_session_cookie_samesite` | `lax` (default) or `none`. Only for a cross-site embed behind cookie-independent authentication – see above. |
+| `etherpad_session_cookie_samesite` | Exactly `lax` (default) or `none` – anything else, `strict` included, is ignored and named by the connection test. Only for a cross-site embed behind cookie-independent authentication, see above. |
 | `etherpad_release_state` | JSON: the detected release, the API host it was read from, when it was last confirmed, and when a check last failed. One value on purpose – a check that finishes after the app has been repointed can only write a record that says which server it is about, and the next reader discards it. |
 
 ```bash

--- a/docs/etherpad-integration.md
+++ b/docs/etherpad-integration.md
@@ -190,7 +190,7 @@ Cookie details:
 
 - Name: `sessionID`
 - `secure: true`
-- `samesite: None`
+- `samesite: Lax`
 - `http_only`: depends on the Etherpad release, see below
 - Domain handling:
   - if `etherpad_cookie_domain` is set, this value is used as-is
@@ -199,6 +199,26 @@ Cookie details:
     - multi-label host (for example `pad.example.org`) -> `.example.org`
   - derivation is skipped for IP hosts and invalid host values
   - recommendation: use explicit `etherpad_cookie_domain` in multi-subdomain/proxy setups
+
+### `SameSite=Lax`
+
+Nextcloud and Etherpad have to share a registrable domain for a protected
+pad to work at all – a browser rejects a `Set-Cookie` whose `Domain=` is not
+a suffix of the host that set it. So the pad iframe is a same-site
+subresource, `Lax` covers it, and a foreign page that frames a pad URL gets
+no session cookie with it: the pad renders unauthenticated instead of as the
+visiting user.
+
+There is no `None` case. The embed routes (`trusted_embed_origins`) look
+like one and are not: they are `NoAdminRequired`, so they need a Nextcloud
+session, and Nextcloud pins its own session cookie to `Lax` on every
+supported version. A cross-site embed is unauthenticated before Etherpad is
+ever reached, so widening this cookie would buy a flow that does not work.
+An embed origin under the same registrable domain – `portal.example.org`
+framing `cloud.example.org` – is same-site throughout and unaffected.
+
+Public shares are `PublicPage` but add no `frame-ancestors`, so Nextcloud's
+default `'self'` keeps them from being framed elsewhere.
 
 ### `HttpOnly` and the Etherpad release
 
@@ -241,7 +261,7 @@ Regression safety check:
 
 - `tests/integration/e2e-protected-cookie-contract.sh` validates the protected open response cookie contract:
   - one `sessionID` `Set-Cookie` header from app flow
-  - includes `Secure` and `SameSite=None`
+  - includes `Secure` and `SameSite=Lax`
   - `HttpOnly` present exactly when the pad server's `/health` reports a
     release of 3 or newer; skipped with a note when `/health` cannot be
     reached from where the script runs

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -162,6 +162,6 @@ Expected result: no new warnings for `PadCreateController::create` above the Nex
 ## 6) Cookie Header Contract (Protected Pads)
 
 - Protected pad open responses intentionally attach one explicit `Set-Cookie` header for Etherpad session bootstrapping.
-- We use explicit cookie attributes (`Domain`, `Secure`, `SameSite=None`) for cross-subdomain iframe sessions.
+- We use explicit cookie attributes (`Domain`, `Secure`, `SameSite=Lax`) for cross-subdomain iframe sessions. `Lax` is enough because Nextcloud and Etherpad must share a registrable domain for the cookie to be settable at all.
 - Current contract: this app writes one Etherpad session cookie on these responses; no additional custom cookies are added by this app on the same response.
 - If future features require multiple custom cookies on the same response, cookie handling must be extended deliberately and covered by dedicated tests.

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -162,6 +162,6 @@ Expected result: no new warnings for `PadCreateController::create` above the Nex
 ## 6) Cookie Header Contract (Protected Pads)
 
 - Protected pad open responses intentionally attach one explicit `Set-Cookie` header for Etherpad session bootstrapping.
-- We use explicit cookie attributes (`Domain`, `Secure`, `SameSite=Lax`) for cross-subdomain iframe sessions. `Lax` is enough because Nextcloud and Etherpad must share a registrable domain for the cookie to be settable at all.
+- We use explicit cookie attributes (`Domain`, `Secure`, `SameSite=Lax`) for cross-subdomain iframe sessions. `Lax` is enough because Nextcloud and Etherpad must share a registrable domain for the cookie to be settable at all. An instance with `etherpad_session_cookie_samesite=none` sends `None` instead – check the setting before reading a deviation as a bug.
 - Current contract: this app writes one Etherpad session cookie on these responses; no additional custom cookies are added by this app on the same response.
 - If future features require multiple custom cookies on the same response, cookie handling must be extended deliberately and covered by dedicated tests.

--- a/lib/Service/CookieDomainPolicy.php
+++ b/lib/Service/CookieDomainPolicy.php
@@ -133,6 +133,24 @@ class CookieDomainPolicy {
 	 * Suffix test on label boundaries, so `example.org` does not cover
 	 * `evil-example.org`.
 	 */
+	/**
+	 * Whether a URL or host sits inside a cookie `Domain=`.
+	 *
+	 * Not a same-site test — it is narrower, and deliberately so. A host the
+	 * cookie already reaches is certainly one site with it; a host outside
+	 * may still be, and the caller treats that as "worth checking" rather
+	 * than as an answer.
+	 */
+	public function isCoveredBy(string $urlOrHost, string $cookieDomain): bool {
+		$host = $this->extractHost($urlOrHost);
+		$domain = ltrim(strtolower(trim($cookieDomain)), '.');
+		if ($host === '' || $domain === '') {
+			return false;
+		}
+
+		return $this->domainCovers($domain, $host);
+	}
+
 	private function domainCovers(string $domain, string $host): bool {
 		return $host === $domain || str_ends_with($host, '.' . $domain);
 	}

--- a/lib/Service/EtherpadHealthCheckService.php
+++ b/lib/Service/EtherpadHealthCheckService.php
@@ -9,8 +9,10 @@ declare(strict_types=1);
 
 namespace OCA\EtherpadNextcloud\Service;
 
+use OCA\EtherpadNextcloud\AppInfo\Application;
 use OCA\EtherpadNextcloud\Exception\AdminHealthCheckException;
 use OCA\EtherpadNextcloud\Exception\EtherpadClientException;
+use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IURLGenerator;
 
@@ -37,6 +39,7 @@ class EtherpadHealthCheckService {
 		private BaseUrlReachabilityCheck $baseUrlCheck,
 		private IURLGenerator $urlGenerator,
 		private EtherpadReleasePolicy $releasePolicy,
+		private IConfig $config,
 	) {
 	}
 
@@ -169,6 +172,11 @@ class EtherpadHealthCheckService {
 			);
 		}
 
+		$crossSite = $this->crossSiteCookieLine();
+		if ($crossSite !== null) {
+			return $crossSite;
+		}
+
 		$unrecognised = $this->releasePolicy->unrecognisedOverride();
 		if ($unrecognised !== '') {
 			return $this->sessionCookieItem(
@@ -262,6 +270,42 @@ class EtherpadHealthCheckService {
 					: $this->l10n->t('Session cookie readable by scripts (Etherpad {release})'),
 				['release' => $this->shorten($knownRelease)],
 			),
+		);
+	}
+
+	/**
+	 * The one line about `SameSite`, and only when it has been widened.
+	 *
+	 * `None` is set by hand, for one deployment: a foreign site framing the
+	 * embed routes where Nextcloud authenticates the request without a
+	 * cookie. Whether that holds is not something this app can decide, but
+	 * Nextcloud's own session cookie is readable at runtime and says which
+	 * half of the question the admin is in — so it is reported rather than
+	 * assumed, which is what the comment in the cookie builder used to do.
+	 */
+	private function crossSiteCookieLine(): ?HealthCheckItem {
+		$configured = strtolower(trim((string)$this->config->getAppValue(
+			Application::APP_ID,
+			PadSessionService::SAME_SITE_KEY,
+			'lax',
+		)));
+		if ($configured !== 'none') {
+			return null;
+		}
+
+		$nextcloudSameSite = strtolower(trim(session_get_cookie_params()['samesite'] ?? ''));
+		$detail = $this->l10n->t('Set by hand so a foreign site can frame the embed routes. It only works where Nextcloud authenticates without a cookie — proxy REMOTE_USER, Kerberos, SAML in environment mode.');
+		if (in_array($nextcloudSameSite, ['lax', 'strict'], true)) {
+			$detail .= ' ' . $this->fill(
+				$this->l10n->t('Nextcloud sends its own session cookie as {samesite}, so a cross-site frame is not logged in through it.'),
+				['samesite' => ucfirst($nextcloudSameSite)],
+			);
+		}
+
+		return $this->sessionCookieItem(
+			HealthCheckItem::STATUS_WARNING,
+			$this->l10n->t('Session cookie sent to other sites (SameSite=None)'),
+			$detail,
 		);
 	}
 

--- a/lib/Service/EtherpadHealthCheckService.php
+++ b/lib/Service/EtherpadHealthCheckService.php
@@ -9,10 +9,8 @@ declare(strict_types=1);
 
 namespace OCA\EtherpadNextcloud\Service;
 
-use OCA\EtherpadNextcloud\AppInfo\Application;
 use OCA\EtherpadNextcloud\Exception\AdminHealthCheckException;
 use OCA\EtherpadNextcloud\Exception\EtherpadClientException;
-use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IURLGenerator;
 
@@ -39,7 +37,8 @@ class EtherpadHealthCheckService {
 		private BaseUrlReachabilityCheck $baseUrlCheck,
 		private IURLGenerator $urlGenerator,
 		private EtherpadReleasePolicy $releasePolicy,
-		private IConfig $config,
+		private PadSessionService $padSessionService,
+		private AppConfigService $appConfigService,
 	) {
 	}
 
@@ -282,17 +281,42 @@ class EtherpadHealthCheckService {
 	 * is in — reported rather than assumed.
 	 */
 	private function withCrossSiteNote(HealthCheckItem $item): HealthCheckItem {
-		$configured = strtolower(trim((string)$this->config->getAppValue(
-			Application::APP_ID,
-			PadSessionService::SAME_SITE_KEY,
-			'lax',
-		)));
-		if ($configured !== 'none') {
+		$note = $this->crossSiteNote();
+		if ($note === '') {
 			return $item;
 		}
 
+		// One slot, two things worth saying. Folded in rather than returned
+		// instead: the line underneath can be the one announcing that no
+		// protected pad opens at all, and a note about how far the cookie
+		// travels must not push that off the panel.
+		//
+		// The label moves into the detail when there was none. A passing
+		// line keeps its text there — the release, the cookie verdict — and
+		// the panel only renders a label while the status is ok.
+		return $this->sessionCookieItem(
+			HealthCheckItem::STATUS_WARNING,
+			$item->label,
+			trim(($item->detail !== '' ? $item->detail : $item->label) . ' ' . $note),
+		);
+	}
+
+	/** What is worth saying about how far the cookie travels, or ''. */
+	private function crossSiteNote(): string {
+		$unrecognised = $this->padSessionService->unrecognisedSameSite();
+		if ($unrecognised !== '') {
+			return $this->fill(
+				$this->l10n->t('"{value}" is not one of lax or none, so the session cookie stays same-site. Set one of those two, or remove the setting.'),
+				['value' => $unrecognised],
+			);
+		}
+
+		if ($this->padSessionService->sameSiteMode() !== PadSessionService::SAME_SITE_NONE) {
+			return $this->embedOriginNote();
+		}
+
 		$note = $this->l10n->t('The session cookie is also sent to other sites (SameSite=None), set by hand so a foreign site can frame the embed routes. It only works where Nextcloud authenticates without a cookie — proxy REMOTE_USER, Kerberos, SAML in environment mode.');
-		$nextcloudSameSite = strtolower(trim(session_get_cookie_params()['samesite'] ?? ''));
+		$nextcloudSameSite = $this->nextcloudSessionSameSite();
 		if (in_array($nextcloudSameSite, ['lax', 'strict'], true)) {
 			$note .= ' ' . $this->fill(
 				$this->l10n->t('Nextcloud sends its own session cookie as {samesite}, so a cross-site frame is not logged in through it.'),
@@ -300,15 +324,48 @@ class EtherpadHealthCheckService {
 			);
 		}
 
-		// One slot, two things worth saying. Folded in rather than returned
-		// instead: the line underneath can be the one announcing that no
-		// protected pad opens at all, and a note about how far the cookie
-		// travels must not push that off the panel.
-		return $this->sessionCookieItem(
-			HealthCheckItem::STATUS_WARNING,
-			$item->label,
-			trim($item->detail . ' ' . $note),
+		return $note;
+	}
+
+	/**
+	 * The configuration that breaks silently: an embed origin outside the
+	 * cookie's own domain while the cookie stays same-site.
+	 *
+	 * Compared against the domain the cookie actually carries, not against
+	 * a guess at the registrable domain — an origin the cookie already
+	 * covers is certainly same-site, and anything else is worth a second
+	 * look. Over-warning is the acceptable direction here: this asks an
+	 * admin to check, where deciding the cookie from the same comparison
+	 * would need a public suffix list to be right.
+	 */
+	private function embedOriginNote(): string {
+		$origins = $this->appConfigService->getTrustedEmbedOrigins();
+		if ($origins === []) {
+			return '';
+		}
+
+		$cookieDomain = $this->cookieDomainPolicy->resolve(
+			$this->urlGenerator->getBaseUrl(),
+			$this->etherpadClient->getConfiguredOrigin(),
+			null,
 		);
+		$outside = array_values(array_filter(
+			$origins,
+			fn (string $origin): bool => !$this->cookieDomainPolicy->isCoveredBy($origin, $cookieDomain),
+		));
+		if ($outside === []) {
+			return '';
+		}
+
+		return $this->fill(
+			$this->l10n->t('{origins} may frame the embed routes but is not covered by the session cookie domain {domain}. If it is on another site, the embedded pad gets no Etherpad session unless etherpad_session_cookie_samesite is set to none.'),
+			['origins' => $this->shorten(implode(', ', $outside)), 'domain' => $cookieDomain !== '' ? $cookieDomain : '(host-only)'],
+		);
+	}
+
+	/** Seam: there is no session in a unit test, so this is overridable. */
+	protected function nextcloudSessionSameSite(): string {
+		return strtolower(trim(session_get_cookie_params()['samesite'] ?? ''));
 	}
 
 	/** The same vocabulary the rest of this class uses for a failed call. */

--- a/lib/Service/EtherpadHealthCheckService.php
+++ b/lib/Service/EtherpadHealthCheckService.php
@@ -172,11 +172,10 @@ class EtherpadHealthCheckService {
 			);
 		}
 
-		$crossSite = $this->crossSiteCookieLine();
-		if ($crossSite !== null) {
-			return $crossSite;
-		}
+		return $this->withCrossSiteNote($this->sessionCookieDiagnosis($settings));
+	}
 
+	private function sessionCookieDiagnosis(ValidatedAdminSettings $settings): HealthCheckItem {
 		$unrecognised = $this->releasePolicy->unrecognisedOverride();
 		if ($unrecognised !== '') {
 			return $this->sessionCookieItem(
@@ -274,38 +273,41 @@ class EtherpadHealthCheckService {
 	}
 
 	/**
-	 * The one line about `SameSite`, and only when it has been widened.
+	 * What `SameSite=None` costs, added to whatever else the line says.
 	 *
-	 * `None` is set by hand, for one deployment: a foreign site framing the
-	 * embed routes where Nextcloud authenticates the request without a
-	 * cookie. Whether that holds is not something this app can decide, but
-	 * Nextcloud's own session cookie is readable at runtime and says which
-	 * half of the question the admin is in — so it is reported rather than
-	 * assumed, which is what the comment in the cookie builder used to do.
+	 * Set by hand, for one deployment: a foreign site framing the embed
+	 * routes where Nextcloud authenticates without a cookie. Whether that
+	 * holds is not this app's to decide, but Nextcloud's own session cookie
+	 * is readable at runtime and says which half of the question the admin
+	 * is in — reported rather than assumed.
 	 */
-	private function crossSiteCookieLine(): ?HealthCheckItem {
+	private function withCrossSiteNote(HealthCheckItem $item): HealthCheckItem {
 		$configured = strtolower(trim((string)$this->config->getAppValue(
 			Application::APP_ID,
 			PadSessionService::SAME_SITE_KEY,
 			'lax',
 		)));
 		if ($configured !== 'none') {
-			return null;
+			return $item;
 		}
 
+		$note = $this->l10n->t('The session cookie is also sent to other sites (SameSite=None), set by hand so a foreign site can frame the embed routes. It only works where Nextcloud authenticates without a cookie — proxy REMOTE_USER, Kerberos, SAML in environment mode.');
 		$nextcloudSameSite = strtolower(trim(session_get_cookie_params()['samesite'] ?? ''));
-		$detail = $this->l10n->t('Set by hand so a foreign site can frame the embed routes. It only works where Nextcloud authenticates without a cookie — proxy REMOTE_USER, Kerberos, SAML in environment mode.');
 		if (in_array($nextcloudSameSite, ['lax', 'strict'], true)) {
-			$detail .= ' ' . $this->fill(
+			$note .= ' ' . $this->fill(
 				$this->l10n->t('Nextcloud sends its own session cookie as {samesite}, so a cross-site frame is not logged in through it.'),
 				['samesite' => ucfirst($nextcloudSameSite)],
 			);
 		}
 
+		// One slot, two things worth saying. Folded in rather than returned
+		// instead: the line underneath can be the one announcing that no
+		// protected pad opens at all, and a note about how far the cookie
+		// travels must not push that off the panel.
 		return $this->sessionCookieItem(
 			HealthCheckItem::STATUS_WARNING,
-			$this->l10n->t('Session cookie sent to other sites (SameSite=None)'),
-			$detail,
+			$item->label,
+			trim($item->detail . ' ' . $note),
 		);
 	}
 

--- a/lib/Service/PadSessionService.php
+++ b/lib/Service/PadSessionService.php
@@ -40,8 +40,10 @@ class PadSessionService {
 	 */
 	private const MAX_SESSION_IDS = 25;
 
-	/** `lax` (default) or `none`; see resolveSameSite(). */
+	/** `lax` (default) or `none`; see sameSiteMode(). */
 	public const SAME_SITE_KEY = 'etherpad_session_cookie_samesite';
+	public const SAME_SITE_LAX = 'Lax';
+	public const SAME_SITE_NONE = 'None';
 
 	/**
 	 * How many ids are read out of the cookie at all. Only a bound on work:
@@ -300,7 +302,7 @@ class PadSessionService {
 			'path' => '/',
 			'domain' => $cookieDomain,
 			'secure' => true,
-			'same_site' => $this->resolveSameSite(),
+			'same_site' => $this->sameSiteMode(),
 			// Up to Etherpad 2.7.3 the pad app reads `sessionID` itself, in
 			// the browser — HttpOnly there would lock the user out of every
 			// protected pad. From 3.0.0 the server takes it out of the
@@ -352,15 +354,49 @@ class PadSessionService {
 	 * cannot see that, and the previous attempt to work it out from the
 	 * hosts involved needed a public suffix list to be right. So the admin
 	 * says so.
+	 *
+	 * Anything else is `Lax`, and named by the connection test rather than
+	 * swallowed — `strict` included, where somebody meant to harden.
 	 */
-	private function resolveSameSite(): string {
+	public function sameSiteMode(): string {
+		return $this->readSameSite()['mode'];
+	}
+
+	/**
+	 * A stored value that is none of the accepted words, or ''.
+	 *
+	 * Worth being able to say: `off`, `no` and `cross-site` all read as
+	 * `Lax` here, and so does `strict` — where somebody meant to harden and
+	 * gets the opposite. The sibling setting for HttpOnly reports the same
+	 * thing for the same reason.
+	 */
+	public function unrecognisedSameSite(): string {
+		return $this->readSameSite()['unrecognised'];
+	}
+
+	/**
+	 * The stored value, read once and in one place.
+	 *
+	 * Public through the two methods above so the admin health check reports
+	 * on the same reading rather than parsing the value again with its own
+	 * default.
+	 *
+	 * @return array{mode:string,unrecognised:string}
+	 */
+	private function readSameSite(): array {
 		$configured = strtolower(trim((string)$this->config->getAppValue(
 			'etherpad_nextcloud',
 			self::SAME_SITE_KEY,
 			'lax',
 		)));
+		if ($configured === 'none') {
+			return ['mode' => self::SAME_SITE_NONE, 'unrecognised' => ''];
+		}
+		if ($configured === 'lax' || $configured === '') {
+			return ['mode' => self::SAME_SITE_LAX, 'unrecognised' => ''];
+		}
 
-		return $configured === 'none' ? 'None' : 'Lax';
+		return ['mode' => self::SAME_SITE_LAX, 'unrecognised' => substr($configured, 0, 32)];
 	}
 
 	private function resolveCookieDomain(): string {

--- a/lib/Service/PadSessionService.php
+++ b/lib/Service/PadSessionService.php
@@ -40,6 +40,9 @@ class PadSessionService {
 	 */
 	private const MAX_SESSION_IDS = 25;
 
+	/** `lax` (default) or `none`; see resolveSameSite(). */
+	public const SAME_SITE_KEY = 'etherpad_session_cookie_samesite';
+
 	/**
 	 * How many ids are read out of the cookie at all. Only a bound on work:
 	 * the cap above decides what survives. Any host under the shared parent
@@ -297,23 +300,7 @@ class PadSessionService {
 			'path' => '/',
 			'domain' => $cookieDomain,
 			'secure' => true,
-			// Lax, and there is no case for None. Nextcloud and Etherpad have
-			// to share a registrable domain for a protected pad to work at
-			// all — a browser rejects a `Set-Cookie` whose `Domain=` is not a
-			// suffix of the host that set it — so the pad iframe is a
-			// same-site subresource, while a foreign page framing a pad URL
-			// gets nothing.
-			//
-			// The embed routes look like the exception and are not: they are
-			// NoAdminRequired, so they need a Nextcloud session, and
-			// Nextcloud pins its own session cookie to Lax on every version
-			// this app supports (Session/Internal.php, 31 through 33). A
-			// cross-site embed is therefore already unauthenticated before
-			// Etherpad is reached. Widening this cookie for it would buy a
-			// flow that does not work. Public shares are PublicPage but add
-			// no frame-ancestors, so Nextcloud's own `'self'` keeps them from
-			// being framed elsewhere.
-			'same_site' => 'Lax',
+			'same_site' => $this->resolveSameSite(),
 			// Up to Etherpad 2.7.3 the pad app reads `sessionID` itself, in
 			// the browser — HttpOnly there would lock the user out of every
 			// protected pad. From 3.0.0 the server takes it out of the
@@ -344,6 +331,36 @@ class PadSessionService {
 			$parts[] = 'SameSite=' . $cookie['same_site'];
 		}
 		return implode('; ', $parts);
+	}
+
+	/**
+	 * How far the session cookie may travel.
+	 *
+	 * `Lax` by default, and it costs nothing in the ordinary chain:
+	 * Nextcloud and Etherpad have to share a registrable domain for a
+	 * protected pad to work at all — a browser rejects a `Set-Cookie` whose
+	 * `Domain=` is not a suffix of the host that set it — so the pad iframe
+	 * is a same-site subresource, while a foreign page framing a pad URL
+	 * gets nothing. `Strict` would go further and is deliberately not used:
+	 * it would also withhold the cookie from a top-level navigation, so a
+	 * pad link in an email would open unauthenticated.
+	 *
+	 * `None` is asked for, never inferred. It is needed by exactly one
+	 * deployment: a foreign site framing the embed routes, where Nextcloud
+	 * authenticates the request without a cookie — proxy-injected
+	 * `REMOTE_USER`, Kerberos, SAML in environment mode. A cookie policy
+	 * cannot see that, and the previous attempt to work it out from the
+	 * hosts involved needed a public suffix list to be right. So the admin
+	 * says so.
+	 */
+	private function resolveSameSite(): string {
+		$configured = strtolower(trim((string)$this->config->getAppValue(
+			'etherpad_nextcloud',
+			self::SAME_SITE_KEY,
+			'lax',
+		)));
+
+		return $configured === 'none' ? 'None' : 'Lax';
 	}
 
 	private function resolveCookieDomain(): string {

--- a/lib/Service/PadSessionService.php
+++ b/lib/Service/PadSessionService.php
@@ -297,13 +297,29 @@ class PadSessionService {
 			'path' => '/',
 			'domain' => $cookieDomain,
 			'secure' => true,
+			// Lax, and there is no case for None. Nextcloud and Etherpad have
+			// to share a registrable domain for a protected pad to work at
+			// all — a browser rejects a `Set-Cookie` whose `Domain=` is not a
+			// suffix of the host that set it — so the pad iframe is a
+			// same-site subresource, while a foreign page framing a pad URL
+			// gets nothing.
+			//
+			// The embed routes look like the exception and are not: they are
+			// NoAdminRequired, so they need a Nextcloud session, and
+			// Nextcloud pins its own session cookie to Lax on every version
+			// this app supports (Session/Internal.php, 31 through 33). A
+			// cross-site embed is therefore already unauthenticated before
+			// Etherpad is reached. Widening this cookie for it would buy a
+			// flow that does not work. Public shares are PublicPage but add
+			// no frame-ancestors, so Nextcloud's own `'self'` keeps them from
+			// being framed elsewhere.
+			'same_site' => 'Lax',
 			// Up to Etherpad 2.7.3 the pad app reads `sessionID` itself, in
 			// the browser — HttpOnly there would lock the user out of every
 			// protected pad. From 3.0.0 the server takes it out of the
 			// socket.io handshake and the browser never needs to see it, so
 			// the cookie can be kept away from any script on the page.
 			'http_only' => $this->releasePolicy->supportsHttpOnlySessionCookie(),
-			'same_site' => 'None',
 		];
 	}
 

--- a/lib/Settings/AdminSettings.php
+++ b/lib/Settings/AdminSettings.php
@@ -137,7 +137,7 @@ class AdminSettings implements ISettings {
 				'external_allowlist' => $this->l10n->t('External Etherpad host allowlist (optional)'),
 				'external_allowlist_hint' => $this->l10n->t('Add trusted Etherpad hostnames or HTTPS origins. Leave empty only if all public HTTPS hosts should be trusted.'),
 				'trusted_embed_origins' => $this->l10n->t('Trusted embed origins (optional)'),
-				'trusted_embed_origins_hint' => $this->l10n->t('Absolute https origins allowed to embed the /embed/by-id and /embed/create-by-parent routes. Leave empty to disable external embedding.'),
+				'trusted_embed_origins_hint' => $this->l10n->t('Absolute https origins allowed to embed the /embed/by-id and /embed/create-by-parent routes. Leave empty to disable external embedding. An origin on another registrable domain also needs Nextcloud to authenticate without a cookie (proxy REMOTE_USER, Kerberos, SAML in environment mode) and the app setting etherpad_session_cookie_samesite=none; without both, the embedded pad has no Etherpad session.'),
 				'save_button' => $this->l10n->t('Save settings'),
 				'health_button' => $this->l10n->t('Test Etherpad connection'),
 				'consistency_button' => $this->l10n->t('Consistency check'),

--- a/tests/e2e/specs/protected-session-cookie-httponly.spec.ts
+++ b/tests/e2e/specs/protected-session-cookie-httponly.spec.ts
@@ -64,10 +64,12 @@ test.describe('the session cookie and the Etherpad that reads it', () => {
 				.find((value) => value.startsWith('sessionID='))
 			expect(setCookie, 'a protected open should set the Etherpad session cookie').toBeDefined()
 
-			// Secure and SameSite=None hold either way: the cookie has to reach
-			// a pad server on another host.
 			expect(setCookie).toContain('Secure')
-			expect(setCookie).toContain('SameSite=None')
+			// Lax, because this stack has no trusted embed origins: Nextcloud
+			// and Etherpad share a registrable domain, so the pad iframe is a
+			// same-site subresource and a foreign page framing a pad URL gets
+			// no cookie. `None` is only for embedding into another site.
+			expect(setCookie).toContain('SameSite=Lax')
 
 			if (readsItServerSide) {
 				expect(setCookie, `Etherpad ${release} reads the session server-side`).toContain('HttpOnly')

--- a/tests/e2e/specs/protected-session-cookie-httponly.spec.ts
+++ b/tests/e2e/specs/protected-session-cookie-httponly.spec.ts
@@ -65,10 +65,11 @@ test.describe('the session cookie and the Etherpad that reads it', () => {
 			expect(setCookie, 'a protected open should set the Etherpad session cookie').toBeDefined()
 
 			expect(setCookie).toContain('Secure')
-			// Lax, because this stack has no trusted embed origins: Nextcloud
-			// and Etherpad share a registrable domain, so the pad iframe is a
-			// same-site subresource and a foreign page framing a pad URL gets
-			// no cookie. `None` is only for embedding into another site.
+			// Lax, the default: the value comes from
+			// etherpad_session_cookie_samesite and from nothing else, and
+			// this stack does not set it. Nextcloud and Etherpad share a
+			// registrable domain, so the pad iframe is a same-site
+			// subresource and a foreign page framing a pad URL gets nothing.
 			expect(setCookie).toContain('SameSite=Lax')
 
 			if (readsItServerSide) {

--- a/tests/integration/e2e-protected-cookie-contract.sh
+++ b/tests/integration/e2e-protected-cookie-contract.sh
@@ -137,7 +137,10 @@ fi
 SESSION_COOKIE_LINE="$(printf '%s\n' "$SESSION_COOKIE_LINES" | sed -n '1p')"
 
 assert_cookie_contains "$SESSION_COOKIE_LINE" "secure" "Secure"
-assert_cookie_contains "$SESSION_COOKIE_LINE" "samesite=none" "SameSite=None"
+# Lax unless trusted_embed_origins names a host on another site: Nextcloud
+# and Etherpad have to share a registrable domain for the cookie to be
+# settable at all, so the ordinary chain is same-site.
+assert_cookie_contains "$SESSION_COOKIE_LINE" "samesite=lax" "SameSite=Lax"
 
 # HttpOnly is not a constant of this contract, it depends on the pad server.
 # The major-3 boundary below restates EtherpadReleasePolicy's

--- a/tests/integration/e2e-protected-cookie-contract.sh
+++ b/tests/integration/e2e-protected-cookie-contract.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 # NC_BASE_URL="https://cloud.example.tld" \
 # NC_USER="alice" \
 # NC_APP_PASSWORD="app-password" \
+# EXPECTED_SAMESITE="Lax" \
 # ./tests/integration/e2e-protected-cookie-contract.sh "/Apps/Test/cookie-contract"
 
 if [[ $# -lt 1 ]]; then
@@ -137,10 +138,12 @@ fi
 SESSION_COOKIE_LINE="$(printf '%s\n' "$SESSION_COOKIE_LINES" | sed -n '1p')"
 
 assert_cookie_contains "$SESSION_COOKIE_LINE" "secure" "Secure"
-# Lax unless trusted_embed_origins names a host on another site: Nextcloud
-# and Etherpad have to share a registrable domain for the cookie to be
-# settable at all, so the ordinary chain is same-site.
-assert_cookie_contains "$SESSION_COOKIE_LINE" "samesite=lax" "SameSite=Lax"
+# Lax on a default instance. An admin can set
+# etherpad_session_cookie_samesite=none for a cross-site embed behind
+# proxy authentication; this check then has to be told, because the value
+# is not derivable from anything the script can see.
+EXPECTED_SAMESITE="$(printf '%s' "${EXPECTED_SAMESITE:-Lax}" | tr '[:upper:]' '[:lower:]')"
+assert_cookie_contains "$SESSION_COOKIE_LINE" "samesite=${EXPECTED_SAMESITE}" "SameSite=${EXPECTED_SAMESITE}"
 
 # HttpOnly is not a constant of this contract, it depends on the pad server.
 # The major-3 boundary below restates EtherpadReleasePolicy's

--- a/tests/integration/e2e-protected-cookie-contract.sh
+++ b/tests/integration/e2e-protected-cookie-contract.sh
@@ -142,8 +142,18 @@ assert_cookie_contains "$SESSION_COOKIE_LINE" "secure" "Secure"
 # etherpad_session_cookie_samesite=none for a cross-site embed behind
 # proxy authentication; this check then has to be told, because the value
 # is not derivable from anything the script can see.
-EXPECTED_SAMESITE="$(printf '%s' "${EXPECTED_SAMESITE:-Lax}" | tr '[:upper:]' '[:lower:]')"
-assert_cookie_contains "$SESSION_COOKIE_LINE" "samesite=${EXPECTED_SAMESITE}" "SameSite=${EXPECTED_SAMESITE}"
+EXPECTED_SAMESITE="${EXPECTED_SAMESITE:-Lax}"
+EXPECTED_SAMESITE_LOWER="$(printf '%s' "$EXPECTED_SAMESITE" | tr '[:upper:]' '[:lower:]')"
+# Checked before use: `Non` would match inside `samesite=none` and pass
+# while asserting nothing.
+case "$EXPECTED_SAMESITE_LOWER" in
+	lax|none|strict) ;;
+	*)
+		echo "EXPECTED_SAMESITE must be Lax, None or Strict, got '${EXPECTED_SAMESITE}'" >&2
+		exit 1
+		;;
+esac
+assert_cookie_contains "$SESSION_COOKIE_LINE" "samesite=${EXPECTED_SAMESITE_LOWER}" "SameSite=${EXPECTED_SAMESITE}"
 
 # HttpOnly is not a constant of this contract, it depends on the pad server.
 # The major-3 boundary below restates EtherpadReleasePolicy's

--- a/tests/phpunit/unit/EtherpadHealthCheckServiceTest.php
+++ b/tests/phpunit/unit/EtherpadHealthCheckServiceTest.php
@@ -108,6 +108,7 @@ class EtherpadHealthCheckServiceTest extends TestCase {
 		string $knownRelease = '',
 		string $unrecognisedOverride = '',
 		string $configuredApiHost = 'https://pad-api.example.test',
+		string $sameSiteSetting = 'lax',
 	): EtherpadHealthCheckService {
 		$urlGenerator = $this->createMock(IURLGenerator::class);
 		$urlGenerator->method('getBaseUrl')->willReturn($nextcloudUrl);
@@ -125,6 +126,12 @@ class EtherpadHealthCheckServiceTest extends TestCase {
 		// be saved.
 		$releasePolicy->expects(self::never())->method('supportsHttpOnlySessionCookie');
 		$releasePolicy->method('knownRelease')->willReturn($knownRelease);
+		$config = $this->createMock(\OCP\IConfig::class);
+		$config->method('getAppValue')->willReturnCallback(
+			static fn (string $app, string $key, string $default = ''): string => $key === \OCA\EtherpadNextcloud\Service\PadSessionService::SAME_SITE_KEY
+				? $sameSiteSetting
+				: $default
+		);
 		return new EtherpadHealthCheckService(
 			$etherpad,
 			$pending,
@@ -133,6 +140,7 @@ class EtherpadHealthCheckServiceTest extends TestCase {
 			$this->baseUrlCheck(),
 			$urlGenerator,
 			$releasePolicy,
+			$config,
 		);
 	}
 
@@ -148,6 +156,7 @@ class EtherpadHealthCheckServiceTest extends TestCase {
 		string $knownRelease = '',
 		string $unrecognisedOverride = '',
 		string $configuredApiHost = 'https://pad-api.example.test',
+		string $sameSiteSetting = 'lax',
 	): HealthCheckItem {
 		$result = $this->buildService(
 			$etherpad,
@@ -156,6 +165,7 @@ class EtherpadHealthCheckServiceTest extends TestCase {
 			knownRelease: $knownRelease,
 			unrecognisedOverride: $unrecognisedOverride,
 			configuredApiHost: $configuredApiHost,
+			sameSiteSetting: $sameSiteSetting,
 		)->check($this->settings());
 		foreach ($result->checks as $item) {
 			if ($item->id === 'session_cookie') {
@@ -297,6 +307,24 @@ class EtherpadHealthCheckServiceTest extends TestCase {
 	}
 
 	/**
+	 * `SameSite=None` is the one setting here that hands the cookie to other
+	 * sites, and it works only where Nextcloud authenticates without a
+	 * cookie. Whether that holds is not this app's to decide — but
+	 * Nextcloud's own session cookie says which half of the question the
+	 * admin is in, so it is reported rather than assumed.
+	 */
+	public function testSessionCookieLineWarnsWhenTheCookieIsSentToOtherSites(): void {
+		$etherpad = $this->createMock(EtherpadClient::class);
+		$etherpad->method('healthCheck')->willReturn(['pad_count' => 1]);
+		$etherpad->expects(self::never())->method('detectReleaseVersion');
+
+		$line = $this->sessionCookieLine($etherpad, sameSiteSetting: 'none');
+		self::assertSame(HealthCheckItem::STATUS_WARNING, $line->status);
+		self::assertStringContainsString('SameSite=None', $line->label);
+		self::assertStringContainsString('REMOTE_USER', $line->detail);
+	}
+
+	/**
 	 * The dangerous half of the override shouts, and says what the server
 	 * actually is so somebody who reached for it during an outage can see
 	 * whether they may put it back.
@@ -384,6 +412,7 @@ class EtherpadHealthCheckServiceTest extends TestCase {
 			$this->baseUrlCheck(),
 			$urlGenerator,
 			$this->createMock(\OCA\EtherpadNextcloud\Service\EtherpadReleasePolicy::class),
+			$this->createMock(\OCP\IConfig::class),
 			$ticks,
 		) extends EtherpadHealthCheckService {
 			/** @param list<float> $ticks */
@@ -395,9 +424,10 @@ class EtherpadHealthCheckServiceTest extends TestCase {
 				BaseUrlReachabilityCheck $baseUrlCheck,
 				IURLGenerator $urlGenerator,
 				\OCA\EtherpadNextcloud\Service\EtherpadReleasePolicy $releasePolicy,
+				\OCP\IConfig $config,
 				private array $ticks,
 			) {
-				parent::__construct($etherpadClient, $pendingDeleteRetryService, $l10n, $cookieDomainPolicy, $baseUrlCheck, $urlGenerator, $releasePolicy);
+				parent::__construct($etherpadClient, $pendingDeleteRetryService, $l10n, $cookieDomainPolicy, $baseUrlCheck, $urlGenerator, $releasePolicy, $config);
 			}
 
 			protected function now(): float {

--- a/tests/phpunit/unit/EtherpadHealthCheckServiceTest.php
+++ b/tests/phpunit/unit/EtherpadHealthCheckServiceTest.php
@@ -316,12 +316,41 @@ class EtherpadHealthCheckServiceTest extends TestCase {
 	public function testSessionCookieLineWarnsWhenTheCookieIsSentToOtherSites(): void {
 		$etherpad = $this->createMock(EtherpadClient::class);
 		$etherpad->method('healthCheck')->willReturn(['pad_count' => 1]);
-		$etherpad->expects(self::never())->method('detectReleaseVersion');
+		$etherpad->method('detectReleaseVersion')->willReturn('2.7.3');
 
 		$line = $this->sessionCookieLine($etherpad, sameSiteSetting: 'none');
 		self::assertSame(HealthCheckItem::STATUS_WARNING, $line->status);
-		self::assertStringContainsString('SameSite=None', $line->label);
+		self::assertStringContainsString('SameSite=None', $line->detail);
 		self::assertStringContainsString('REMOTE_USER', $line->detail);
+	}
+
+	/**
+	 * There is one session-cookie slot. A note about how far the cookie
+	 * travels must not push off the line saying that no protected pad opens
+	 * at all — which is what `yes` below Etherpad 3.0 means.
+	 */
+	public function testTheCrossSiteNoteDoesNotHideALockout(): void {
+		$etherpad = $this->createMock(EtherpadClient::class);
+		$etherpad->method('healthCheck')->willReturn(['pad_count' => 1]);
+		$etherpad->method('detectReleaseVersion')->willReturn('2.7.3');
+
+		$line = $this->sessionCookieLine($etherpad, 'yes', sameSiteSetting: 'none');
+		self::assertSame(HealthCheckItem::STATUS_WARNING, $line->status);
+		// The lockout, still there.
+		self::assertStringContainsString('by hand', $line->detail);
+		self::assertStringContainsString('2.7.3', $line->detail);
+		// And the note beside it.
+		self::assertStringContainsString('SameSite=None', $line->detail);
+	}
+
+	/** Same for a value nobody meant: the ignored setting still gets named. */
+	public function testTheCrossSiteNoteDoesNotHideAnUnrecognisedOverride(): void {
+		$etherpad = $this->createMock(EtherpadClient::class);
+		$etherpad->method('healthCheck')->willReturn(['pad_count' => 1]);
+
+		$line = $this->sessionCookieLine($etherpad, unrecognisedOverride: 'true', sameSiteSetting: 'none');
+		self::assertStringContainsString('true', $line->detail);
+		self::assertStringContainsString('SameSite=None', $line->detail);
 	}
 
 	/**

--- a/tests/phpunit/unit/EtherpadHealthCheckServiceTest.php
+++ b/tests/phpunit/unit/EtherpadHealthCheckServiceTest.php
@@ -109,6 +109,9 @@ class EtherpadHealthCheckServiceTest extends TestCase {
 		string $unrecognisedOverride = '',
 		string $configuredApiHost = 'https://pad-api.example.test',
 		string $sameSiteSetting = 'lax',
+		string $unrecognisedSameSite = '',
+		array $trustedEmbedOrigins = [],
+		string $nextcloudSameSite = '',
 	): EtherpadHealthCheckService {
 		$urlGenerator = $this->createMock(IURLGenerator::class);
 		$urlGenerator->method('getBaseUrl')->willReturn($nextcloudUrl);
@@ -126,13 +129,19 @@ class EtherpadHealthCheckServiceTest extends TestCase {
 		// be saved.
 		$releasePolicy->expects(self::never())->method('supportsHttpOnlySessionCookie');
 		$releasePolicy->method('knownRelease')->willReturn($knownRelease);
-		$config = $this->createMock(\OCP\IConfig::class);
-		$config->method('getAppValue')->willReturnCallback(
-			static fn (string $app, string $key, string $default = ''): string => $key === \OCA\EtherpadNextcloud\Service\PadSessionService::SAME_SITE_KEY
-				? $sameSiteSetting
-				: $default
+		$padSessions = $this->createMock(\OCA\EtherpadNextcloud\Service\PadSessionService::class);
+		$padSessions->method('sameSiteMode')->willReturn(
+			$sameSiteSetting === 'none'
+				? \OCA\EtherpadNextcloud\Service\PadSessionService::SAME_SITE_NONE
+				: \OCA\EtherpadNextcloud\Service\PadSessionService::SAME_SITE_LAX
 		);
-		return new EtherpadHealthCheckService(
+		$padSessions->method('unrecognisedSameSite')->willReturn($unrecognisedSameSite);
+		$appConfig = $this->createMock(\OCA\EtherpadNextcloud\Service\AppConfigService::class);
+		$appConfig->method('getTrustedEmbedOrigins')->willReturn($trustedEmbedOrigins);
+
+		// There is no session in a unit test, so the runtime read of
+		// Nextcloud's own cookie needs a seam to be exercised at all.
+		return new class(
 			$etherpad,
 			$pending,
 			$this->buildL10n(),
@@ -140,8 +149,29 @@ class EtherpadHealthCheckServiceTest extends TestCase {
 			$this->baseUrlCheck(),
 			$urlGenerator,
 			$releasePolicy,
-			$config,
-		);
+			$padSessions,
+			$appConfig,
+			$nextcloudSameSite,
+		) extends EtherpadHealthCheckService {
+			public function __construct(
+				EtherpadClient $etherpadClient,
+				PendingDeleteRetryService $pendingDeleteRetryService,
+				IL10N $l10n,
+				CookieDomainPolicy $cookieDomainPolicy,
+				BaseUrlReachabilityCheck $baseUrlCheck,
+				IURLGenerator $urlGenerator,
+				\OCA\EtherpadNextcloud\Service\EtherpadReleasePolicy $releasePolicy,
+				\OCA\EtherpadNextcloud\Service\PadSessionService $padSessionService,
+				\OCA\EtherpadNextcloud\Service\AppConfigService $appConfigService,
+				private string $nextcloudSameSite,
+			) {
+				parent::__construct($etherpadClient, $pendingDeleteRetryService, $l10n, $cookieDomainPolicy, $baseUrlCheck, $urlGenerator, $releasePolicy, $padSessionService, $appConfigService);
+			}
+
+			protected function nextcloudSessionSameSite(): string {
+				return $this->nextcloudSameSite;
+			}
+		};
 	}
 
 	/**
@@ -157,6 +187,9 @@ class EtherpadHealthCheckServiceTest extends TestCase {
 		string $unrecognisedOverride = '',
 		string $configuredApiHost = 'https://pad-api.example.test',
 		string $sameSiteSetting = 'lax',
+		string $unrecognisedSameSite = '',
+		array $trustedEmbedOrigins = [],
+		string $nextcloudSameSite = '',
 	): HealthCheckItem {
 		$result = $this->buildService(
 			$etherpad,
@@ -166,6 +199,9 @@ class EtherpadHealthCheckServiceTest extends TestCase {
 			unrecognisedOverride: $unrecognisedOverride,
 			configuredApiHost: $configuredApiHost,
 			sameSiteSetting: $sameSiteSetting,
+			unrecognisedSameSite: $unrecognisedSameSite,
+			trustedEmbedOrigins: $trustedEmbedOrigins,
+			nextcloudSameSite: $nextcloudSameSite,
 		)->check($this->settings());
 		foreach ($result->checks as $item) {
 			if ($item->id === 'session_cookie') {
@@ -325,6 +361,73 @@ class EtherpadHealthCheckServiceTest extends TestCase {
 	}
 
 	/**
+	 * The panel shows a label only while the status is ok. Folding the note
+	 * in makes the line a warning, so a passing line's text — the release,
+	 * the cookie verdict — has to move into the detail or it is gone.
+	 */
+	public function testTheCrossSiteNoteKeepsWhatThePassingLineSaid(): void {
+		$etherpad = $this->createMock(EtherpadClient::class);
+		$etherpad->method('healthCheck')->willReturn(['pad_count' => 1]);
+		$etherpad->method('detectReleaseVersion')->willReturn('3.3.3');
+
+		$line = $this->sessionCookieLine($etherpad, knownRelease: '3.3.3', sameSiteSetting: 'none');
+		self::assertSame(HealthCheckItem::STATUS_WARNING, $line->status);
+		self::assertStringContainsString('3.3.3', $line->detail);
+		self::assertStringContainsString('SameSite=None', $line->detail);
+	}
+
+	/** The runtime read, in both directions. */
+	public function testTheCrossSiteNoteNamesWhatNextcloudDoesWithItsOwnCookie(): void {
+		$etherpad = $this->createMock(EtherpadClient::class);
+		$etherpad->method('healthCheck')->willReturn(['pad_count' => 1]);
+		$etherpad->method('detectReleaseVersion')->willReturn('2.7.3');
+
+		$named = $this->sessionCookieLine($etherpad, sameSiteSetting: 'none', nextcloudSameSite: 'lax');
+		self::assertStringContainsString('Nextcloud sends its own session cookie as Lax', $named->detail);
+
+		$silent = $this->sessionCookieLine($etherpad, sameSiteSetting: 'none', nextcloudSameSite: '');
+		self::assertStringNotContainsString('sends its own session cookie', $silent->detail);
+	}
+
+	/**
+	 * The configuration that breaks silently, and the one this check had no
+	 * word for: an embed origin the session cookie does not reach, while the
+	 * cookie stays same-site.
+	 */
+	public function testAnEmbedOriginOutsideTheCookieDomainIsNamed(): void {
+		$etherpad = $this->createMock(EtherpadClient::class);
+		$etherpad->method('healthCheck')->willReturn(['pad_count' => 1]);
+		$etherpad->method('detectReleaseVersion')->willReturn('2.7.3');
+		$etherpad->method('getConfiguredOrigin')->willReturn('https://pad.example.test');
+
+		$line = $this->sessionCookieLine($etherpad, trustedEmbedOrigins: ['https://partner.example.com']);
+		self::assertSame(HealthCheckItem::STATUS_WARNING, $line->status);
+		self::assertStringContainsString('partner.example.com', $line->detail);
+	}
+
+	/** One the cookie already reaches is certainly fine and stays quiet. */
+	public function testAnEmbedOriginInsideTheCookieDomainIsNotNamed(): void {
+		$etherpad = $this->createMock(EtherpadClient::class);
+		$etherpad->method('healthCheck')->willReturn(['pad_count' => 1]);
+		$etherpad->method('detectReleaseVersion')->willReturn('2.7.3');
+		$etherpad->method('getConfiguredOrigin')->willReturn('https://pad.example.test');
+
+		$line = $this->sessionCookieLine($etherpad, trustedEmbedOrigins: ['https://portal.example.test']);
+		self::assertSame(HealthCheckItem::STATUS_OK, $line->status);
+	}
+
+	/** A value that is neither lax nor none is said out loud, like its sibling. */
+	public function testAnUnrecognisedSameSiteValueIsNamed(): void {
+		$etherpad = $this->createMock(EtherpadClient::class);
+		$etherpad->method('healthCheck')->willReturn(['pad_count' => 1]);
+		$etherpad->method('detectReleaseVersion')->willReturn('2.7.3');
+
+		$line = $this->sessionCookieLine($etherpad, unrecognisedSameSite: 'strict');
+		self::assertSame(HealthCheckItem::STATUS_WARNING, $line->status);
+		self::assertStringContainsString('strict', $line->detail);
+	}
+
+	/**
 	 * There is one session-cookie slot. A note about how far the cookie
 	 * travels must not push off the line saying that no protected pad opens
 	 * at all — which is what `yes` below Etherpad 3.0 means.
@@ -441,7 +544,8 @@ class EtherpadHealthCheckServiceTest extends TestCase {
 			$this->baseUrlCheck(),
 			$urlGenerator,
 			$this->createMock(\OCA\EtherpadNextcloud\Service\EtherpadReleasePolicy::class),
-			$this->createMock(\OCP\IConfig::class),
+			$this->createMock(\OCA\EtherpadNextcloud\Service\PadSessionService::class),
+			$this->createMock(\OCA\EtherpadNextcloud\Service\AppConfigService::class),
 			$ticks,
 		) extends EtherpadHealthCheckService {
 			/** @param list<float> $ticks */
@@ -453,10 +557,11 @@ class EtherpadHealthCheckServiceTest extends TestCase {
 				BaseUrlReachabilityCheck $baseUrlCheck,
 				IURLGenerator $urlGenerator,
 				\OCA\EtherpadNextcloud\Service\EtherpadReleasePolicy $releasePolicy,
-				\OCP\IConfig $config,
+				\OCA\EtherpadNextcloud\Service\PadSessionService $padSessionService,
+				\OCA\EtherpadNextcloud\Service\AppConfigService $appConfigService,
 				private array $ticks,
 			) {
-				parent::__construct($etherpadClient, $pendingDeleteRetryService, $l10n, $cookieDomainPolicy, $baseUrlCheck, $urlGenerator, $releasePolicy, $config);
+				parent::__construct($etherpadClient, $pendingDeleteRetryService, $l10n, $cookieDomainPolicy, $baseUrlCheck, $urlGenerator, $releasePolicy, $padSessionService, $appConfigService);
 			}
 
 			protected function now(): float {

--- a/tests/phpunit/unit/PadSessionServiceTest.php
+++ b/tests/phpunit/unit/PadSessionServiceTest.php
@@ -78,9 +78,17 @@ class PadSessionServiceTest extends TestCase {
 		$etherpadClient->method('createAuthorIfNotExistsFor')->willReturn('a.author');
 		$etherpadClient->method('buildPadUrl')->willReturn('https://pad.example.test/p/x');
 
+		// The pad host matters here: SameSite is decided against it, since
+		// that is where the cookie is sent.
+		$config = $this->createMock(IConfig::class);
+		$config->method('getAppValue')->willReturnCallback(
+			static fn (string $app, string $key, string $default = ''): string => $key === 'etherpad_host'
+				? 'https://pad.example.test'
+				: $default
+		);
 		$service = $this->buildService(
 			$etherpadClient,
-			$this->createMock(IConfig::class),
+			$config,
 			'https://cloud.example.test',
 			$incoming,
 			$httpOnlySupported,
@@ -437,8 +445,22 @@ class PadSessionServiceTest extends TestCase {
 		$this->assertSame('sessionID', $result['cookie']['name']);
 		$this->assertSame($sessionId, $result['cookie']['value']);
 		$this->assertSame('.example.test', $result['cookie']['domain']);
-		$this->assertSame('None', $result['cookie']['same_site']);
+		$this->assertSame('Lax', $result['cookie']['same_site']);
 		$this->assertTrue($result['cookie']['secure']);
+	}
+
+	/**
+	 * `Lax` covers the ordinary chain by itself: Nextcloud and Etherpad have
+	 * to share a registrable domain for the cookie to be settable at all, so
+	 * the pad iframe is a same-site subresource — while a foreign page
+	 * framing a pad URL gets nothing.
+	 *
+	 * Unconditional. The embed routes need a Nextcloud session, and
+	 * Nextcloud pins that cookie to `Lax` itself, so there is no cross-site
+	 * flow left for `None` to serve.
+	 */
+	public function testTheSessionCookieDoesNotTravelToOtherSites(): void {
+		$this->assertSame('Lax', $this->openContextCookie([], null)['same_site']);
 	}
 
 	public function testCreateProtectedOpenContextUsesExplicitCookieDomainOnly(): void {
@@ -500,7 +522,7 @@ class PadSessionServiceTest extends TestCase {
 			'domain' => '.example.test',
 			'secure' => true,
 			'http_only' => false,
-			'same_site' => 'None',
+			'same_site' => 'Lax',
 		]);
 
 		$this->assertStringContainsString('sessionID=s.abc123', $header);
@@ -509,7 +531,7 @@ class PadSessionServiceTest extends TestCase {
 		$this->assertStringContainsString('Path=/', $header);
 		$this->assertStringContainsString('Domain=.example.test', $header);
 		$this->assertStringContainsString('Secure', $header);
-		$this->assertStringContainsString('SameSite=None', $header);
+		$this->assertStringContainsString('SameSite=Lax', $header);
 		$this->assertStringNotContainsString("\n", $header);
 		$this->assertStringNotContainsString("\r", $header);
 	}

--- a/tests/phpunit/unit/PadSessionServiceTest.php
+++ b/tests/phpunit/unit/PadSessionServiceTest.php
@@ -487,6 +487,44 @@ class PadSessionServiceTest extends TestCase {
 		$this->assertSame('Lax', $this->openContextCookie([], null, sameSiteSetting: '')['same_site']);
 	}
 
+	/**
+	 * But it is not swallowed. `strict` is the one that stings: somebody
+	 * meant to harden and gets the opposite, and without this the only
+	 * evidence is the cookie itself.
+	 *
+	 * @param string $stored
+	 * @param string $expected
+	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('sameSiteValues')]
+	public function testAnUnrecognisedSameSiteValueIsReported(string $stored, string $expected): void {
+		$service = $this->buildService(
+			$this->createMock(EtherpadClient::class),
+			$this->configReturning(PadSessionService::SAME_SITE_KEY, $stored),
+		);
+
+		$this->assertSame($expected, $service->unrecognisedSameSite());
+	}
+
+	/** @return array<string,array{string,string}> */
+	public static function sameSiteValues(): array {
+		return [
+			'none' => ['none', ''],
+			'lax' => ['lax', ''],
+			'unset' => ['', ''],
+			'strict' => ['strict', 'strict'],
+			'off' => ['off', 'off'],
+			'cross-site' => ['cross-site', 'cross-site'],
+		];
+	}
+
+	private function configReturning(string $key, string $value): IConfig {
+		$config = $this->createMock(IConfig::class);
+		$config->method('getAppValue')->willReturnCallback(
+			static fn (string $app, string $wanted, string $default = ''): string => $wanted === $key ? $value : $default
+		);
+		return $config;
+	}
+
 	public function testCreateProtectedOpenContextUsesExplicitCookieDomainOnly(): void {
 		$uid = 'admin';
 		$padId = 'g.ABCDEFGHIJKLMNOP$pad-1';

--- a/tests/phpunit/unit/PadSessionServiceTest.php
+++ b/tests/phpunit/unit/PadSessionServiceTest.php
@@ -66,6 +66,7 @@ class PadSessionServiceTest extends TestCase {
 		string $groupId = 'g.ABCDEFGHIJKLMNOP',
 		bool $listingFails = false,
 		bool $httpOnlySupported = false,
+		string $sameSiteSetting = 'lax',
 	): array {
 		$etherpadClient = $this->createMock(EtherpadClient::class);
 		$etherpadClient->method('createSession')->willReturn($this->sid('new'));
@@ -78,12 +79,10 @@ class PadSessionServiceTest extends TestCase {
 		$etherpadClient->method('createAuthorIfNotExistsFor')->willReturn('a.author');
 		$etherpadClient->method('buildPadUrl')->willReturn('https://pad.example.test/p/x');
 
-		// The pad host matters here: SameSite is decided against it, since
-		// that is where the cookie is sent.
 		$config = $this->createMock(IConfig::class);
 		$config->method('getAppValue')->willReturnCallback(
-			static fn (string $app, string $key, string $default = ''): string => $key === 'etherpad_host'
-				? 'https://pad.example.test'
+			static fn (string $app, string $key, string $default = ''): string => $key === PadSessionService::SAME_SITE_KEY
+				? $sameSiteSetting
 				: $default
 		);
 		$service = $this->buildService(
@@ -366,6 +365,7 @@ class PadSessionServiceTest extends TestCase {
 			['etherpad_nextcloud', 'etherpad_cookie_domain', '', ''],
 			['etherpad_nextcloud', 'etherpad_cookie_domain_configured', 'no', 'no'],
 			['etherpad_nextcloud', 'etherpad_host', '', 'https://pad.example.test'],
+			['etherpad_nextcloud', PadSessionService::SAME_SITE_KEY, 'lax', 'lax'],
 		]);
 		$config->method('getUserValue')->willReturnMap([
 			[$uid, 'etherpad_nextcloud', 'etherpad_author_id', '', 'a.cached'],
@@ -435,6 +435,8 @@ class PadSessionServiceTest extends TestCase {
 				['etherpad_nextcloud', 'etherpad_cookie_domain', '', ''],
 				['etherpad_nextcloud', 'etherpad_cookie_domain_configured', 'no', 'no'],
 				['etherpad_nextcloud', 'etherpad_host', '', 'https://pad.example.test'],
+			['etherpad_nextcloud', PadSessionService::SAME_SITE_KEY, 'lax', 'lax'],
+				['etherpad_nextcloud', PadSessionService::SAME_SITE_KEY, 'lax', 'lax'],
 			]);
 
 		$service = $this->buildService($etherpadClient, $config);
@@ -455,12 +457,35 @@ class PadSessionServiceTest extends TestCase {
 	 * the pad iframe is a same-site subresource — while a foreign page
 	 * framing a pad URL gets nothing.
 	 *
-	 * Unconditional. The embed routes need a Nextcloud session, and
-	 * Nextcloud pins that cookie to `Lax` itself, so there is no cross-site
-	 * flow left for `None` to serve.
+	 * Not `Strict`, which is the other direction this could drift: that
+	 * withholds the cookie from a top-level navigation too, so a pad link
+	 * in an email would open unauthenticated.
 	 */
 	public function testTheSessionCookieDoesNotTravelToOtherSites(): void {
 		$this->assertSame('Lax', $this->openContextCookie([], null)['same_site']);
+	}
+
+	/**
+	 * Asked for, never inferred. The one deployment that needs it is a
+	 * foreign site framing the embed routes where Nextcloud authenticates
+	 * without a cookie — proxy `REMOTE_USER`, Kerberos, SAML in environment
+	 * mode. Nothing in a cookie policy can see that.
+	 */
+	public function testTheCookieIsNotStrict(): void {
+		// A later hardening pass reads the comment above, sees "do not give
+		// this to other sites", and reaches for Strict. That breaks opening
+		// a pad from a link, and nothing else in the suite would notice.
+		$this->assertNotSame('Strict', $this->openContextCookie([], null)['same_site']);
+	}
+
+	public function testAnAdminCanWidenTheCookieForACrossSiteEmbed(): void {
+		$this->assertSame('None', $this->openContextCookie([], null, sameSiteSetting: 'none')['same_site']);
+	}
+
+	/** Anything else is Lax, including a value nobody meant. */
+	public function testAnythingButNoneMeansLax(): void {
+		$this->assertSame('Lax', $this->openContextCookie([], null, sameSiteSetting: 'true')['same_site']);
+		$this->assertSame('Lax', $this->openContextCookie([], null, sameSiteSetting: '')['same_site']);
 	}
 
 	public function testCreateProtectedOpenContextUsesExplicitCookieDomainOnly(): void {
@@ -478,6 +503,8 @@ class PadSessionServiceTest extends TestCase {
 				['etherpad_nextcloud', 'etherpad_cookie_domain', '', '.example.test'],
 				['etherpad_nextcloud', 'etherpad_cookie_domain_configured', 'no', 'yes'],
 				['etherpad_nextcloud', 'etherpad_host', '', 'https://pad.example.test'],
+			['etherpad_nextcloud', PadSessionService::SAME_SITE_KEY, 'lax', 'lax'],
+				['etherpad_nextcloud', PadSessionService::SAME_SITE_KEY, 'lax', 'lax'],
 			]);
 
 		$service = $this->buildService($etherpadClient, $config);
@@ -501,6 +528,8 @@ class PadSessionServiceTest extends TestCase {
 				['etherpad_nextcloud', 'etherpad_cookie_domain', '', ''],
 				['etherpad_nextcloud', 'etherpad_cookie_domain_configured', 'no', 'yes'],
 				['etherpad_nextcloud', 'etherpad_host', '', 'https://pad.example.test'],
+			['etherpad_nextcloud', PadSessionService::SAME_SITE_KEY, 'lax', 'lax'],
+				['etherpad_nextcloud', PadSessionService::SAME_SITE_KEY, 'lax', 'lax'],
 			]);
 
 		$service = $this->buildService($etherpadClient, $config);
@@ -571,6 +600,8 @@ class PadSessionServiceTest extends TestCase {
 				['etherpad_nextcloud', 'etherpad_cookie_domain', '', ''],
 				['etherpad_nextcloud', 'etherpad_cookie_domain_configured', 'no', 'no'],
 				['etherpad_nextcloud', 'etherpad_host', '', 'https://pad.example.test'],
+			['etherpad_nextcloud', PadSessionService::SAME_SITE_KEY, 'lax', 'lax'],
+				['etherpad_nextcloud', PadSessionService::SAME_SITE_KEY, 'lax', 'lax'],
 			]);
 		$config->method('getUserValue')
 			->willReturnMap([
@@ -612,6 +643,8 @@ class PadSessionServiceTest extends TestCase {
 				['etherpad_nextcloud', 'etherpad_cookie_domain', '', ''],
 				['etherpad_nextcloud', 'etherpad_cookie_domain_configured', 'no', 'no'],
 				['etherpad_nextcloud', 'etherpad_host', '', 'https://pad.example.test'],
+			['etherpad_nextcloud', PadSessionService::SAME_SITE_KEY, 'lax', 'lax'],
+				['etherpad_nextcloud', PadSessionService::SAME_SITE_KEY, 'lax', 'lax'],
 			]);
 		$config->method('getUserValue')
 			->willReturnMap([
@@ -671,6 +704,8 @@ class PadSessionServiceTest extends TestCase {
 				['etherpad_nextcloud', 'etherpad_cookie_domain', '', ''],
 				['etherpad_nextcloud', 'etherpad_cookie_domain_configured', 'no', 'no'],
 				['etherpad_nextcloud', 'etherpad_host', '', 'https://pad.example.test'],
+			['etherpad_nextcloud', PadSessionService::SAME_SITE_KEY, 'lax', 'lax'],
+				['etherpad_nextcloud', PadSessionService::SAME_SITE_KEY, 'lax', 'lax'],
 			]);
 		$config->method('getUserValue')
 			->willReturnMap([
@@ -737,6 +772,8 @@ class PadSessionServiceTest extends TestCase {
 				['etherpad_nextcloud', 'etherpad_cookie_domain', '', ''],
 				['etherpad_nextcloud', 'etherpad_cookie_domain_configured', 'no', 'no'],
 				['etherpad_nextcloud', 'etherpad_host', '', 'https://pad.example.test'],
+			['etherpad_nextcloud', PadSessionService::SAME_SITE_KEY, 'lax', 'lax'],
+				['etherpad_nextcloud', PadSessionService::SAME_SITE_KEY, 'lax', 'lax'],
 			]);
 		$config->expects($this->never())->method('setUserValue');
 		$config->expects($this->never())->method('deleteUserValue');

--- a/tests/phpunit/unit/PadSessionServiceTest.php
+++ b/tests/phpunit/unit/PadSessionServiceTest.php
@@ -435,7 +435,6 @@ class PadSessionServiceTest extends TestCase {
 				['etherpad_nextcloud', 'etherpad_cookie_domain', '', ''],
 				['etherpad_nextcloud', 'etherpad_cookie_domain_configured', 'no', 'no'],
 				['etherpad_nextcloud', 'etherpad_host', '', 'https://pad.example.test'],
-			['etherpad_nextcloud', PadSessionService::SAME_SITE_KEY, 'lax', 'lax'],
 				['etherpad_nextcloud', PadSessionService::SAME_SITE_KEY, 'lax', 'lax'],
 			]);
 
@@ -503,7 +502,6 @@ class PadSessionServiceTest extends TestCase {
 				['etherpad_nextcloud', 'etherpad_cookie_domain', '', '.example.test'],
 				['etherpad_nextcloud', 'etherpad_cookie_domain_configured', 'no', 'yes'],
 				['etherpad_nextcloud', 'etherpad_host', '', 'https://pad.example.test'],
-			['etherpad_nextcloud', PadSessionService::SAME_SITE_KEY, 'lax', 'lax'],
 				['etherpad_nextcloud', PadSessionService::SAME_SITE_KEY, 'lax', 'lax'],
 			]);
 
@@ -528,7 +526,6 @@ class PadSessionServiceTest extends TestCase {
 				['etherpad_nextcloud', 'etherpad_cookie_domain', '', ''],
 				['etherpad_nextcloud', 'etherpad_cookie_domain_configured', 'no', 'yes'],
 				['etherpad_nextcloud', 'etherpad_host', '', 'https://pad.example.test'],
-			['etherpad_nextcloud', PadSessionService::SAME_SITE_KEY, 'lax', 'lax'],
 				['etherpad_nextcloud', PadSessionService::SAME_SITE_KEY, 'lax', 'lax'],
 			]);
 
@@ -600,7 +597,6 @@ class PadSessionServiceTest extends TestCase {
 				['etherpad_nextcloud', 'etherpad_cookie_domain', '', ''],
 				['etherpad_nextcloud', 'etherpad_cookie_domain_configured', 'no', 'no'],
 				['etherpad_nextcloud', 'etherpad_host', '', 'https://pad.example.test'],
-			['etherpad_nextcloud', PadSessionService::SAME_SITE_KEY, 'lax', 'lax'],
 				['etherpad_nextcloud', PadSessionService::SAME_SITE_KEY, 'lax', 'lax'],
 			]);
 		$config->method('getUserValue')
@@ -643,7 +639,6 @@ class PadSessionServiceTest extends TestCase {
 				['etherpad_nextcloud', 'etherpad_cookie_domain', '', ''],
 				['etherpad_nextcloud', 'etherpad_cookie_domain_configured', 'no', 'no'],
 				['etherpad_nextcloud', 'etherpad_host', '', 'https://pad.example.test'],
-			['etherpad_nextcloud', PadSessionService::SAME_SITE_KEY, 'lax', 'lax'],
 				['etherpad_nextcloud', PadSessionService::SAME_SITE_KEY, 'lax', 'lax'],
 			]);
 		$config->method('getUserValue')
@@ -704,7 +699,6 @@ class PadSessionServiceTest extends TestCase {
 				['etherpad_nextcloud', 'etherpad_cookie_domain', '', ''],
 				['etherpad_nextcloud', 'etherpad_cookie_domain_configured', 'no', 'no'],
 				['etherpad_nextcloud', 'etherpad_host', '', 'https://pad.example.test'],
-			['etherpad_nextcloud', PadSessionService::SAME_SITE_KEY, 'lax', 'lax'],
 				['etherpad_nextcloud', PadSessionService::SAME_SITE_KEY, 'lax', 'lax'],
 			]);
 		$config->method('getUserValue')
@@ -772,7 +766,6 @@ class PadSessionServiceTest extends TestCase {
 				['etherpad_nextcloud', 'etherpad_cookie_domain', '', ''],
 				['etherpad_nextcloud', 'etherpad_cookie_domain_configured', 'no', 'no'],
 				['etherpad_nextcloud', 'etherpad_host', '', 'https://pad.example.test'],
-			['etherpad_nextcloud', PadSessionService::SAME_SITE_KEY, 'lax', 'lax'],
 				['etherpad_nextcloud', PadSessionService::SAME_SITE_KEY, 'lax', 'lax'],
 			]);
 		$config->expects($this->never())->method('setUserValue');


### PR DESCRIPTION
The Etherpad session cookie was `SameSite=None`, so any page on the web could frame a pad URL and a visiting user's cookie went with it – the pad renders authenticated, readable and, behind an overlay, editable. The pad id is the only thing in the way, and pad ids travel in URLs, screenshots and history.

It is `Lax` now.

### Why that costs nothing

`SameSite` keys on the registrable domain. Nextcloud and Etherpad have to share one for a protected pad to work at all – a browser rejects a `Set-Cookie` whose `Domain=` is not a suffix of the host that set it – so the pad iframe is a same-site subresource and `Lax` covers it. A pad link opened from an email still works, which is why not `Strict`; a test pins that, because the comment beside it argues for keeping the cookie away from other sites and that is what a later hardening pass reads.

### Why `None` is asked for, never inferred

```bash
occ config:app:set etherpad_nextcloud etherpad_session_cookie_samesite --value=none
```

One deployment needs it: a foreign site framing the embed routes, where Nextcloud authenticates the request without a cookie – proxy `REMOTE_USER`, Kerberos, SAML in environment mode. Nothing in a cookie policy can see that.

Two attempts to decide it automatically were dropped. Deriving it from the hosts needs a public suffix list to be right (`alice.eu.org` / `bob.eu.org` and friends came out "same site" where browsers disagree, in the direction that breaks a working embed). Concluding the case away – embed routes need a Nextcloud session, Nextcloud pins that cookie to `Lax`, therefore cross-site embeds are never authenticated – proves something about a cookie and concludes something about authentication.

While the setting is on, the connection test says what it costs and what Nextcloud does with its own session cookie, read at runtime rather than written into a comment that goes stale. The `trusted_embed_origins` field says the same where an admin fills it in.

### Tests

Unit tests separate all three values: the `None` opt-in, the `Lax` default, and not-`Strict`. A counter-check with `None` fails both the unit test and the e2e spec.

**Gap:** nothing proves in a browser that a *foreign* site is denied. That needs a second registrable domain in the e2e stack – Caddy vhost, cert SAN, workflow line, and an `/etc/hosts` entry for every contributor. Its own change, and it would also give the embed routes their first e2e coverage.

### Also

`SameSite=None` was written into the contract in three documents and asserted by `tests/integration/e2e-protected-cookie-contract.sh`. The script now takes `EXPECTED_SAMESITE`, because the value is no longer derivable from anything it can see.
