### PR TITLE
Release 1.1.0-alpha.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,49 @@
 # Changelog
 
+## 1.1.0-alpha.4 — 2026-08-31
+
+Fourth public-review release. Focus: one pad-creation entry point with shared templates, a clearer admin surface, protected-pad session and lifecycle correctness, and a disposable end-to-end stack that runs the browser suite across three Nextcloud and two Etherpad majors.
+
+### Added
+
+- **Instance-wide pad templates.** Administrators upload and manage shared `.pad` templates; they appear in Nextcloud's template picker for everyone and always create a fresh Etherpad pad. (#181)
+- **One "New pad" entry.** The separate protected/public/external entries in the New menu are replaced by a single entry, with the pad type and any shared template chosen in Nextcloud's own template picker. (#187)
+- **Configurable pad types.** Protected and public pads can be enabled or disabled independently; pads of a disabled type keep working, and external pads keep their own setting. (#177)
+- **Italian locale**, alongside German, Spanish and French. (#188)
+
+### Changed
+
+- **Admin page grouped into sections**, with the descriptions rewritten. (#178)
+- **Connection test reports each part separately** — API, API key, browser-facing Etherpad URL, protected-pad cookie — with field-specific guidance where a setting needs attention. (#179)
+- The cookie-domain calculation used by the settings page, the diagnostics and the runtime is one implementation. (#179)
+
+### Security
+
+- **The Etherpad session cookie is `SameSite=Lax`.** It was `None`, so any page on the web could frame a pad URL and a visiting user's cookie went with it. `etherpad_session_cookie_samesite=none` remains for a cross-site embed behind cookie-independent authentication. (#210)
+- **`HttpOnly` from Etherpad 3.0.** The release is detected from `/health`; up to 2.7.3 the pad app reads the cookie in the browser, where `HttpOnly` would lock users out of every protected pad. (#209)
+- **Deleting a protected pad removes its Etherpad group and that group's sessions**, instead of leaving both behind with nothing pointing at them. (#208)
+- **Legacy Ownpad migration checks that a group pad is in the group it names**, closing a path where a hand-written `.pad` could name someone else's Etherpad group and have a session minted for it. (#208)
+
+### Fixed
+
+- **Several protected pads stay open at once.** Opening a second one no longer replaces the first one's Etherpad session. (#206)
+- **Opening by file id is trustworthy** for group folders, shares, external storage and files whose path changed. (#205)
+- **Pad names keep their special characters**, and Nextcloud judges what a valid name is. (#200)
+- **Pad files are created atomically**, and a failed create rolls back the file it made. (#198)
+- Creating a pad directly in the user's root folder works. (#196)
+- Restoring a `.pad` from the trash works on Nextcloud 31. (#190)
+- Cleanup and rollback are consistent when creation, binding, restoration or deletion only partly succeeds. (#198, #205, #208)
+
+### Tooling / tests / CI
+
+- **Disposable Docker e2e stack** — Nextcloud, Etherpad, PostgreSQL and TLS — so the browser suite runs against a throwaway target. (#195)
+- **The Playwright suite runs in CI** against Nextcloud 31, 32 and 33 on Etherpad 2, and Nextcloud 33 on Etherpad 3. (#195, #207)
+- Browser and unit coverage extended across creation, templates, shares, protected sessions, trash and restore, lifecycle cleanup and the security-sensitive paths. (#53, #138, #194)
+- Test runs no longer leave fixtures in the Nextcloud trash. (#194)
+- DOMPurify updated and the shipped frontend bundles rebuilt with it. (#144, #166, #189)
+- Playwright artefacts excluded from the release tarball. (#136)
+- Dependabot PRs auto-merge once CI passes. (#151)
+
 ## 1.1.0-alpha.3 — 2026-06-09
 
 Third public-review release. Focus: security hardening of the Etherpad/admin surface, a browser end-to-end test suite, and a deep static-analysis / tech-debt pass. No user-facing feature changes since alpha.2.

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -5,7 +5,7 @@
 	<name>Etherpad Integration for Nextcloud</name>
 	<summary>Standalone Etherpad integration for Nextcloud</summary>
 	<description>Standalone Etherpad integration for Nextcloud with binding-based lifecycle and secure viewer flows.</description>
-	<version>1.1.0-alpha.3</version>
+	<version>1.1.0-alpha.4</version>
 	<licence>agpl</licence>
 	<author>Jacob Bühler</author>
 	<author>John McLear</author>

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -19,12 +19,13 @@ What it does:
 
 - Verifies required local tools (`git`, `php`).
 - Fails on dirty working tree by default.
-- Runs local tiny unit test:
-  - `php tests/unit/padfile-pathnormalizer-test.php`
-- Runs PHPUnit unit suite when available:
+- Runs the PHPUnit unit suite, which is required rather than optional – it is
+  the only local test path, so a missing `vendor/bin/phpunit` fails the check
+  instead of skipping it:
   - `vendor/bin/phpunit --testsuite unit`
-  - If `vendor/bin/phpunit` is missing, install once with:
-    - `composer install --no-interaction`
+  - Install once with `composer install --no-interaction`
+  - The path-normalizer coverage this step used to run as a standalone script
+    lives in that suite as `PathNormalizerTest`
 - If Nextcloud test credentials are present, runs core E2E checks:
   - pad flow
   - protected cookie contract (session cookie attrs + no `HttpOnly` for current Etherpad runtime compatibility)

--- a/js/api-client-D9L0yYjH.chunk.mjs.license
+++ b/js/api-client-D9L0yYjH.chunk.mjs.license
@@ -3,5 +3,5 @@ SPDX-FileCopyrightText: etherpad-nextcloud developers
 
 This file is generated from multiple sources. Included packages:
 - etherpad-nextcloud
-	- version: 1.1.0-alpha.3
+	- version: 1.1.0-alpha.4
 	- license: AGPL-3.0-or-later

--- a/js/etherpad_nextcloud-admin-settings.mjs.license
+++ b/js/etherpad_nextcloud-admin-settings.mjs.license
@@ -3,5 +3,5 @@ SPDX-FileCopyrightText: etherpad-nextcloud developers
 
 This file is generated from multiple sources. Included packages:
 - etherpad-nextcloud
-	- version: 1.1.0-alpha.3
+	- version: 1.1.0-alpha.4
 	- license: AGPL-3.0-or-later

--- a/js/etherpad_nextcloud-embed-create-main.mjs.license
+++ b/js/etherpad_nextcloud-embed-create-main.mjs.license
@@ -3,5 +3,5 @@ SPDX-FileCopyrightText: etherpad-nextcloud developers
 
 This file is generated from multiple sources. Included packages:
 - etherpad-nextcloud
-	- version: 1.1.0-alpha.3
+	- version: 1.1.0-alpha.4
 	- license: AGPL-3.0-or-later

--- a/js/etherpad_nextcloud-embed-main.mjs.license
+++ b/js/etherpad_nextcloud-embed-main.mjs.license
@@ -3,5 +3,5 @@ SPDX-FileCopyrightText: etherpad-nextcloud developers
 
 This file is generated from multiple sources. Included packages:
 - etherpad-nextcloud
-	- version: 1.1.0-alpha.3
+	- version: 1.1.0-alpha.4
 	- license: AGPL-3.0-or-later

--- a/js/etherpad_nextcloud-files-main.mjs.license
+++ b/js/etherpad_nextcloud-files-main.mjs.license
@@ -3,5 +3,5 @@ SPDX-FileCopyrightText: etherpad-nextcloud developers
 
 This file is generated from multiple sources. Included packages:
 - etherpad-nextcloud
-	- version: 1.1.0-alpha.3
+	- version: 1.1.0-alpha.4
 	- license: AGPL-3.0-or-later

--- a/js/etherpad_nextcloud-viewer-main.mjs.license
+++ b/js/etherpad_nextcloud-viewer-main.mjs.license
@@ -3,5 +3,5 @@ SPDX-FileCopyrightText: etherpad-nextcloud developers
 
 This file is generated from multiple sources. Included packages:
 - etherpad-nextcloud
-	- version: 1.1.0-alpha.3
+	- version: 1.1.0-alpha.4
 	- license: AGPL-3.0-or-later

--- a/js/fetch-helpers-D1lrO36R.chunk.mjs.license
+++ b/js/fetch-helpers-D1lrO36R.chunk.mjs.license
@@ -3,5 +3,5 @@ SPDX-FileCopyrightText: etherpad-nextcloud developers
 
 This file is generated from multiple sources. Included packages:
 - etherpad-nextcloud
-	- version: 1.1.0-alpha.3
+	- version: 1.1.0-alpha.4
 	- license: AGPL-3.0-or-later

--- a/js/sanitize-html-Bz4T9gSE.chunk.mjs.license
+++ b/js/sanitize-html-Bz4T9gSE.chunk.mjs.license
@@ -8,5 +8,5 @@ This file is generated from multiple sources. Included packages:
 	- version: 3.4.13
 	- license: (MPL-2.0 OR Apache-2.0)
 - etherpad-nextcloud
-	- version: 1.1.0-alpha.3
+	- version: 1.1.0-alpha.4
 	- license: AGPL-3.0-or-later

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "etherpad-nextcloud",
-	"version": "1.1.0-alpha.3",
+	"version": "1.1.0-alpha.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "etherpad-nextcloud",
-			"version": "1.1.0-alpha.3",
+			"version": "1.1.0-alpha.4",
 			"license": "AGPL-3.0-or-later",
 			"dependencies": {
 				"dompurify": "^3.4.13"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "etherpad-nextcloud",
-	"version": "1.1.0-alpha.3",
+	"version": "1.1.0-alpha.4",
 	"private": true,
 	"license": "AGPL-3.0-or-later",
 	"type": "module",

--- a/tests/integration/release-check.sh
+++ b/tests/integration/release-check.sh
@@ -40,12 +40,19 @@ echo "[2/5] Unit checks"
 cd "$ROOT_DIR"
 # The standalone path-normalizer script this used to run was folded into the
 # PHPUnit suite in #41 (PathNormalizerTest). The call outlived it and, under
-# set -e, aborted the whole check — so this gate has not completed since.
-if [[ -x "${ROOT_DIR}/vendor/bin/phpunit" ]]; then
-	"${ROOT_DIR}/vendor/bin/phpunit" --testsuite unit
-else
-	echo "-> PHPUnit suite skipped (run 'composer install --no-interaction' to enable)."
+# set -e, aborted the whole check — so this gate did not complete for two
+# releases.
+#
+# PHPUnit is required rather than optional. It was the second of two test
+# paths when the standalone script existed; as the only one, skipping it
+# would let this gate report "local-only checks passed" having run nothing
+# at all — which is worse than the abort it replaced.
+if [[ ! -x "${ROOT_DIR}/vendor/bin/phpunit" ]]; then
+	echo "PHPUnit is missing and this check runs no tests without it." >&2
+	echo "Install it once with: composer install --no-interaction" >&2
+	exit 2
 fi
+"${ROOT_DIR}/vendor/bin/phpunit" --testsuite unit
 
 if ! has_nextcloud_e2e_env; then
 	echo "[3/5] Core E2E checks skipped (missing NC_BASE_URL / NC_USER / NC_APP_PASSWORD)."

--- a/tests/integration/release-check.sh
+++ b/tests/integration/release-check.sh
@@ -38,7 +38,9 @@ fi
 
 echo "[2/5] Unit checks"
 cd "$ROOT_DIR"
-php tests/unit/padfile-pathnormalizer-test.php
+# The standalone path-normalizer script this used to run was folded into the
+# PHPUnit suite in #41 (PathNormalizerTest). The call outlived it and, under
+# set -e, aborted the whole check — so this gate has not completed since.
 if [[ -x "${ROOT_DIR}/vendor/bin/phpunit" ]]; then
 	"${ROOT_DIR}/vendor/bin/phpunit" --testsuite unit
 else


### PR DESCRIPTION
Version bump, changelog entry, and a fix to the release check.

`tests/integration/release-check.sh` called `php tests/unit/padfile-pathnormalizer-test.php`, which moved into the PHPUnit suite as `PathNormalizerTest` in #41. Under `set -e` that aborted the whole script, so the documented release gate has not completed since — it runs now.

Release notes for the tag are prepared separately; the changelog entry here is the repo-format version, written from the PRs merged since v1.1.0-alpha.3.

Verified: release-check (761 tests), vitest 221, Playwright 30 passed / 1 skipped against the Docker stack, tarball 764K / 226 files with no `tests/`, `src/`, `.github/` or Playwright artefacts.