### PR TITLE
Collect expired Etherpad sessions

### DIFF
--- a/docs/etherpad-integration.md
+++ b/docs/etherpad-integration.md
@@ -200,6 +200,35 @@ Cookie details:
   - derivation is skipped for IP hosts and invalid host values
   - recommendation: use explicit `etherpad_cookie_domain` in multi-subdomain/proxy setups
 
+### Expired Etherpad sessions
+
+Every open of a protected pad mints a session – that has been true since
+1.0.0 – and Etherpad never removes one once it expires. The pile was free
+while nothing read it. Since 1.1.0-alpha.4 something does: keeping several
+protected pads open at once means checking which of the ids in the cookie
+are still valid, and that asks `listSessionsOfAuthor`, which walks the
+author's whole index one awaited lookup at a time, expired entries
+included.
+
+So the cost of an open grows with the number of past opens rather than
+with the number of sessions that still grant anything. Ten opens a day is
+a few thousand entries in a year, and each one is a round trip inside
+Etherpad before the pad appears.
+
+No request deletes them – doing that one call at a time is the backlog
+itself. Instead the open that is already holding the listing counts the
+expired entries, and past fifty queues a job for that author. The sweep
+runs there, up to 250 per run inside a 20-second budget, and requeues
+itself for whatever did not fit. The job list keys on class plus argument,
+so ten opens before the sweep runs still queue one sweep.
+
+What this does not do is stop the sessions being created. That is a
+property of issuing a fresh session per open, which is what keeps an
+already-open pad working; the collector only keeps the record of it from
+growing without end. An author nobody opens a pad for is never swept –
+it costs storage and nothing else, because the cost that matters is paid
+by whoever reads the index.
+
 ### `SameSite=Lax`
 
 Nextcloud and Etherpad have to share a registrable domain for a protected

--- a/docs/etherpad-integration.md
+++ b/docs/etherpad-integration.md
@@ -231,9 +231,21 @@ refusals ends one.
 
 The id alone is enough, and that is the point. A listing is only made when
 the browser carries session ids, so the first open after arriving made
-none — and a public link never does, while every visitor of one link
+none – and a public link never does, while every visitor of one link
 writes to the same shared author's index. Both were invisible to a sweep
 that had to be told there was a backlog.
+
+The author id is also all that is written down. A public link's Nextcloud
+uid is `public-share:<token>` – the credential out of the share URL – and
+a job argument is persisted in the jobs table, printed by `occ`, and
+carried into database dumps and support bundles. The job has no use for
+it.
+
+A sweep that finds nothing to collect does not simply end: it comes back
+when the earliest session still standing falls due. That row is also what
+tells the next open a sweep is already accounted for, so a busy public
+link does not queue another walk of one shared index behind every
+visitor.
 
 Nothing is deleted until five minutes after it expired. `validUntil` is a
 number Nextcloud computes and Etherpad judges against its own clock, and

--- a/docs/etherpad-integration.md
+++ b/docs/etherpad-integration.md
@@ -247,6 +247,20 @@ tells the next open a sweep is already accounted for, so a busy public
 link does not queue another walk of one shared index behind every
 visitor.
 
+This rests on one property of the pad server: deleting a session takes its
+id out of the author's index, so the listing gets shorter. Etherpad
+updates that index with `setSub(..., undefined)`, and there are reports of
+the key surviving on some versions and storage backends – which would
+leave an id the listing still walks and `deleteSession` will no longer
+take, since it answers that the session does not exist. Collecting cannot
+help there. Measured to hold on 2.5.3 with PostgreSQL, where a swept
+author's index record disappears entirely, and on 2.x with the built-in
+store; an integration test pins it against whatever Etherpad the suite
+runs, counting the raw keys of the API response rather than what the
+client hands back, because the client drops exactly the entries a
+surviving key produces. When such entries do turn up, the sweep says so in
+the log instead of reporting a clean run.
+
 Nothing is deleted until five minutes after it expired. `validUntil` is a
 number Nextcloud computes and Etherpad judges against its own clock, and
 in the window where the two disagree a session this side calls dead is one

--- a/docs/etherpad-integration.md
+++ b/docs/etherpad-integration.md
@@ -202,80 +202,44 @@ Cookie details:
 
 ### Expired Etherpad sessions
 
-Every open of a protected pad mints a session – that has been true since
-1.0.0 – and Etherpad never removes one once it expires. The pile was free
-while nothing read it. Since 1.1.0-alpha.4 something does: keeping several
-protected pads open at once means checking which of the ids in the cookie
-are still valid, and that asks `listSessionsOfAuthor`, which walks the
-author's whole index one awaited lookup at a time, expired entries
-included.
+Every open of a protected pad mints a session – since 1.0.0 – and Etherpad
+never removes one once it expires. Nothing read the pile until 1.1.0-alpha.4,
+when keeping several pads open at once began checking which cookie ids are
+still valid: `listSessionsOfAuthor` walks the author's whole index one
+awaited lookup at a time, expired entries included. The cost of an open
+therefore grows with past opens rather than with live access.
 
-So the cost of an open grows with the number of past opens rather than
-with the number of sessions that still grant anything. Ten opens a day is
-a few thousand entries in a year, and each one is a round trip inside
-Etherpad before the pad appears.
+An open leaves the author's id in the job table; a queued job does the rest.
+The id says which author to look at, not whether there is anything to
+collect – that answer is the listing, and the listing is the slow call, so
+it belongs in the job together with the deleting. This also reaches the two
+cases a request could not: the first open of a browsing session carries no
+cookie ids and so makes no listing, and a public link never carries any,
+although every visitor of one adds a session under the same shared author.
 
-No request deletes them, and no request finds out whether there are any
-– the listing is the call that gets slow, so asking is as much the problem
-as deleting. Every open of a protected pad leaves the author's id in the
-job table instead, and the sweep does both: it lists, and it deletes what
-has expired. Up to 250 per run inside a 20-second budget that no single
-call may overrun, requeued for whatever did not fit. A run that ended on a
-refusal – for the listing or for a delete – is requeued with a growing
-delay and a limit instead: a queued job is removed from the list before it
-runs, so a pad server hiccup would otherwise leave the pile for the next
-open to rediscover, and a refusal read as progress would have the job
-coming back every minute for good. A single session the server will never
-delete does not stop the run; it is skipped past, and only a handful of
-refusals ends one.
+The id is also all that is stored. A public link's uid is
+`public-share:<token>`, the credential from the share URL, and job
+arguments are persisted and printed by `occ`.
 
-The id alone is enough, and that is the point. A listing is only made when
-the browser carries session ids, so the first open after arriving made
-none – and a public link never does, while every visitor of one link
-writes to the same shared author's index. Both were invisible to a sweep
-that had to be told there was a backlog.
+A run deletes up to 250 sessions within 20 seconds, requeueing itself for
+the rest. A refusal is requeued with a growing delay and a limit; a single
+session the server will never delete is skipped rather than allowed to
+block the ones behind it. A run with nothing to do comes back when the
+earliest session still standing falls due, which also keeps the next open
+from queueing a second sweep. Nothing is deleted until five minutes after
+expiry, because Etherpad judges `validUntil` against its own clock and a
+session dead by ours may still be live there.
 
-The author id is also all that is written down. A public link's Nextcloud
-uid is `public-share:<token>` – the credential out of the share URL – and
-a job argument is persisted in the jobs table, printed by `occ`, and
-carried into database dumps and support bundles. The job has no use for
-it.
+This assumes deleting a session removes its id from the author index.
+Verified on 2.5.3 with PostgreSQL and on 2.x with the built-in store; an
+integration test pins it by counting raw API keys, since the client filters
+out exactly the entries a surviving key produces. Where entries do survive,
+collecting cannot shrink the index and the sweep says so in the log.
 
-A sweep that finds nothing to collect does not simply end: it comes back
-when the earliest session still standing falls due. That row is also what
-tells the next open a sweep is already accounted for, so a busy public
-link does not queue another walk of one shared index behind every
-visitor.
-
-This rests on one property of the pad server: deleting a session takes its
-id out of the author's index, so the listing gets shorter. Etherpad
-updates that index with `setSub(..., undefined)`, and there are reports of
-the key surviving on some versions and storage backends – which would
-leave an id the listing still walks and `deleteSession` will no longer
-take, since it answers that the session does not exist. Collecting cannot
-help there. Measured to hold on 2.5.3 with PostgreSQL, where a swept
-author's index record disappears entirely, and on 2.x with the built-in
-store; an integration test pins it against whatever Etherpad the suite
-runs, counting the raw keys of the API response rather than what the
-client hands back, because the client drops exactly the entries a
-surviving key produces. When such entries do turn up, the sweep says so in
-the log instead of reporting a clean run.
-
-Nothing is deleted until five minutes after it expired. `validUntil` is a
-number Nextcloud computes and Etherpad judges against its own clock, and
-in the window where the two disagree a session this side calls dead is one
-the pad server still grants – deleting it there would close a socket
-somebody is typing into. Queueing is best-effort too: it writes to the
-jobs table from inside an open, and housekeeping is not allowed to be the
-reason a pad fails to open.
-
-What this does not do is stop the sessions being created. That is a
-property of issuing a fresh session per open, which is what keeps an
-already-open pad working; the collector only keeps the record of it from
-growing without end. Noting the id and expiry of each session as it is
-issued would let the sweep skip the listing entirely; renewing one session
-instead of minting another would remove the reason for the pile. Both are
-larger changes than this.
+Not covered: sessions still being created – that is what keeps an open pad
+working – and authors nobody opens a pad for, whose leftovers cost storage
+only. Recording each session's id at issue time would remove the listing;
+renewing sessions instead of minting them would remove the pile.
 
 ### `SameSite=Lax`
 

--- a/docs/etherpad-integration.md
+++ b/docs/etherpad-integration.md
@@ -217,17 +217,28 @@ Etherpad before the pad appears.
 
 No request deletes them – doing that one call at a time is the backlog
 itself. Instead the open that is already holding the listing counts the
-expired entries, and past fifty queues a job for that author. The sweep
-runs there, up to 250 per run inside a 20-second budget, and requeues
-itself for whatever did not fit. The job list keys on class plus argument,
-so ten opens before the sweep runs still queue one sweep.
+expired entries, and past fifty queues a job for that author, unless one
+is queued already. The sweep runs there, up to 250 per run inside a
+20-second budget, and requeues itself for whatever did not fit. A listing
+that failed is requeued too, with a growing delay and a limit: a queued
+job is removed from the list before it runs, so a pad server hiccup would
+otherwise leave the pile for whichever open notices it next.
+
+Two limits are worth knowing. The sweep only ever sees an author somebody
+opens a pad for, so an account nobody uses keeps whatever piled up – that
+costs storage and nothing else, since the cost that matters is paid by
+whoever reads the index. And public link shares are not covered at all:
+they open under a shared anonymous author whose id is never cached, so the
+listing that spots a backlog is never made for them, while every visitor
+of one link adds a session under that same author.
 
 What this does not do is stop the sessions being created. That is a
 property of issuing a fresh session per open, which is what keeps an
 already-open pad working; the collector only keeps the record of it from
-growing without end. An author nobody opens a pad for is never swept –
-it costs storage and nothing else, because the cost that matters is paid
-by whoever reads the index.
+growing without end. Noting the id and expiry of each session as it is
+issued would cover the public-link case too and need no listing at all;
+renewing one session instead of minting another would remove the reason
+for the pile. Both are larger changes than this.
 
 ### `SameSite=Lax`
 

--- a/docs/etherpad-integration.md
+++ b/docs/etherpad-integration.md
@@ -215,41 +215,41 @@ with the number of sessions that still grant anything. Ten opens a day is
 a few thousand entries in a year, and each one is a round trip inside
 Etherpad before the pad appears.
 
-No request deletes them – doing that one call at a time is the backlog
-itself. Instead the open that is already holding the listing counts the
-expired entries, and past fifty queues a job for that author, unless one
-is queued already. The sweep runs there, up to 250 per run inside a
-20-second budget that no single call may overrun, and requeues itself for
-whatever did not fit. A run that ended on a refusal – for the listing or
-for a delete – is requeued with a growing delay and a limit instead: a
-queued job is removed from the list before it runs, so a pad server
-hiccup would otherwise leave the pile for whichever open notices it next,
-and a refusal read as progress would have the job coming back every
-minute for good.
+No request deletes them, and no request finds out whether there are any
+– the listing is the call that gets slow, so asking is as much the problem
+as deleting. Every open of a protected pad leaves the author's id in the
+job table instead, and the sweep does both: it lists, and it deletes what
+has expired. Up to 250 per run inside a 20-second budget that no single
+call may overrun, requeued for whatever did not fit. A run that ended on a
+refusal – for the listing or for a delete – is requeued with a growing
+delay and a limit instead: a queued job is removed from the list before it
+runs, so a pad server hiccup would otherwise leave the pile for the next
+open to rediscover, and a refusal read as progress would have the job
+coming back every minute for good. A single session the server will never
+delete does not stop the run; it is skipped past, and only a handful of
+refusals ends one.
+
+The id alone is enough, and that is the point. A listing is only made when
+the browser carries session ids, so the first open after arriving made
+none — and a public link never does, while every visitor of one link
+writes to the same shared author's index. Both were invisible to a sweep
+that had to be told there was a backlog.
 
 Nothing is deleted until five minutes after it expired. `validUntil` is a
 number Nextcloud computes and Etherpad judges against its own clock, and
-in the window where the two disagree a session this side calls dead is
-one the pad server still grants – deleting it there would close a socket
-somebody is typing into. Queueing the sweep is best-effort too: it writes
-to the jobs table from inside an open, and housekeeping is not allowed to
-be the reason a pad fails to open.
-
-Two limits are worth knowing. The sweep only ever sees an author somebody
-opens a pad for, so an account nobody uses keeps whatever piled up – that
-costs storage and nothing else, since the cost that matters is paid by
-whoever reads the index. And public link shares are not covered at all:
-they open under a shared anonymous author whose id is never cached, so the
-listing that spots a backlog is never made for them, while every visitor
-of one link adds a session under that same author.
+in the window where the two disagree a session this side calls dead is one
+the pad server still grants – deleting it there would close a socket
+somebody is typing into. Queueing is best-effort too: it writes to the
+jobs table from inside an open, and housekeeping is not allowed to be the
+reason a pad fails to open.
 
 What this does not do is stop the sessions being created. That is a
 property of issuing a fresh session per open, which is what keeps an
 already-open pad working; the collector only keeps the record of it from
 growing without end. Noting the id and expiry of each session as it is
-issued would cover the public-link case too and need no listing at all;
-renewing one session instead of minting another would remove the reason
-for the pile. Both are larger changes than this.
+issued would let the sweep skip the listing entirely; renewing one session
+instead of minting another would remove the reason for the pile. Both are
+larger changes than this.
 
 ### `SameSite=Lax`
 

--- a/docs/etherpad-integration.md
+++ b/docs/etherpad-integration.md
@@ -219,10 +219,21 @@ No request deletes them – doing that one call at a time is the backlog
 itself. Instead the open that is already holding the listing counts the
 expired entries, and past fifty queues a job for that author, unless one
 is queued already. The sweep runs there, up to 250 per run inside a
-20-second budget, and requeues itself for whatever did not fit. A listing
-that failed is requeued too, with a growing delay and a limit: a queued
-job is removed from the list before it runs, so a pad server hiccup would
-otherwise leave the pile for whichever open notices it next.
+20-second budget that no single call may overrun, and requeues itself for
+whatever did not fit. A run that ended on a refusal – for the listing or
+for a delete – is requeued with a growing delay and a limit instead: a
+queued job is removed from the list before it runs, so a pad server
+hiccup would otherwise leave the pile for whichever open notices it next,
+and a refusal read as progress would have the job coming back every
+minute for good.
+
+Nothing is deleted until five minutes after it expired. `validUntil` is a
+number Nextcloud computes and Etherpad judges against its own clock, and
+in the window where the two disagree a session this side calls dead is
+one the pad server still grants – deleting it there would close a socket
+somebody is typing into. Queueing the sweep is best-effort too: it writes
+to the jobs table from inside an open, and housekeeping is not allowed to
+be the reason a pad fails to open.
 
 Two limits are worth knowing. The sweep only ever sees an author somebody
 opens a pad for, so an account nobody uses keeps whatever piled up – that

--- a/lib/BackgroundJob/CollectExpiredSessionsJob.php
+++ b/lib/BackgroundJob/CollectExpiredSessionsJob.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Copyright (c) 2026 Jacob Bühler
+ */
+
+namespace OCA\EtherpadNextcloud\BackgroundJob;
+
+use OCA\EtherpadNextcloud\Service\ExpiredSessionCollector;
+use OCP\BackgroundJob\IJobList;
+use OCP\BackgroundJob\QueuedJob;
+
+/**
+ * Works through one author's expired Etherpad sessions.
+ *
+ * Queued rather than timed, and per author rather than over everyone: the
+ * backlog is noticed while a request is holding the listing anyway, so the
+ * work is created exactly where it exists instead of being found again by
+ * a sweep over every account on the instance.
+ *
+ * The author id travels in the argument. Resolving it from the uid would
+ * mean reaching back into the session service, and there is no reason to:
+ * whoever queued this had it in hand, and the two are one to one.
+ *
+ * @psalm-api
+ */
+class CollectExpiredSessionsJob extends QueuedJob {
+	public function __construct(
+		\OCP\AppFramework\Utility\ITimeFactory $time,
+		private ExpiredSessionCollector $collector,
+		private IJobList $jobList,
+	) {
+		parent::__construct($time);
+	}
+
+	/**
+	 * @param mixed $argument
+	 */
+	protected function run($argument): void {
+		if (!is_array($argument)) {
+			return;
+		}
+		$uid = (string)($argument['uid'] ?? '');
+		$authorId = (string)($argument['authorId'] ?? '');
+		if ($uid === '' || $authorId === '') {
+			return;
+		}
+
+		$result = $this->collector->collect($uid, $authorId);
+		if ($result['remaining'] <= 0) {
+			return;
+		}
+
+		// More than one run's worth. Queued for later rather than looped
+		// here: a backlog large enough to need a second pass is large
+		// enough that holding a cron worker on it would starve everything
+		// behind it, and nothing is waiting for this to finish.
+		$this->jobList->scheduleAfter(
+			self::class,
+			$this->time->getTime() + 60,
+			['uid' => $uid, 'authorId' => $authorId],
+		);
+	}
+}

--- a/lib/BackgroundJob/CollectExpiredSessionsJob.php
+++ b/lib/BackgroundJob/CollectExpiredSessionsJob.php
@@ -28,6 +28,13 @@ use OCP\BackgroundJob\QueuedJob;
  * @psalm-api
  */
 class CollectExpiredSessionsJob extends QueuedJob {
+	/** Seconds to wait before the next pass of a sweep that had more to do. */
+	private const CONTINUE_DELAY_SECONDS = 60;
+
+	/** Backoff after a failed listing, one entry per attempt. */
+	private const RETRY_DELAYS = [60, 300, 900];
+	private const MAX_RETRIES = 3;
+
 	public function __construct(
 		\OCP\AppFramework\Utility\ITimeFactory $time,
 		private ExpiredSessionCollector $collector,
@@ -49,7 +56,27 @@ class CollectExpiredSessionsJob extends QueuedJob {
 			return;
 		}
 
+		// Clamped, not trusted. The attempt travels through the jobs table,
+		// and a row is just data: a negative one would index past the start
+		// of the backoff table.
+		$attempt = max(0, (int)($argument['attempt'] ?? 0));
+
 		$result = $this->collector->collect($uid, $authorId);
+		if ($result['retry']) {
+			// The listing failed, so nothing was even attempted. This has to
+			// be re-queued explicitly: QueuedJob removes its row before
+			// run(), so an unreported failure is a backlog that waits for
+			// somebody to open a pad and notice it all over again.
+			//
+			// Backed off, and given up on after a few tries. A pad server
+			// that has been unreachable for half an hour will not be helped
+			// by a fourth attempt, and the next open queues a fresh sweep
+			// anyway.
+			if ($attempt < self::MAX_RETRIES) {
+				$this->reschedule($uid, $authorId, $attempt + 1, self::RETRY_DELAYS[$attempt]);
+			}
+			return;
+		}
 		if ($result['remaining'] <= 0) {
 			return;
 		}
@@ -58,10 +85,32 @@ class CollectExpiredSessionsJob extends QueuedJob {
 		// here: a backlog large enough to need a second pass is large
 		// enough that holding a cron worker on it would starve everything
 		// behind it, and nothing is waiting for this to finish.
-		$this->jobList->scheduleAfter(
-			self::class,
-			$this->time->getTime() + 60,
-			['uid' => $uid, 'authorId' => $authorId],
-		);
+		//
+		// The attempt counter starts over: this run did its work, so the
+		// next one is a continuation, not a retry.
+		$this->reschedule($uid, $authorId, 0, self::CONTINUE_DELAY_SECONDS);
+	}
+
+	/**
+	 * Queue the next pass.
+	 *
+	 * scheduleAfter() rather than add(): the delay is the whole point, and
+	 * add() would leave the row runnable at once. It can still be released
+	 * early — a pad open that finds the backlog again calls add() for the
+	 * same class and argument, and Nextcloud updates the row rather than
+	 * ignoring it. That is acceptable here and not in the collector: an
+	 * early sweep is wasted work, whereas an early retry against a pad
+	 * server that is still down is the loop the backoff exists to avoid.
+	 * Which is why the attempt counter lives in the argument: a retry is a
+	 * different row from the plain one an open queues, so an open cannot
+	 * reset the backoff.
+	 */
+	private function reschedule(string $uid, string $authorId, int $attempt, int $delaySeconds): void {
+		$argument = ['uid' => $uid, 'authorId' => $authorId];
+		if ($attempt > 0) {
+			$argument['attempt'] = $attempt;
+		}
+
+		$this->jobList->scheduleAfter(self::class, $this->time->getTime() + $delaySeconds, $argument);
 	}
 }

--- a/lib/BackgroundJob/CollectExpiredSessionsJob.php
+++ b/lib/BackgroundJob/CollectExpiredSessionsJob.php
@@ -21,9 +21,10 @@ use OCP\BackgroundJob\QueuedJob;
  * work is created exactly where it exists instead of being found again by
  * a sweep over every account on the instance.
  *
- * The author id travels in the argument. Resolving it from the uid would
- * mean reaching back into the session service, and there is no reason to:
- * whoever queued this had it in hand, and the two are one to one.
+ * The author id travels in the argument, and nothing else does. For a
+ * public link the Nextcloud uid is `public-share:<token>` — the credential
+ * from the share URL — and a job argument is persisted, printed by occ,
+ * and carried into database dumps. The job has no use for it either way.
  *
  * @psalm-api
  */
@@ -47,8 +48,8 @@ class CollectExpiredSessionsJob extends QueuedJob {
 	 * matches arguments exactly, so a sweep queued while a retry waits
 	 * would be a second row that runs at once.
 	 *
-	 * @param array{uid:string,authorId:string} $argument
-	 * @return list<array{uid:string,authorId:string,attempt:int}>
+	 * @param array{authorId:string} $argument
+	 * @return list<array{authorId:string,attempt:int}>
 	 */
 	public static function attemptArguments(array $argument): array {
 		$arguments = [];
@@ -57,6 +58,17 @@ class CollectExpiredSessionsJob extends QueuedJob {
 		}
 
 		return $arguments;
+	}
+
+	/** Whether a backed-off retry for this author is waiting its turn. */
+	private function retryIsWaiting(string $authorId): bool {
+		foreach (self::attemptArguments(['authorId' => $authorId]) as $retryArgument) {
+			if ($this->jobList->has(self::class, $retryArgument)) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	public function __construct(
@@ -75,18 +87,25 @@ class CollectExpiredSessionsJob extends QueuedJob {
 		if (!is_array($argument)) {
 			return;
 		}
-		$uid = (string)($argument['uid'] ?? '');
 		$authorId = (string)($argument['authorId'] ?? '');
-		if ($uid === '' || $authorId === '') {
+		if ($authorId === '') {
 			return;
 		}
-
 		// Clamped, not trusted. The attempt travels through the jobs table,
 		// and a row is just data: a negative one would index past the start
 		// of the backoff table.
 		$attempt = max(0, (int)($argument['attempt'] ?? 0));
 
-		$result = $this->collector->collect($uid, $authorId);
+		// A plain row can be queued while a run is in progress — QueuedJob
+		// removes its own row before running, so for those seconds nothing
+		// says a sweep exists — and the failing run then adds its retry
+		// behind it. The plain row would run at once and undo the waiting
+		// the backoff is for, so it stands down when a retry is pending.
+		if ($attempt === 0 && $this->retryIsWaiting($authorId)) {
+			return;
+		}
+
+		$result = $this->collector->collect($authorId);
 		if ($result['retry']) {
 			// Something was refused — the listing, or a delete. Either way
 			// this has to be re-queued explicitly: QueuedJob removes its row
@@ -99,7 +118,7 @@ class CollectExpiredSessionsJob extends QueuedJob {
 			// few of them were refused. It waits out the backoff and then
 			// carries on as a fresh attempt.
 			if ($result['deleted'] > 0) {
-				$this->reschedule($uid, $authorId, 0, self::RETRY_DELAYS[$attempt] ?? self::CONTINUE_DELAY_SECONDS);
+				$this->reschedule($authorId, 0, self::RETRY_DELAYS[$attempt] ?? self::CONTINUE_DELAY_SECONDS);
 				return;
 			}
 
@@ -108,22 +127,28 @@ class CollectExpiredSessionsJob extends QueuedJob {
 			// helped by a fourth ask, and the next open queues a fresh sweep
 			// anyway.
 			if (isset(self::RETRY_DELAYS[$attempt])) {
-				$this->reschedule($uid, $authorId, $attempt + 1, self::RETRY_DELAYS[$attempt]);
+				$this->reschedule($authorId, $attempt + 1, self::RETRY_DELAYS[$attempt]);
 			}
 			return;
 		}
-		if ($result['remaining'] <= 0) {
+
+		if ($result['remaining'] > 0) {
+			// More than one run's worth. Queued for later rather than looped
+			// here: a backlog large enough to need a second pass is large
+			// enough that holding a cron worker on it would starve
+			// everything behind it, and nothing is waiting for this.
+			$this->reschedule($authorId, 0, self::CONTINUE_DELAY_SECONDS);
 			return;
 		}
 
-		// More than one run's worth. Queued for later rather than looped
-		// here: a backlog large enough to need a second pass is large
-		// enough that holding a cron worker on it would starve everything
-		// behind it, and nothing is waiting for this to finish.
-		//
-		// The attempt counter starts over: this run did its work, so the
-		// next one is a continuation, not a retry.
-		$this->reschedule($uid, $authorId, 0, self::CONTINUE_DELAY_SECONDS);
+		// Nothing left to collect. Coming back when the earliest session
+		// still standing expires, rather than not at all: this row is also
+		// what tells an open that a sweep is already accounted for, so
+		// without it every visitor of a busy public link would queue
+		// another full walk of one shared author's index.
+		if ($result['nextDueAt'] !== null) {
+			$this->reschedule($authorId, 0, max(1, $result['nextDueAt'] - $this->time->getTime()));
+		}
 	}
 
 	/**
@@ -140,8 +165,8 @@ class CollectExpiredSessionsJob extends QueuedJob {
 	 * different row from the plain one an open queues, so an open cannot
 	 * reset the backoff.
 	 */
-	private function reschedule(string $uid, string $authorId, int $attempt, int $delaySeconds): void {
-		$argument = ['uid' => $uid, 'authorId' => $authorId];
+	private function reschedule(string $authorId, int $attempt, int $delaySeconds): void {
+		$argument = ['authorId' => $authorId];
 		if ($attempt > 0) {
 			$argument['attempt'] = $attempt;
 		}
@@ -155,7 +180,6 @@ class CollectExpiredSessionsJob extends QueuedJob {
 			// collector guards the same call for the same reason.
 			$this->logger->warning('Could not queue the next Etherpad session sweep; the rest waits for another open.', [
 				'app' => 'etherpad_nextcloud',
-				'uid' => $uid,
 				'authorId' => $authorId,
 				'exception' => $e,
 			]);

--- a/lib/BackgroundJob/CollectExpiredSessionsJob.php
+++ b/lib/BackgroundJob/CollectExpiredSessionsJob.php
@@ -31,14 +31,39 @@ class CollectExpiredSessionsJob extends QueuedJob {
 	/** Seconds to wait before the next pass of a sweep that had more to do. */
 	private const CONTINUE_DELAY_SECONDS = 60;
 
-	/** Backoff after a failed listing, one entry per attempt. */
+	/**
+	 * Backoff after a refusal, one entry per attempt. The table is the
+	 * limit: a second constant saying how many there are would be a fact
+	 * about this array kept somewhere else, and tuning the delays without
+	 * noticing would index past its end — inside a cron worker, with this
+	 * job's row already removed and the backlog with it.
+	 */
 	private const RETRY_DELAYS = [60, 300, 900];
-	private const MAX_RETRIES = 3;
+
+	/**
+	 * The arguments a waiting retry for this author can have.
+	 *
+	 * The collector has to recognise every one of them: the job list
+	 * matches arguments exactly, so a sweep queued while a retry waits
+	 * would be a second row that runs at once.
+	 *
+	 * @param array{uid:string,authorId:string} $argument
+	 * @return list<array{uid:string,authorId:string,attempt:int}>
+	 */
+	public static function attemptArguments(array $argument): array {
+		$arguments = [];
+		foreach (array_keys(self::RETRY_DELAYS) as $index) {
+			$arguments[] = $argument + ['attempt' => $index + 1];
+		}
+
+		return $arguments;
+	}
 
 	public function __construct(
 		\OCP\AppFramework\Utility\ITimeFactory $time,
 		private ExpiredSessionCollector $collector,
 		private IJobList $jobList,
+		private \Psr\Log\LoggerInterface $logger,
 	) {
 		parent::__construct($time);
 	}
@@ -63,16 +88,26 @@ class CollectExpiredSessionsJob extends QueuedJob {
 
 		$result = $this->collector->collect($uid, $authorId);
 		if ($result['retry']) {
-			// The listing failed, so nothing was even attempted. This has to
-			// be re-queued explicitly: QueuedJob removes its row before
-			// run(), so an unreported failure is a backlog that waits for
-			// somebody to open a pad and notice it all over again.
+			// Something was refused — the listing, or a delete. Either way
+			// this has to be re-queued explicitly: QueuedJob removes its row
+			// before run(), so a failure nobody reports is a backlog waiting
+			// for somebody to open a pad and notice it all over again.
 			//
-			// Backed off, and given up on after a few tries. A pad server
-			// that has been unreachable for half an hour will not be helped
-			// by a fourth attempt, and the next open queues a fresh sweep
+			// A run that deleted something is not an outage. The server
+			// answered, the pile got smaller, and giving up on a sweep that
+			// is visibly working would drop thousands of entries because a
+			// few of them were refused. It waits out the backoff and then
+			// carries on as a fresh attempt.
+			if ($result['deleted'] > 0) {
+				$this->reschedule($uid, $authorId, 0, self::RETRY_DELAYS[$attempt] ?? self::CONTINUE_DELAY_SECONDS);
+				return;
+			}
+
+			// Nothing moved. Backed off, and given up on after a few tries:
+			// a pad server unreachable for a quarter of an hour will not be
+			// helped by a fourth ask, and the next open queues a fresh sweep
 			// anyway.
-			if ($attempt < self::MAX_RETRIES) {
+			if (isset(self::RETRY_DELAYS[$attempt])) {
 				$this->reschedule($uid, $authorId, $attempt + 1, self::RETRY_DELAYS[$attempt]);
 			}
 			return;
@@ -111,6 +146,19 @@ class CollectExpiredSessionsJob extends QueuedJob {
 			$argument['attempt'] = $attempt;
 		}
 
-		$this->jobList->scheduleAfter(self::class, $this->time->getTime() + $delaySeconds, $argument);
+		try {
+			$this->jobList->scheduleAfter(self::class, $this->time->getTime() + $delaySeconds, $argument);
+		} catch (\Throwable $e) {
+			// This job's row is already gone — QueuedJob removes it before
+			// run() — so an exception here loses the rest of the backlog with
+			// nothing but Nextcloud's generic job error to show for it. The
+			// collector guards the same call for the same reason.
+			$this->logger->warning('Could not queue the next Etherpad session sweep; the rest waits for another open.', [
+				'app' => 'etherpad_nextcloud',
+				'uid' => $uid,
+				'authorId' => $authorId,
+				'exception' => $e,
+			]);
+		}
 	}
 }

--- a/lib/BackgroundJob/CollectExpiredSessionsJob.php
+++ b/lib/BackgroundJob/CollectExpiredSessionsJob.php
@@ -16,15 +16,10 @@ use OCP\BackgroundJob\QueuedJob;
 /**
  * Works through one author's expired Etherpad sessions.
  *
- * Queued rather than timed, and per author rather than over everyone: the
- * backlog is noticed while a request is holding the listing anyway, so the
- * work is created exactly where it exists instead of being found again by
- * a sweep over every account on the instance.
- *
- * The author id travels in the argument, and nothing else does. For a
- * public link the Nextcloud uid is `public-share:<token>` — the credential
- * from the share URL — and a job argument is persisted, printed by occ,
- * and carried into database dumps. The job has no use for it either way.
+ * Queued rather than timed, and per author: an open says who might need
+ * collecting, so no sweep over every account is needed. The argument
+ * carries the author id and nothing else — for a public link the uid is
+ * `public-share:<token>`, and job arguments are persisted.
  *
  * @psalm-api
  */
@@ -32,21 +27,12 @@ class CollectExpiredSessionsJob extends QueuedJob {
 	/** Seconds to wait before the next pass of a sweep that had more to do. */
 	private const CONTINUE_DELAY_SECONDS = 60;
 
-	/**
-	 * Backoff after a refusal, one entry per attempt. The table is the
-	 * limit: a second constant saying how many there are would be a fact
-	 * about this array kept somewhere else, and tuning the delays without
-	 * noticing would index past its end — inside a cron worker, with this
-	 * job's row already removed and the backlog with it.
-	 */
+	/** Backoff after a refusal. The table is also the limit on attempts. */
 	private const RETRY_DELAYS = [60, 300, 900];
 
 	/**
-	 * The arguments a waiting retry for this author can have.
-	 *
-	 * The collector has to recognise every one of them: the job list
-	 * matches arguments exactly, so a sweep queued while a retry waits
-	 * would be a second row that runs at once.
+	 * The arguments a waiting retry can have, so the collector can
+	 * recognise one before queueing a second row beside it.
 	 *
 	 * @param array{authorId:string} $argument
 	 * @return list<array{authorId:string,attempt:int}>
@@ -91,41 +77,30 @@ class CollectExpiredSessionsJob extends QueuedJob {
 		if ($authorId === '') {
 			return;
 		}
-		// Clamped, not trusted. The attempt travels through the jobs table,
-		// and a row is just data: a negative one would index past the start
-		// of the backoff table.
+		// A row is just data; a negative attempt would index past the table.
 		$attempt = max(0, (int)($argument['attempt'] ?? 0));
 
-		// A plain row can be queued while a run is in progress — QueuedJob
-		// removes its own row before running, so for those seconds nothing
-		// says a sweep exists — and the failing run then adds its retry
-		// behind it. The plain row would run at once and undo the waiting
-		// the backoff is for, so it stands down when a retry is pending.
+		// QueuedJob removes its row before running, so during a run nothing
+		// says a sweep exists and an open can queue a runnable row beside
+		// the retry that follows. It stands down rather than undo the wait.
 		if ($attempt === 0 && $this->retryIsWaiting($authorId)) {
 			return;
 		}
 
 		$result = $this->collector->collect($authorId);
 		if ($result['retry']) {
-			// Something was refused — the listing, or a delete. Either way
-			// this has to be re-queued explicitly: QueuedJob removes its row
-			// before run(), so a failure nobody reports is a backlog waiting
-			// for somebody to open a pad and notice it all over again.
-			//
-			// A run that deleted something is not an outage. The server
-			// answered, the pile got smaller, and giving up on a sweep that
-			// is visibly working would drop thousands of entries because a
-			// few of them were refused. It waits out the backoff and then
-			// carries on as a fresh attempt.
+			// A run that deleted something is not an outage: the server
+			// answered and the pile got smaller, so it waits out the delay
+			// and carries on as a fresh attempt rather than being given up
+			// on because a few entries were refused.
 			if ($result['deleted'] > 0) {
 				$this->reschedule($authorId, 0, self::RETRY_DELAYS[$attempt] ?? self::CONTINUE_DELAY_SECONDS);
 				return;
 			}
 
-			// Nothing moved. Backed off, and given up on after a few tries:
-			// a pad server unreachable for a quarter of an hour will not be
-			// helped by a fourth ask, and the next open queues a fresh sweep
-			// anyway.
+			// Nothing moved. A server unreachable for a quarter of an hour
+			// will not be helped by a fourth ask, and the next open queues a
+			// fresh sweep anyway.
 			if (isset(self::RETRY_DELAYS[$attempt])) {
 				$this->reschedule($authorId, $attempt + 1, self::RETRY_DELAYS[$attempt]);
 			}
@@ -133,37 +108,25 @@ class CollectExpiredSessionsJob extends QueuedJob {
 		}
 
 		if ($result['remaining'] > 0) {
-			// More than one run's worth. Queued for later rather than looped
-			// here: a backlog large enough to need a second pass is large
-			// enough that holding a cron worker on it would starve
-			// everything behind it, and nothing is waiting for this.
+			// Queued rather than looped: holding a cron worker on a long
+			// backlog would starve everything behind it.
 			$this->reschedule($authorId, 0, self::CONTINUE_DELAY_SECONDS);
 			return;
 		}
 
-		// Nothing left to collect. Coming back when the earliest session
-		// still standing expires, rather than not at all: this row is also
-		// what tells an open that a sweep is already accounted for, so
-		// without it every visitor of a busy public link would queue
-		// another full walk of one shared author's index.
+		// Nothing left, so come back when the earliest session still
+		// standing falls due. That row is also what tells an open a sweep is
+		// already accounted for.
 		if ($result['nextDueAt'] !== null) {
 			$this->reschedule($authorId, 0, max(1, $result['nextDueAt'] - $this->time->getTime()));
 		}
 	}
 
 	/**
-	 * Queue the next pass.
-	 *
-	 * scheduleAfter() rather than add(): the delay is the whole point, and
-	 * add() would leave the row runnable at once. It can still be released
-	 * early — a pad open that finds the backlog again calls add() for the
-	 * same class and argument, and Nextcloud updates the row rather than
-	 * ignoring it. That is acceptable here and not in the collector: an
-	 * early sweep is wasted work, whereas an early retry against a pad
-	 * server that is still down is the loop the backoff exists to avoid.
-	 * Which is why the attempt counter lives in the argument: a retry is a
-	 * different row from the plain one an open queues, so an open cannot
-	 * reset the backoff.
+	 * Queue the next pass. scheduleAfter() rather than add(), which would
+	 * leave the row runnable at once; and the attempt lives in the argument
+	 * so a plain row from an open is a different row and cannot reset a
+	 * backoff.
 	 */
 	private function reschedule(string $authorId, int $attempt, int $delaySeconds): void {
 		$argument = ['authorId' => $authorId];
@@ -174,10 +137,8 @@ class CollectExpiredSessionsJob extends QueuedJob {
 		try {
 			$this->jobList->scheduleAfter(self::class, $this->time->getTime() + $delaySeconds, $argument);
 		} catch (\Throwable $e) {
-			// This job's row is already gone — QueuedJob removes it before
-			// run() — so an exception here loses the rest of the backlog with
-			// nothing but Nextcloud's generic job error to show for it. The
-			// collector guards the same call for the same reason.
+			// This job's row is already gone, so an unguarded throw loses the
+			// rest of the backlog behind a generic job error.
 			$this->logger->warning('Could not queue the next Etherpad session sweep; the rest waits for another open.', [
 				'app' => 'etherpad_nextcloud',
 				'authorId' => $authorId,

--- a/lib/Service/EtherpadClient.php
+++ b/lib/Service/EtherpadClient.php
@@ -213,22 +213,17 @@ class EtherpadClient {
 		$data = $this->apiCall('listSessionsOfAuthor', ['authorID' => $authorId], 'POST', null, null, null, $timeoutSeconds);
 
 		$sessions = [];
-		// A null is a key the index lists whose session record is gone: it
-		// still costs a lookup per listing and `deleteSession` will not take
-		// it. Dropping those silently would let a sweep look successful
-		// while the index stayed as long.
+		// Every entry the index listed that cannot be turned into a session,
+		// whatever made it unusable — a null, a malformed record, an
+		// unexpected key. Each still costs a lookup per listing and
+		// `deleteSession` will not take it, so dropping any of them quietly
+		// would let a sweep look successful while the index stayed as long.
 		$unreadableEntries = 0;
 		foreach ($data as $sessionId => $info) {
-			if (!is_string($sessionId)) {
-				continue;
-			}
-			if (!is_array($info)) {
+			$groupId = is_array($info) ? (string)($info['groupID'] ?? '') : '';
+			$validUntil = is_array($info) ? (int)($info['validUntil'] ?? 0) : 0;
+			if (!is_string($sessionId) || $groupId === '' || $validUntil <= 0) {
 				$unreadableEntries++;
-				continue;
-			}
-			$groupId = (string)($info['groupID'] ?? '');
-			$validUntil = (int)($info['validUntil'] ?? 0);
-			if ($groupId === '' || $validUntil <= 0) {
 				continue;
 			}
 			$sessions[$sessionId] = ['groupID' => $groupId, 'validUntil' => $validUntil];

--- a/lib/Service/EtherpadClient.php
+++ b/lib/Service/EtherpadClient.php
@@ -202,10 +202,10 @@ class EtherpadClient {
 	 *
 	 * @return array<string,array{groupID:string,validUntil:int}>
 	 */
-	public function listSessionsOfAuthor(string $authorId): array {
+	public function listSessionsOfAuthor(string $authorId, ?int $timeoutSeconds = null): array {
 		// POST like every other authenticated call: a GET would put the
 		// apikey in the URL, and from there into proxy and access logs.
-		$data = $this->apiCall('listSessionsOfAuthor', ['authorID' => $authorId]);
+		$data = $this->apiCall('listSessionsOfAuthor', ['authorID' => $authorId], 'POST', null, null, null, $timeoutSeconds);
 
 		$sessions = [];
 		foreach ($data as $sessionId => $info) {
@@ -362,7 +362,11 @@ class EtherpadClient {
 		?int $timeoutSeconds = null,
 	): string {
 		$method = strtoupper($httpMethod);
-		$options = $this->baseRequestOptions($timeoutSeconds ?? self::REQUEST_TIMEOUT_SECONDS);
+		// Clamped, not merely defaulted. Guzzle reads `timeout => 0` as no
+		// timeout at all, so a caller computing a remainder that reaches
+		// zero would turn the one parameter whose purpose is bounding time
+		// into an unbounded call.
+		$options = $this->baseRequestOptions($this->boundedTimeout($timeoutSeconds));
 		if ($method === 'GET') {
 			$options['query'] = $query;
 		} else {
@@ -478,6 +482,15 @@ class EtherpadClient {
 	 *
 	 * @return array<string,mixed>
 	 */
+	/** At least a second, never more than any other call in this app. */
+	private function boundedTimeout(?int $timeoutSeconds): int {
+		if ($timeoutSeconds === null) {
+			return self::REQUEST_TIMEOUT_SECONDS;
+		}
+
+		return max(1, min($timeoutSeconds, self::REQUEST_TIMEOUT_SECONDS));
+	}
+
 	private function baseRequestOptions(int $timeoutSeconds = self::REQUEST_TIMEOUT_SECONDS): array {
 		return [
 			'timeout' => $timeoutSeconds,

--- a/lib/Service/EtherpadClient.php
+++ b/lib/Service/EtherpadClient.php
@@ -177,6 +177,16 @@ class EtherpadClient {
 	}
 
 	/**
+	 * Take one session away.
+	 *
+	 * Measured: a second delete of the same id answers `sessionID does not
+	 * exist`, which the classifier reads as already gone.
+	 */
+	public function deleteSession(string $sessionId): void {
+		$this->apiCall('deleteSession', ['sessionID' => $sessionId]);
+	}
+
+	/**
 	 * The author's sessions, keyed by session id, each carrying the group it
 	 * grants access to and when it stops doing so.
 	 *

--- a/lib/Service/EtherpadClient.php
+++ b/lib/Service/EtherpadClient.php
@@ -202,14 +202,34 @@ class EtherpadClient {
 	 *
 	 * @return array<string,array{groupID:string,validUntil:int}>
 	 */
-	public function listSessionsOfAuthor(string $authorId, ?int $timeoutSeconds = null): array {
+	/**
+	 * @param ?int $unreadableEntries set to how many ids the index listed
+	 *   that Etherpad could not describe — see below
+	 */
+	public function listSessionsOfAuthor(
+		string $authorId,
+		?int $timeoutSeconds = null,
+		?int &$unreadableEntries = null,
+	): array {
 		// POST like every other authenticated call: a GET would put the
 		// apikey in the URL, and from there into proxy and access logs.
 		$data = $this->apiCall('listSessionsOfAuthor', ['authorID' => $authorId], 'POST', null, null, null, $timeoutSeconds);
 
 		$sessions = [];
+		// An id the index lists but Etherpad cannot describe comes back as
+		// null. That is not noise: Etherpad's own listing walks the author
+		// index and answers null for a key whose session record is gone, so
+		// a null is an entry that still costs a lookup on every listing and
+		// that `deleteSession` cannot remove — it answers "does not exist".
+		// Dropping them silently would let a collector report success while
+		// the index it exists to shrink stayed exactly as long.
+		$unreadableEntries = 0;
 		foreach ($data as $sessionId => $info) {
-			if (!is_string($sessionId) || !is_array($info)) {
+			if (!is_string($sessionId)) {
+				continue;
+			}
+			if (!is_array($info)) {
+				$unreadableEntries++;
 				continue;
 			}
 			$groupId = (string)($info['groupID'] ?? '');

--- a/lib/Service/EtherpadClient.php
+++ b/lib/Service/EtherpadClient.php
@@ -183,10 +183,7 @@ class EtherpadClient {
 	 * exist`, which the classifier reads as already gone.
 	 *
 	 * The timeout is a parameter because the collector promises a total run
-	 * length, and a call that may take the standard timeout on its own can
-	 * only be started, never bounded. Without this the promise is off by a
-	 * whole timeout — the last call is allowed to begin just under the
-	 * deadline and then run past it.
+	 * length, which a call carrying the standard timeout would overrun.
 	 */
 	public function deleteSession(string $sessionId, ?int $timeoutSeconds = null): void {
 		$this->apiCall('deleteSession', ['sessionID' => $sessionId], 'POST', null, null, null, $timeoutSeconds);
@@ -216,13 +213,10 @@ class EtherpadClient {
 		$data = $this->apiCall('listSessionsOfAuthor', ['authorID' => $authorId], 'POST', null, null, null, $timeoutSeconds);
 
 		$sessions = [];
-		// An id the index lists but Etherpad cannot describe comes back as
-		// null. That is not noise: Etherpad's own listing walks the author
-		// index and answers null for a key whose session record is gone, so
-		// a null is an entry that still costs a lookup on every listing and
-		// that `deleteSession` cannot remove — it answers "does not exist".
-		// Dropping them silently would let a collector report success while
-		// the index it exists to shrink stayed exactly as long.
+		// A null is a key the index lists whose session record is gone: it
+		// still costs a lookup per listing and `deleteSession` will not take
+		// it. Dropping those silently would let a sweep look successful
+		// while the index stayed as long.
 		$unreadableEntries = 0;
 		foreach ($data as $sessionId => $info) {
 			if (!is_string($sessionId)) {
@@ -382,10 +376,7 @@ class EtherpadClient {
 		?int $timeoutSeconds = null,
 	): string {
 		$method = strtoupper($httpMethod);
-		// Clamped, not merely defaulted. Guzzle reads `timeout => 0` as no
-		// timeout at all, so a caller computing a remainder that reaches
-		// zero would turn the one parameter whose purpose is bounding time
-		// into an unbounded call.
+		// Clamped: Guzzle reads `timeout => 0` as no timeout at all.
 		$options = $this->baseRequestOptions($this->boundedTimeout($timeoutSeconds));
 		if ($method === 'GET') {
 			$options['query'] = $query;

--- a/lib/Service/EtherpadClient.php
+++ b/lib/Service/EtherpadClient.php
@@ -181,9 +181,15 @@ class EtherpadClient {
 	 *
 	 * Measured: a second delete of the same id answers `sessionID does not
 	 * exist`, which the classifier reads as already gone.
+	 *
+	 * The timeout is a parameter because the collector promises a total run
+	 * length, and a call that may take the standard timeout on its own can
+	 * only be started, never bounded. Without this the promise is off by a
+	 * whole timeout — the last call is allowed to begin just under the
+	 * deadline and then run past it.
 	 */
-	public function deleteSession(string $sessionId): void {
-		$this->apiCall('deleteSession', ['sessionID' => $sessionId]);
+	public function deleteSession(string $sessionId, ?int $timeoutSeconds = null): void {
+		$this->apiCall('deleteSession', ['sessionID' => $sessionId], 'POST', null, null, null, $timeoutSeconds);
 	}
 
 	/**
@@ -307,7 +313,8 @@ class EtherpadClient {
 		string $httpMethod = 'POST',
 		?string $hostOverride = null,
 		?string $apiKeyOverride = null,
-		?string $apiVersionOverride = null
+		?string $apiVersionOverride = null,
+		?int $timeoutSeconds = null
 	): array {
 		$apiVersion = $apiVersionOverride !== null && trim($apiVersionOverride) !== ''
 			? trim($apiVersionOverride)
@@ -325,7 +332,7 @@ class EtherpadClient {
 		]);
 
 		try {
-			$rawBody = $this->sendRequest($url, $query, $httpMethod);
+			$rawBody = $this->sendRequest($url, $query, $httpMethod, $timeoutSeconds);
 		} catch (\Throwable $e) {
 			throw new EtherpadClientException('Etherpad API request failed: ' . $method, 0, $e);
 		}
@@ -348,9 +355,14 @@ class EtherpadClient {
 	/**
 	 * @param array<string,mixed> $query
 	 */
-	private function sendRequest(string $url, array $query, string $httpMethod): string {
+	private function sendRequest(
+		string $url,
+		array $query,
+		string $httpMethod,
+		?int $timeoutSeconds = null,
+	): string {
 		$method = strtoupper($httpMethod);
-		$options = $this->baseRequestOptions();
+		$options = $this->baseRequestOptions($timeoutSeconds ?? self::REQUEST_TIMEOUT_SECONDS);
 		if ($method === 'GET') {
 			$options['query'] = $query;
 		} else {

--- a/lib/Service/ExpiredSessionCollector.php
+++ b/lib/Service/ExpiredSessionCollector.php
@@ -178,6 +178,7 @@ class ExpiredSessionCollector {
 			$sessions = $this->etherpadClient->listSessionsOfAuthor(
 				$authorId,
 				$this->callTimeout($deadline - microtime(true)),
+				$unreadable,
 			);
 		} catch (\Throwable $e) {
 			$this->logger->warning('Could not list the Etherpad sessions to collect.', [
@@ -186,6 +187,22 @@ class ExpiredSessionCollector {
 				'exception' => $e,
 			]);
 			return ['deleted' => 0, 'remaining' => 0, 'retry' => true, 'nextDueAt' => null];
+		}
+
+		if (($unreadable ?? 0) > 0) {
+			// Ids the author index lists that Etherpad can no longer
+			// describe. `deleteSession` will not take them either — it
+			// answers that they do not exist — so this run cannot shrink
+			// that part of the index, and neither can any later one. It is
+			// worth saying out loud rather than reporting a clean sweep:
+			// the listing stays as slow as the number of keys, and on an
+			// Etherpad that leaves them behind, collecting is not the
+			// remedy it is here.
+			$this->logger->warning('Etherpad lists sessions it cannot describe; those entries cannot be collected.', [
+				'app' => 'etherpad_nextcloud',
+				'authorId' => $authorId,
+				'unreadableEntries' => $unreadable,
+			]);
 		}
 
 		// The same grace as the counting above, for the same reason: a

--- a/lib/Service/ExpiredSessionCollector.php
+++ b/lib/Service/ExpiredSessionCollector.php
@@ -54,6 +54,17 @@ class ExpiredSessionCollector {
 	private const MAX_PER_RUN = 250;
 	private const BUDGET_SECONDS = 20.0;
 
+	/**
+	 * The collector's own request timeout, in place of the client's.
+	 *
+	 * A deadline checked between calls bounds when the last one starts, not
+	 * when it ends: with the standard timeout a delete begun just under the
+	 * deadline runs well past it, and the budget above would be a number
+	 * that describes nothing. Each call gets whatever is left, floored so a
+	 * request is never issued with an already-dead timeout.
+	 */
+	private const MIN_CALL_TIMEOUT_SECONDS = 2;
+
 	public function __construct(
 		private EtherpadClient $etherpadClient,
 		private IJobList $jobList,
@@ -87,18 +98,36 @@ class ExpiredSessionCollector {
 			return;
 		}
 
-		// Adding the same job twice is a no-op on the second call: the job
-		// list keys on class plus argument, so a user who opens ten pads
-		// before the sweep runs still queues one sweep.
-		$this->jobList->add(CollectExpiredSessionsJob::class, ['uid' => $uid, 'authorId' => $authorId]);
+		$argument = ['uid' => $uid, 'authorId' => $authorId];
+		// Not simply add(). Nextcloud's job list does not ignore a second
+		// add for the same class and argument — it updates the row, setting
+		// last_run and reserved_at back to zero and last_checked to now. A
+		// job this collector deliberately scheduled a minute out would be
+		// released immediately by the next pad open, which is how a backoff
+		// stops being one.
+		//
+		// has() then add() is still not atomic, and the jobs table has no
+		// unique index on (class, argument_hash), so two simultaneous opens
+		// can queue two sweeps. That is waste, not damage: a sweep deletes
+		// what has already expired, and a session the other run removed
+		// first comes back as "already gone" and counts as handled.
+		if ($this->jobList->has(CollectExpiredSessionsJob::class, $argument)) {
+			return;
+		}
+		$this->jobList->add(CollectExpiredSessionsJob::class, $argument);
 	}
 
 	/**
 	 * Delete what has expired, up to the run's budget.
 	 *
-	 * @return array{deleted:int,remaining:int} remaining counts what was
-	 *   still expired when the budget ran out, so the caller can decide
-	 *   whether to come back rather than guess.
+	 * Three outcomes, not two. `remaining` says the sweep worked and did
+	 * not finish; `retry` says it never got to start, because the listing
+	 * failed. They must not be one number: the job removes its own row
+	 * before running, so a run that reported nothing left would leave a
+	 * pad server hiccup to be discovered by whichever open happens to
+	 * notice the backlog again.
+	 *
+	 * @return array{deleted:int,remaining:int,retry:bool}
 	 */
 	public function collect(string $uid, string $authorId): array {
 		$deadline = microtime(true) + self::BUDGET_SECONDS;
@@ -112,7 +141,7 @@ class ExpiredSessionCollector {
 				'authorId' => $authorId,
 				'exception' => $e,
 			]);
-			return ['deleted' => 0, 'remaining' => 0];
+			return ['deleted' => 0, 'remaining' => 0, 'retry' => true];
 		}
 
 		$now = time();
@@ -138,7 +167,7 @@ class ExpiredSessionCollector {
 			}
 
 			try {
-				$this->etherpadClient->deleteSession($sessionId);
+				$this->etherpadClient->deleteSession($sessionId, $this->timeoutLeft($deadline));
 				$deleted++;
 				$handled++;
 			} catch (\Throwable $e) {
@@ -169,6 +198,11 @@ class ExpiredSessionCollector {
 			]);
 		}
 
-		return ['deleted' => $deleted, 'remaining' => $remaining];
+		return ['deleted' => $deleted, 'remaining' => $remaining, 'retry' => false];
+	}
+
+	/** Whatever is left of the run's budget, never below the floor. */
+	private function timeoutLeft(float $deadline): int {
+		return max(self::MIN_CALL_TIMEOUT_SECONDS, (int)ceil($deadline - microtime(true)));
 	}
 }

--- a/lib/Service/ExpiredSessionCollector.php
+++ b/lib/Service/ExpiredSessionCollector.php
@@ -26,22 +26,16 @@ use Psr\Log\LoggerInterface;
  * user has ever opened rather than with the sessions that still grant
  * anything.
  *
- * Deleting them is not something a request can do. Each one is its own
- * call, and a backlog of thousands in front of a pad appearing is worse
- * than the listing it would save. So the open that is already holding the
- * listing counts what has expired and leaves a note; the deleting happens
- * in a job.
+ * Neither the asking nor the deleting belongs in a request. Each delete is
+ * its own call, and a backlog of thousands in front of a pad appearing is
+ * worse than the listing it would save; and the listing itself is what
+ * gets slow. So an open leaves nothing behind but the author's id, and the
+ * job does both — it finds out whether there is anything to collect, and
+ * collects it.
  *
  * @psalm-api
  */
 class ExpiredSessionCollector {
-	/**
-	 * How many expired sessions have to pile up before a sweep is worth a
-	 * row in the job table. Well under the point where the listing costs
-	 * real time, and well above the handful that one day of ordinary use
-	 * leaves behind.
-	 */
-	private const BACKLOG_THRESHOLD = 50;
 
 	/**
 	 * A sweep is bounded like everything else that talks to Etherpad, but
@@ -108,44 +102,27 @@ class ExpiredSessionCollector {
 	}
 
 	/**
-	 * Note a backlog seen in a listing somebody else already paid for.
+	 * Remember that this author might have something to collect.
 	 *
-	 * Deliberately takes the sessions rather than fetching them: every
-	 * caller is a request that has the list in hand, and a collector that
-	 * asked again would add a round trip to the very path it exists to
-	 * keep short.
+	 * Deliberately knows nothing about whether there is a backlog. Finding
+	 * that out means the listing, and the listing is the expensive call
+	 * this class exists to keep out of a request — so it happens in the
+	 * job, which is also where the deleting happens and where nobody is
+	 * waiting.
 	 *
-	 * @param array<string,array{groupID:string,validUntil:int}> $sessions
+	 * That is the difference from asking a request to spot the backlog
+	 * first: a listing is only made when a browser carries session ids, so
+	 * the very first open after arriving never made one, and neither did a
+	 * public link — every visitor of which writes to one shared author's
+	 * index. Both were invisible to a sweep that had to be told what to
+	 * look at. An author id is known on every open.
 	 */
-	public function noteBacklog(string $uid, string $authorId, array $sessions): void {
-		if ($uid === '' || $authorId === '') {
-			return;
-		}
-
-		$cutoff = time() - self::EXPIRY_GRACE_SECONDS;
-		$expired = 0;
-		foreach ($sessions as $info) {
-			if ($info['validUntil'] <= $cutoff) {
-				$expired++;
-			}
-		}
-		if ($expired < self::BACKLOG_THRESHOLD) {
+	public function noteAuthor(string $uid, string $authorId): void {
+		if ($authorId === '') {
 			return;
 		}
 
 		$argument = ['uid' => $uid, 'authorId' => $authorId];
-		// Not simply add(). Nextcloud's job list does not ignore a second
-		// add for the same class and argument — it updates the row, setting
-		// last_run and reserved_at back to zero and last_checked to now. A
-		// job this collector deliberately scheduled a minute out would be
-		// released immediately by the next pad open, which is how a backoff
-		// stops being one.
-		//
-		// has() then add() is still not atomic, and the jobs table has no
-		// unique index on (class, argument_hash), so two simultaneous opens
-		// can queue two sweeps. That is waste, not damage: a sweep deletes
-		// what has already expired, and a session the other run removed
-		// first comes back as "already gone" and counts as handled.
 		// Both of these are Nextcloud database calls, and they run inside an
 		// open somebody is waiting for. Housekeeping may not be the reason a
 		// pad fails to open: a deadlock or a lost connection here would turn

--- a/lib/Service/ExpiredSessionCollector.php
+++ b/lib/Service/ExpiredSessionCollector.php
@@ -18,21 +18,19 @@ use Psr\Log\LoggerInterface;
  * Collects the Etherpad sessions that have already expired.
  *
  * They grant nothing, so this is not about access. It is about the cost of
- * asking about access: Etherpad never removes an expired session, and
+ * asking: Etherpad never removes an expired session, and
  * `listSessionsOfAuthor` walks the author's whole index one awaited lookup
- * at a time — expired entries included. So the price of a revoke grows
- * with every pad this user has ever opened, not with the number of
- * sessions that still grant anything.
+ * at a time, expired entries included. Opening a protected pad asks that
+ * question — it is how the app decides which of the ids in the cookie are
+ * still worth carrying — so the price of an open grows with every pad the
+ * user has ever opened rather than with the sessions that still grant
+ * anything.
  *
- * Far enough along that stops being a performance question. The revoker
- * gives a logout two seconds, and the listing is inside that budget: once
- * the listing alone can spend it, the logout revokes nothing at all and
- * the guarantee this app makes about logging out quietly stops holding.
- *
- * Which is why the collecting happens here rather than in the revoker. A
- * logout must not wait on a backlog it did not create, and deleting
- * sessions one call at a time is exactly the backlog. The request only
- * notices that there is one and leaves a note.
+ * Deleting them is not something a request can do. Each one is its own
+ * call, and a backlog of thousands in front of a pad appearing is worse
+ * than the listing it would save. So the open that is already holding the
+ * listing counts what has expired and leaves a note; the deleting happens
+ * in a job.
  *
  * @psalm-api
  */
@@ -52,6 +50,22 @@ class ExpiredSessionCollector {
 	 * fit is picked up by the job it queues behind itself.
 	 */
 	private const MAX_PER_RUN = 250;
+
+	/**
+	 * How many refusals a run puts up with before it stops.
+	 *
+	 * Not one. A session Etherpad will never let go of — a record whose
+	 * group is gone in a way that makes the delete answer with something
+	 * other than "already gone" — would otherwise stand in front of every
+	 * entry behind it for good: the run breaks, the next run re-lists and
+	 * finds the same entry first, and the backlog never moves. Skipping
+	 * past it costs one wasted call per run and reaches the other 3999.
+	 *
+	 * Bounded all the same, because the other reading of a refusal is that
+	 * the server is down, and then there is nothing to be gained by asking
+	 * two hundred more times.
+	 */
+	private const MAX_FAILURES_PER_RUN = 5;
 	private const BUDGET_SECONDS = 20.0;
 
 	/**
@@ -138,7 +152,7 @@ class ExpiredSessionCollector {
 		// a working open into a 500, and the worst case of swallowing it is
 		// that the sweep is queued by the next open instead.
 		try {
-			if ($this->jobList->has(CollectExpiredSessionsJob::class, $argument)) {
+			if ($this->sweepIsQueued($argument)) {
 				return;
 			}
 			$this->jobList->add(CollectExpiredSessionsJob::class, $argument);
@@ -169,7 +183,14 @@ class ExpiredSessionCollector {
 		$deadline = microtime(true) + $this->budgetSeconds;
 
 		try {
-			$sessions = $this->etherpadClient->listSessionsOfAuthor($authorId);
+			// The listing is inside the budget, and until now it was the one
+			// call in the run that could ignore it. It is also the expensive
+			// one — the reason this class exists — so a slow index could eat
+			// the whole run and leave no time to delete anything from it.
+			$sessions = $this->etherpadClient->listSessionsOfAuthor(
+				$authorId,
+				$this->callTimeout($deadline - microtime(true)),
+			);
 		} catch (\Throwable $e) {
 			$this->logger->warning('Could not list the Etherpad sessions to collect.', [
 				'app' => 'etherpad_nextcloud',
@@ -185,9 +206,10 @@ class ExpiredSessionCollector {
 		$cutoff = time() - self::EXPIRY_GRACE_SECONDS;
 		$expired = [];
 		foreach ($sessions as $sessionId => $info) {
-			// Anything still live is left alone. Taking one away is a decision
-			// about permissions, and it is made in the revoker, where the
-			// reason for it is known.
+			// Anything still live is left alone. This job reclaims storage;
+			// deciding that somebody's access should end is a different
+			// question with different reasons behind it, and not one a
+			// housekeeping sweep gets to answer.
 			if ($info['validUntil'] <= $cutoff) {
 				$expired[] = $sessionId;
 			}
@@ -199,7 +221,7 @@ class ExpiredSessionCollector {
 		// is what the log line is about.
 		$handled = 0;
 		$deleted = 0;
-		$failed = false;
+		$failures = 0;
 		foreach ($expired as $sessionId) {
 			// A call that cannot finish inside the budget must not start.
 			// Checking only that the deadline has not passed would let the
@@ -212,7 +234,7 @@ class ExpiredSessionCollector {
 			}
 
 			try {
-				$this->etherpadClient->deleteSession($sessionId, (int)floor($left));
+				$this->etherpadClient->deleteSession($sessionId, $this->callTimeout($left));
 				$deleted++;
 				$handled++;
 			} catch (\Throwable $e) {
@@ -220,17 +242,26 @@ class ExpiredSessionCollector {
 					$handled++;
 					continue;
 				}
-				$failed = true;
-				// One line for the run, not one per session: a pad server that
-				// refuses this call refuses the next two hundred too, and the
-				// queued job will come back to it anyway.
-				$this->logger->warning('Could not collect an expired Etherpad session; stopping this run.', [
+
+				$failures++;
+				// One line per refusal, and a handful of refusals per run.
+				// Stopping at the first would let a single record Etherpad
+				// will never delete stand in front of everything behind it:
+				// the next run re-lists, meets the same entry first, and the
+				// backlog never moves. Going past it wastes one call a run
+				// and reaches the rest.
+				$this->logger->warning('Could not collect an expired Etherpad session.', [
 					'app' => 'etherpad_nextcloud',
 					'uid' => $uid,
 					'authorId' => $authorId,
+					'sessionId' => $sessionId,
 					'exception' => $e,
 				]);
-				break;
+				if ($failures >= self::MAX_FAILURES_PER_RUN) {
+					// The other reading of a refusal: the server is down, and
+					// two hundred more calls will not change that.
+					break;
+				}
 			}
 		}
 		$remaining = count($expired) - $handled;
@@ -248,7 +279,48 @@ class ExpiredSessionCollector {
 		// listing gets. Without it the job reads "some progress, more to do"
 		// and comes back every minute for good — one call and one warning a
 		// minute against a pad server that has already said no.
-		return ['deleted' => $deleted, 'remaining' => $remaining, 'retry' => $failed];
+		return ['deleted' => $deleted, 'remaining' => $remaining, 'retry' => $failures > 0];
 	}
 
+	/**
+	 * Whether any sweep for this author is already waiting.
+	 *
+	 * Every shape of it, not just the plain one. A retry carries its
+	 * attempt in the argument so that an open cannot reset a backoff, and
+	 * the job list matches arguments exactly — so asking only about the
+	 * plain form would miss a retry that is deliberately waiting and queue
+	 * a second, immediately runnable row beside it. That is the loop the
+	 * backoff exists to prevent, arrived at from the other side.
+	 *
+	 * A handful of lookups, in a path that only runs once a backlog has
+	 * built up.
+	 *
+	 * @param array{uid:string,authorId:string} $argument
+	 */
+	private function sweepIsQueued(array $argument): bool {
+		if ($this->jobList->has(CollectExpiredSessionsJob::class, $argument)) {
+			return true;
+		}
+		foreach (CollectExpiredSessionsJob::attemptArguments($argument) as $retryArgument) {
+			if ($this->jobList->has(CollectExpiredSessionsJob::class, $retryArgument)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * What one call may take: the rest of the run's budget, but never more
+	 * patience than any other request this app makes.
+	 *
+	 * Without the upper half a run whose listing came back quickly would
+	 * hand its first delete nearly the whole budget — a housekeeping call
+	 * given more time than the ones a user is waiting on, and a pad server
+	 * that stalls after accepting the connection would spend the whole run
+	 * on one session.
+	 */
+	private function callTimeout(float $left): int {
+		return (int)min(floor($left), EtherpadClient::REQUEST_TIMEOUT_SECONDS);
+	}
 }

--- a/lib/Service/ExpiredSessionCollector.php
+++ b/lib/Service/ExpiredSessionCollector.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Copyright (c) 2026 Jacob Bühler
+ */
+
+namespace OCA\EtherpadNextcloud\Service;
+
+use OCA\EtherpadNextcloud\BackgroundJob\CollectExpiredSessionsJob;
+use OCA\EtherpadNextcloud\Util\EtherpadErrorClassifier;
+use OCP\BackgroundJob\IJobList;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Collects the Etherpad sessions that have already expired.
+ *
+ * They grant nothing, so this is not about access. It is about the cost of
+ * asking about access: Etherpad never removes an expired session, and
+ * `listSessionsOfAuthor` walks the author's whole index one awaited lookup
+ * at a time — expired entries included. So the price of a revoke grows
+ * with every pad this user has ever opened, not with the number of
+ * sessions that still grant anything.
+ *
+ * Far enough along that stops being a performance question. The revoker
+ * gives a logout two seconds, and the listing is inside that budget: once
+ * the listing alone can spend it, the logout revokes nothing at all and
+ * the guarantee this app makes about logging out quietly stops holding.
+ *
+ * Which is why the collecting happens here rather than in the revoker. A
+ * logout must not wait on a backlog it did not create, and deleting
+ * sessions one call at a time is exactly the backlog. The request only
+ * notices that there is one and leaves a note.
+ *
+ * @psalm-api
+ */
+class ExpiredSessionCollector {
+	/**
+	 * How many expired sessions have to pile up before a sweep is worth a
+	 * row in the job table. Well under the point where the listing costs
+	 * real time, and well above the handful that one day of ordinary use
+	 * leaves behind.
+	 */
+	private const BACKLOG_THRESHOLD = 50;
+
+	/**
+	 * A sweep is bounded like everything else that talks to Etherpad, but
+	 * generously: nobody is waiting for it, and the whole point is to get
+	 * through a backlog rather than to stay out of the way. What does not
+	 * fit is picked up by the job it queues behind itself.
+	 */
+	private const MAX_PER_RUN = 250;
+	private const BUDGET_SECONDS = 20.0;
+
+	public function __construct(
+		private EtherpadClient $etherpadClient,
+		private IJobList $jobList,
+		private LoggerInterface $logger,
+	) {
+	}
+
+	/**
+	 * Note a backlog seen in a listing somebody else already paid for.
+	 *
+	 * Deliberately takes the sessions rather than fetching them: every
+	 * caller is a request that has the list in hand, and a collector that
+	 * asked again would add a round trip to the very path it exists to
+	 * keep short.
+	 *
+	 * @param array<string,array{groupID:string,validUntil:int}> $sessions
+	 */
+	public function noteBacklog(string $uid, string $authorId, array $sessions): void {
+		if ($uid === '' || $authorId === '') {
+			return;
+		}
+
+		$now = time();
+		$expired = 0;
+		foreach ($sessions as $info) {
+			if ($info['validUntil'] <= $now) {
+				$expired++;
+			}
+		}
+		if ($expired < self::BACKLOG_THRESHOLD) {
+			return;
+		}
+
+		// Adding the same job twice is a no-op on the second call: the job
+		// list keys on class plus argument, so a user who opens ten pads
+		// before the sweep runs still queues one sweep.
+		$this->jobList->add(CollectExpiredSessionsJob::class, ['uid' => $uid, 'authorId' => $authorId]);
+	}
+
+	/**
+	 * Delete what has expired, up to the run's budget.
+	 *
+	 * @return array{deleted:int,remaining:int} remaining counts what was
+	 *   still expired when the budget ran out, so the caller can decide
+	 *   whether to come back rather than guess.
+	 */
+	public function collect(string $uid, string $authorId): array {
+		$deadline = microtime(true) + self::BUDGET_SECONDS;
+
+		try {
+			$sessions = $this->etherpadClient->listSessionsOfAuthor($authorId);
+		} catch (\Throwable $e) {
+			$this->logger->warning('Could not list the Etherpad sessions to collect.', [
+				'app' => 'etherpad_nextcloud',
+				'uid' => $uid,
+				'authorId' => $authorId,
+				'exception' => $e,
+			]);
+			return ['deleted' => 0, 'remaining' => 0];
+		}
+
+		$now = time();
+		$expired = [];
+		foreach ($sessions as $sessionId => $info) {
+			// Anything still live is left alone. Taking one away is a decision
+			// about permissions, and it is made in the revoker, where the
+			// reason for it is known.
+			if ($info['validUntil'] <= $now) {
+				$expired[] = $sessionId;
+			}
+		}
+
+		// Counted separately: `handled` is what is no longer there, whether
+		// this run removed it or found it already gone, and it is the only
+		// honest basis for what is left. `deleted` is what this run did, which
+		// is what the log line is about.
+		$handled = 0;
+		$deleted = 0;
+		foreach ($expired as $sessionId) {
+			if ($handled >= self::MAX_PER_RUN || microtime(true) >= $deadline) {
+				break;
+			}
+
+			try {
+				$this->etherpadClient->deleteSession($sessionId);
+				$deleted++;
+				$handled++;
+			} catch (\Throwable $e) {
+				if (EtherpadErrorClassifier::isSessionAlreadyGone($e)) {
+					$handled++;
+					continue;
+				}
+				// One line for the run, not one per session: a pad server that
+				// refuses this call refuses the next two hundred too, and the
+				// queued job will come back to it anyway.
+				$this->logger->warning('Could not collect an expired Etherpad session; stopping this run.', [
+					'app' => 'etherpad_nextcloud',
+					'uid' => $uid,
+					'authorId' => $authorId,
+					'exception' => $e,
+				]);
+				break;
+			}
+		}
+		$remaining = count($expired) - $handled;
+
+		if ($deleted > 0 || $remaining > 0) {
+			$this->logger->debug('Collected expired Etherpad sessions.', [
+				'app' => 'etherpad_nextcloud',
+				'uid' => $uid,
+				'deleted' => $deleted,
+				'remaining' => $remaining,
+			]);
+		}
+
+		return ['deleted' => $deleted, 'remaining' => $remaining];
+	}
+}

--- a/lib/Service/ExpiredSessionCollector.php
+++ b/lib/Service/ExpiredSessionCollector.php
@@ -166,10 +166,16 @@ class ExpiredSessionCollector {
 				// one undeletable record shadow everything behind it for
 				// good, since the next run meets it first again.
 				$failures++;
+				// A digest, not the id: a session id is the value of the
+				// `sessionID` cookie, so it is the credential itself — and
+				// this branch is reached for sessions the pad server may
+				// still accept, which is why the grace above exists. The
+				// digest is enough to see the same entry failing run after
+				// run.
 				$this->logger->warning('Could not collect an expired Etherpad session.', [
 					'app' => 'etherpad_nextcloud',
 					'authorId' => $authorId,
-					'sessionId' => $sessionId,
+					'sessionRef' => substr(hash('sha256', $sessionId), 0, 12),
 					'exception' => $e,
 				]);
 				if ($failures >= self::MAX_FAILURES_PER_RUN) {

--- a/lib/Service/ExpiredSessionCollector.php
+++ b/lib/Service/ExpiredSessionCollector.php
@@ -55,20 +55,41 @@ class ExpiredSessionCollector {
 	private const BUDGET_SECONDS = 20.0;
 
 	/**
+	 * How long past expiry a session has to be before this touches it.
+	 *
+	 * `validUntil` is a number Nextcloud computes and Etherpad judges
+	 * against its own clock. If Nextcloud runs ahead, there is a window in
+	 * which this side calls a session expired while the pad server still
+	 * grants it — and deleting one there would close a socket somebody is
+	 * typing into, which is the one thing collecting garbage must not do.
+	 * Nothing here is urgent enough to be worth that, so it waits out any
+	 * plausible drift first.
+	 */
+	private const EXPIRY_GRACE_SECONDS = 300;
+
+	/**
 	 * The collector's own request timeout, in place of the client's.
 	 *
 	 * A deadline checked between calls bounds when the last one starts, not
 	 * when it ends: with the standard timeout a delete begun just under the
 	 * deadline runs well past it, and the budget above would be a number
-	 * that describes nothing. Each call gets whatever is left, floored so a
-	 * request is never issued with an already-dead timeout.
+	 * that describes nothing. Each call gets whatever is left instead, and
+	 * a call that no longer fits is not started at all — its session goes
+	 * to the next run rather than over the budget.
 	 */
 	private const MIN_CALL_TIMEOUT_SECONDS = 2;
 
+	/**
+	 * The budget is a parameter so that the bound can be checked rather
+	 * than believed. It is not a setting: nothing configures it, and the
+	 * default is the only value production ever sees. A limit no test can
+	 * drive is how the last one came to be off by a whole timeout.
+	 */
 	public function __construct(
 		private EtherpadClient $etherpadClient,
 		private IJobList $jobList,
 		private LoggerInterface $logger,
+		private float $budgetSeconds = self::BUDGET_SECONDS,
 	) {
 	}
 
@@ -87,10 +108,10 @@ class ExpiredSessionCollector {
 			return;
 		}
 
-		$now = time();
+		$cutoff = time() - self::EXPIRY_GRACE_SECONDS;
 		$expired = 0;
 		foreach ($sessions as $info) {
-			if ($info['validUntil'] <= $now) {
+			if ($info['validUntil'] <= $cutoff) {
 				$expired++;
 			}
 		}
@@ -111,26 +132,41 @@ class ExpiredSessionCollector {
 		// can queue two sweeps. That is waste, not damage: a sweep deletes
 		// what has already expired, and a session the other run removed
 		// first comes back as "already gone" and counts as handled.
-		if ($this->jobList->has(CollectExpiredSessionsJob::class, $argument)) {
-			return;
+		// Both of these are Nextcloud database calls, and they run inside an
+		// open somebody is waiting for. Housekeeping may not be the reason a
+		// pad fails to open: a deadlock or a lost connection here would turn
+		// a working open into a 500, and the worst case of swallowing it is
+		// that the sweep is queued by the next open instead.
+		try {
+			if ($this->jobList->has(CollectExpiredSessionsJob::class, $argument)) {
+				return;
+			}
+			$this->jobList->add(CollectExpiredSessionsJob::class, $argument);
+		} catch (\Throwable $e) {
+			$this->logger->warning('Could not queue the Etherpad session sweep.', [
+				'app' => 'etherpad_nextcloud',
+				'uid' => $uid,
+				'exception' => $e,
+			]);
 		}
-		$this->jobList->add(CollectExpiredSessionsJob::class, $argument);
 	}
 
 	/**
 	 * Delete what has expired, up to the run's budget.
 	 *
 	 * Three outcomes, not two. `remaining` says the sweep worked and did
-	 * not finish; `retry` says it never got to start, because the listing
-	 * failed. They must not be one number: the job removes its own row
-	 * before running, so a run that reported nothing left would leave a
-	 * pad server hiccup to be discovered by whichever open happens to
-	 * notice the backlog again.
+	 * not finish — the ceiling, the budget, and nothing more to say than
+	 * "come back". `retry` says the pad server refused, either for the
+	 * listing or for a delete, and the next run should wait longer. They
+	 * must not be one number in either direction: the job removes its own
+	 * row before running, so a swallowed failure leaves the pile for
+	 * whichever open notices it again — and a failure reported as progress
+	 * has the job coming back every minute for good.
 	 *
 	 * @return array{deleted:int,remaining:int,retry:bool}
 	 */
 	public function collect(string $uid, string $authorId): array {
-		$deadline = microtime(true) + self::BUDGET_SECONDS;
+		$deadline = microtime(true) + $this->budgetSeconds;
 
 		try {
 			$sessions = $this->etherpadClient->listSessionsOfAuthor($authorId);
@@ -144,13 +180,15 @@ class ExpiredSessionCollector {
 			return ['deleted' => 0, 'remaining' => 0, 'retry' => true];
 		}
 
-		$now = time();
+		// The same grace as the counting above, for the same reason: a
+		// session is only collected once both clocks must agree it is dead.
+		$cutoff = time() - self::EXPIRY_GRACE_SECONDS;
 		$expired = [];
 		foreach ($sessions as $sessionId => $info) {
 			// Anything still live is left alone. Taking one away is a decision
 			// about permissions, and it is made in the revoker, where the
 			// reason for it is known.
-			if ($info['validUntil'] <= $now) {
+			if ($info['validUntil'] <= $cutoff) {
 				$expired[] = $sessionId;
 			}
 		}
@@ -161,13 +199,20 @@ class ExpiredSessionCollector {
 		// is what the log line is about.
 		$handled = 0;
 		$deleted = 0;
+		$failed = false;
 		foreach ($expired as $sessionId) {
-			if ($handled >= self::MAX_PER_RUN || microtime(true) >= $deadline) {
+			// A call that cannot finish inside the budget must not start.
+			// Checking only that the deadline has not passed would let the
+			// last one begin with a fraction of a second left and still run
+			// for its whole timeout, which is the budget being wrong by a
+			// timeout again, just a smaller one.
+			$left = $deadline - microtime(true);
+			if ($handled >= self::MAX_PER_RUN || $left < self::MIN_CALL_TIMEOUT_SECONDS) {
 				break;
 			}
 
 			try {
-				$this->etherpadClient->deleteSession($sessionId, $this->timeoutLeft($deadline));
+				$this->etherpadClient->deleteSession($sessionId, (int)floor($left));
 				$deleted++;
 				$handled++;
 			} catch (\Throwable $e) {
@@ -175,6 +220,7 @@ class ExpiredSessionCollector {
 					$handled++;
 					continue;
 				}
+				$failed = true;
 				// One line for the run, not one per session: a pad server that
 				// refuses this call refuses the next two hundred too, and the
 				// queued job will come back to it anyway.
@@ -198,11 +244,11 @@ class ExpiredSessionCollector {
 			]);
 		}
 
-		return ['deleted' => $deleted, 'remaining' => $remaining, 'retry' => false];
+		// A run that ended on a failure asks for the same backoff a failed
+		// listing gets. Without it the job reads "some progress, more to do"
+		// and comes back every minute for good — one call and one warning a
+		// minute against a pad server that has already said no.
+		return ['deleted' => $deleted, 'remaining' => $remaining, 'retry' => $failed];
 	}
 
-	/** Whatever is left of the run's budget, never below the floor. */
-	private function timeoutLeft(float $deadline): int {
-		return max(self::MIN_CALL_TIMEOUT_SECONDS, (int)ceil($deadline - microtime(true)));
-	}
 }

--- a/lib/Service/ExpiredSessionCollector.php
+++ b/lib/Service/ExpiredSessionCollector.php
@@ -17,82 +17,33 @@ use Psr\Log\LoggerInterface;
 /**
  * Collects the Etherpad sessions that have already expired.
  *
- * They grant nothing, so this is not about access. It is about the cost of
- * asking: Etherpad never removes an expired session, and
- * `listSessionsOfAuthor` walks the author's whole index one awaited lookup
- * at a time, expired entries included. Opening a protected pad asks that
- * question — it is how the app decides which of the ids in the cookie are
- * still worth carrying — so the price of an open grows with every pad the
- * user has ever opened rather than with the sessions that still grant
- * anything.
- *
- * Neither the asking nor the deleting belongs in a request. Each delete is
- * its own call, and a backlog of thousands in front of a pad appearing is
- * worse than the listing it would save; and the listing itself is what
- * gets slow. So an open leaves nothing behind but the author's id, and the
- * job does both — it finds out whether there is anything to collect, and
- * collects it.
+ * Etherpad never removes one, and `listSessionsOfAuthor` walks the whole
+ * author index one awaited lookup at a time — so the cost of the listing,
+ * which every protected open makes, grows with past opens rather than with
+ * live access. Neither the listing nor the deleting happens in a request:
+ * an open leaves the author's id, and the job does both.
  *
  * @psalm-api
  */
 class ExpiredSessionCollector {
 
-	/**
-	 * A sweep is bounded like everything else that talks to Etherpad, but
-	 * generously: nobody is waiting for it, and the whole point is to get
-	 * through a backlog rather than to stay out of the way. What does not
-	 * fit is picked up by the job it queues behind itself.
-	 */
 	private const MAX_PER_RUN = 250;
-
-	/**
-	 * How many refusals a run puts up with before it stops.
-	 *
-	 * Not one. A session Etherpad will never let go of — a record whose
-	 * group is gone in a way that makes the delete answer with something
-	 * other than "already gone" — would otherwise stand in front of every
-	 * entry behind it for good: the run breaks, the next run re-lists and
-	 * finds the same entry first, and the backlog never moves. Skipping
-	 * past it costs one wasted call per run and reaches the other 3999.
-	 *
-	 * Bounded all the same, because the other reading of a refusal is that
-	 * the server is down, and then there is nothing to be gained by asking
-	 * two hundred more times.
-	 */
-	private const MAX_FAILURES_PER_RUN = 5;
 	private const BUDGET_SECONDS = 20.0;
 
+	/** Refusals a run puts up with before reading them as an outage. */
+	private const MAX_FAILURES_PER_RUN = 5;
+
 	/**
-	 * How long past expiry a session has to be before this touches it.
-	 *
-	 * `validUntil` is a number Nextcloud computes and Etherpad judges
-	 * against its own clock. If Nextcloud runs ahead, there is a window in
-	 * which this side calls a session expired while the pad server still
-	 * grants it — and deleting one there would close a socket somebody is
-	 * typing into, which is the one thing collecting garbage must not do.
-	 * Nothing here is urgent enough to be worth that, so it waits out any
-	 * plausible drift first.
+	 * Nextcloud computes `validUntil`; Etherpad judges it against its own
+	 * clock. In the window where the two disagree, deleting would close a
+	 * socket somebody is typing into.
 	 */
 	private const EXPIRY_GRACE_SECONDS = 300;
 
-	/**
-	 * The collector's own request timeout, in place of the client's.
-	 *
-	 * A deadline checked between calls bounds when the last one starts, not
-	 * when it ends: with the standard timeout a delete begun just under the
-	 * deadline runs well past it, and the budget above would be a number
-	 * that describes nothing. Each call gets whatever is left instead, and
-	 * a call that no longer fits is not started at all — its session goes
-	 * to the next run rather than over the budget.
-	 */
+	/** Below this, a call cannot finish inside the budget and is not made. */
 	private const MIN_CALL_TIMEOUT_SECONDS = 2;
 
-	/**
-	 * The budget is a parameter so that the bound can be checked rather
-	 * than believed. It is not a setting: nothing configures it, and the
-	 * default is the only value production ever sees. A limit no test can
-	 * drive is how the last one came to be off by a whole timeout.
-	 */
+	/** The budget is a parameter so a test can reach it, not a setting. */
 	public function __construct(
 		private EtherpadClient $etherpadClient,
 		private IJobList $jobList,
@@ -102,38 +53,19 @@ class ExpiredSessionCollector {
 	}
 
 	/**
-	 * Remember that this author might have something to collect.
-	 *
-	 * Deliberately knows nothing about whether there is a backlog. Finding
-	 * that out means the listing, and the listing is the expensive call
-	 * this class exists to keep out of a request — so it happens in the
-	 * job, which is also where the deleting happens and where nobody is
-	 * waiting.
-	 *
-	 * That is the difference from asking a request to spot the backlog
-	 * first: a listing is only made when a browser carries session ids, so
-	 * the very first open after arriving never made one, and neither did a
-	 * public link — every visitor of which writes to one shared author's
-	 * index. Both were invisible to a sweep that had to be told what to
-	 * look at. An author id is known on every open.
+	 * Remember that this author might have something to collect, without
+	 * finding out whether it does — that is the listing, and the listing
+	 * belongs in the job.
 	 */
 	public function noteAuthor(string $authorId): void {
 		if ($authorId === '') {
 			return;
 		}
 
-		// The author id and nothing else. For a public link the uid is
-		// `public-share:<token>` — the bearer credential from the share
-		// URL — and a job argument is persisted in the jobs table, printed
-		// by occ, and carried into database dumps and support bundles. The
-		// job has no use for it, and an author id maps back to a Nextcloud
-		// user through their stored setting when a real one is behind it.
+		// No uid: for a public link it is `public-share:<token>`, and a job
+		// argument is persisted and printed by occ.
 		$argument = ['authorId' => $authorId];
-		// Both of these are Nextcloud database calls, and they run inside an
-		// open somebody is waiting for. Housekeeping may not be the reason a
-		// pad fails to open: a deadlock or a lost connection here would turn
-		// a working open into a 500, and the worst case of swallowing it is
-		// that the sweep is queued by the next open instead.
+		// Housekeeping may not be the reason a pad fails to open.
 		try {
 			if ($this->sweepIsQueued($argument)) {
 				return;
@@ -151,19 +83,12 @@ class ExpiredSessionCollector {
 	/**
 	 * Delete what has expired, up to the run's budget.
 	 *
-	 * Three outcomes, not two. `remaining` says the sweep worked and did
-	 * not finish — the ceiling, the budget, and nothing more to say than
-	 * "come back". `retry` says the pad server refused, either for the
-	 * listing or for a delete, and the next run should wait longer. They
-	 * must not be one number in either direction: the job removes its own
-	 * row before running, so a swallowed failure leaves the pile for
-	 * whichever open notices it again — and a failure reported as progress
-	 * has the job coming back every minute for good.
-	 *
+	 * `remaining` means the run worked and did not finish; `retry` means
+	 * the server refused. They must stay separate: the job removes its own
+	 * row before running, so a swallowed failure loses the backlog, and a
+	 * failure read as progress has the job returning every minute for good.
 	 * `nextDueAt` is when the earliest session still standing becomes
-	 * collectable, so a run that found nothing to do can say when it is
-	 * worth coming back instead of leaving the next open to ask again. Null
-	 * when the author holds nothing at all.
+	 * collectable, or null when the author holds nothing.
 	 *
 	 * @return array{deleted:int,remaining:int,retry:bool,nextDueAt:?int}
 	 */
@@ -171,10 +96,6 @@ class ExpiredSessionCollector {
 		$deadline = microtime(true) + $this->budgetSeconds;
 
 		try {
-			// The listing is inside the budget, and until now it was the one
-			// call in the run that could ignore it. It is also the expensive
-			// one — the reason this class exists — so a slow index could eat
-			// the whole run and leave no time to delete anything from it.
 			$sessions = $this->etherpadClient->listSessionsOfAuthor(
 				$authorId,
 				$this->callTimeout($deadline - microtime(true)),
@@ -190,14 +111,10 @@ class ExpiredSessionCollector {
 		}
 
 		if (($unreadable ?? 0) > 0) {
-			// Ids the author index lists that Etherpad can no longer
-			// describe. `deleteSession` will not take them either — it
-			// answers that they do not exist — so this run cannot shrink
-			// that part of the index, and neither can any later one. It is
-			// worth saying out loud rather than reporting a clean sweep:
-			// the listing stays as slow as the number of keys, and on an
-			// Etherpad that leaves them behind, collecting is not the
-			// remedy it is here.
+			// Keys the index lists but Etherpad cannot describe.
+			// `deleteSession` will not take them either, so no run can
+			// shrink that part of the index — worth saying rather than
+			// reporting a clean sweep.
 			$this->logger->warning('Etherpad lists sessions it cannot describe; those entries cannot be collected.', [
 				'app' => 'etherpad_nextcloud',
 				'authorId' => $authorId,
@@ -205,43 +122,31 @@ class ExpiredSessionCollector {
 			]);
 		}
 
-		// The same grace as the counting above, for the same reason: a
-		// session is only collected once both clocks must agree it is dead.
 		$cutoff = time() - self::EXPIRY_GRACE_SECONDS;
 		$expired = [];
 		$nextDueAt = null;
 		foreach ($sessions as $sessionId => $info) {
-			// Anything still live is left alone. This job reclaims storage;
-			// deciding that somebody's access should end is a different
-			// question with different reasons behind it, and not one a
-			// housekeeping sweep gets to answer.
+			// Live sessions are left alone: ending someone's access is not a
+			// housekeeping decision.
 			if ($info['validUntil'] <= $cutoff) {
 				$expired[] = $sessionId;
 				continue;
 			}
 
-			// Not collectable yet. Remembering when the earliest one becomes
-			// so is what keeps a sweep that found nothing from being asked
-			// again by the very next open: a busy public link would
-			// otherwise walk one shared author's whole index behind every
-			// visitor, for the length of a session lifetime.
+			// When the earliest becomes collectable — without it, a sweep
+			// that found nothing is queued again by the very next open.
 			$dueAt = (int)$info['validUntil'] + self::EXPIRY_GRACE_SECONDS;
 			$nextDueAt = $nextDueAt === null ? $dueAt : min($nextDueAt, $dueAt);
 		}
 
-		// Counted separately: `handled` is what is no longer there, whether
-		// this run removed it or found it already gone, and it is the only
-		// honest basis for what is left. `deleted` is what this run did, which
-		// is what the log line is about.
+		// `handled` counts what is no longer there, however it went, and is
+		// the only honest basis for what is left over.
 		$handled = 0;
 		$deleted = 0;
 		$failures = 0;
 		foreach ($expired as $sessionId) {
-			// A call that cannot finish inside the budget must not start.
-			// Checking only that the deadline has not passed would let the
-			// last one begin with a fraction of a second left and still run
-			// for its whole timeout, which is the budget being wrong by a
-			// timeout again, just a smaller one.
+			// A deadline alone bounds when the last call starts, not when it
+			// ends. One that no longer fits is not made.
 			$left = $deadline - microtime(true);
 			if ($handled >= self::MAX_PER_RUN || $left < self::MIN_CALL_TIMEOUT_SECONDS) {
 				break;
@@ -257,13 +162,10 @@ class ExpiredSessionCollector {
 					continue;
 				}
 
+				// Carrying on past a refusal: stopping at the first would let
+				// one undeletable record shadow everything behind it for
+				// good, since the next run meets it first again.
 				$failures++;
-				// One line per refusal, and a handful of refusals per run.
-				// Stopping at the first would let a single record Etherpad
-				// will never delete stand in front of everything behind it:
-				// the next run re-lists, meets the same entry first, and the
-				// backlog never moves. Going past it wastes one call a run
-				// and reaches the rest.
 				$this->logger->warning('Could not collect an expired Etherpad session.', [
 					'app' => 'etherpad_nextcloud',
 					'authorId' => $authorId,
@@ -271,8 +173,6 @@ class ExpiredSessionCollector {
 					'exception' => $e,
 				]);
 				if ($failures >= self::MAX_FAILURES_PER_RUN) {
-					// The other reading of a refusal: the server is down, and
-					// two hundred more calls will not change that.
 					break;
 				}
 			}
@@ -287,25 +187,13 @@ class ExpiredSessionCollector {
 			]);
 		}
 
-		// A run that ended on a failure asks for the same backoff a failed
-		// listing gets. Without it the job reads "some progress, more to do"
-		// and comes back every minute for good — one call and one warning a
-		// minute against a pad server that has already said no.
 		return ['deleted' => $deleted, 'remaining' => $remaining, 'retry' => $failures > 0, 'nextDueAt' => $nextDueAt];
 	}
 
 	/**
-	 * Whether any sweep for this author is already waiting.
-	 *
-	 * Every shape of it, not just the plain one. A retry carries its
-	 * attempt in the argument so that an open cannot reset a backoff, and
-	 * the job list matches arguments exactly — so asking only about the
-	 * plain form would miss a retry that is deliberately waiting and queue
-	 * a second, immediately runnable row beside it. That is the loop the
-	 * backoff exists to prevent, arrived at from the other side.
-	 *
-	 * A handful of lookups, in a path that only runs once a backlog has
-	 * built up.
+	 * Whether any sweep for this author is waiting — every shape of it. The
+	 * job list matches arguments exactly, so asking only about the plain
+	 * one would miss a retry and queue a runnable row beside it.
 	 *
 	 * @param array{authorId:string} $argument
 	 */
@@ -323,14 +211,8 @@ class ExpiredSessionCollector {
 	}
 
 	/**
-	 * What one call may take: the rest of the run's budget, but never more
-	 * patience than any other request this app makes.
-	 *
-	 * Without the upper half a run whose listing came back quickly would
-	 * hand its first delete nearly the whole budget — a housekeeping call
-	 * given more time than the ones a user is waiting on, and a pad server
-	 * that stalls after accepting the connection would spend the whole run
-	 * on one session.
+	 * The rest of the budget, capped so housekeeping is never more patient
+	 * than the calls a user waits on.
 	 */
 	private function callTimeout(float $left): int {
 		return (int)min(floor($left), EtherpadClient::REQUEST_TIMEOUT_SECONDS);

--- a/lib/Service/ExpiredSessionCollector.php
+++ b/lib/Service/ExpiredSessionCollector.php
@@ -117,12 +117,18 @@ class ExpiredSessionCollector {
 	 * index. Both were invisible to a sweep that had to be told what to
 	 * look at. An author id is known on every open.
 	 */
-	public function noteAuthor(string $uid, string $authorId): void {
+	public function noteAuthor(string $authorId): void {
 		if ($authorId === '') {
 			return;
 		}
 
-		$argument = ['uid' => $uid, 'authorId' => $authorId];
+		// The author id and nothing else. For a public link the uid is
+		// `public-share:<token>` — the bearer credential from the share
+		// URL — and a job argument is persisted in the jobs table, printed
+		// by occ, and carried into database dumps and support bundles. The
+		// job has no use for it, and an author id maps back to a Nextcloud
+		// user through their stored setting when a real one is behind it.
+		$argument = ['authorId' => $authorId];
 		// Both of these are Nextcloud database calls, and they run inside an
 		// open somebody is waiting for. Housekeeping may not be the reason a
 		// pad fails to open: a deadlock or a lost connection here would turn
@@ -136,7 +142,7 @@ class ExpiredSessionCollector {
 		} catch (\Throwable $e) {
 			$this->logger->warning('Could not queue the Etherpad session sweep.', [
 				'app' => 'etherpad_nextcloud',
-				'uid' => $uid,
+				'authorId' => $authorId,
 				'exception' => $e,
 			]);
 		}
@@ -154,9 +160,14 @@ class ExpiredSessionCollector {
 	 * whichever open notices it again — and a failure reported as progress
 	 * has the job coming back every minute for good.
 	 *
-	 * @return array{deleted:int,remaining:int,retry:bool}
+	 * `nextDueAt` is when the earliest session still standing becomes
+	 * collectable, so a run that found nothing to do can say when it is
+	 * worth coming back instead of leaving the next open to ask again. Null
+	 * when the author holds nothing at all.
+	 *
+	 * @return array{deleted:int,remaining:int,retry:bool,nextDueAt:?int}
 	 */
-	public function collect(string $uid, string $authorId): array {
+	public function collect(string $authorId): array {
 		$deadline = microtime(true) + $this->budgetSeconds;
 
 		try {
@@ -171,17 +182,17 @@ class ExpiredSessionCollector {
 		} catch (\Throwable $e) {
 			$this->logger->warning('Could not list the Etherpad sessions to collect.', [
 				'app' => 'etherpad_nextcloud',
-				'uid' => $uid,
 				'authorId' => $authorId,
 				'exception' => $e,
 			]);
-			return ['deleted' => 0, 'remaining' => 0, 'retry' => true];
+			return ['deleted' => 0, 'remaining' => 0, 'retry' => true, 'nextDueAt' => null];
 		}
 
 		// The same grace as the counting above, for the same reason: a
 		// session is only collected once both clocks must agree it is dead.
 		$cutoff = time() - self::EXPIRY_GRACE_SECONDS;
 		$expired = [];
+		$nextDueAt = null;
 		foreach ($sessions as $sessionId => $info) {
 			// Anything still live is left alone. This job reclaims storage;
 			// deciding that somebody's access should end is a different
@@ -189,7 +200,16 @@ class ExpiredSessionCollector {
 			// housekeeping sweep gets to answer.
 			if ($info['validUntil'] <= $cutoff) {
 				$expired[] = $sessionId;
+				continue;
 			}
+
+			// Not collectable yet. Remembering when the earliest one becomes
+			// so is what keeps a sweep that found nothing from being asked
+			// again by the very next open: a busy public link would
+			// otherwise walk one shared author's whole index behind every
+			// visitor, for the length of a session lifetime.
+			$dueAt = (int)$info['validUntil'] + self::EXPIRY_GRACE_SECONDS;
+			$nextDueAt = $nextDueAt === null ? $dueAt : min($nextDueAt, $dueAt);
 		}
 
 		// Counted separately: `handled` is what is no longer there, whether
@@ -229,7 +249,6 @@ class ExpiredSessionCollector {
 				// and reaches the rest.
 				$this->logger->warning('Could not collect an expired Etherpad session.', [
 					'app' => 'etherpad_nextcloud',
-					'uid' => $uid,
 					'authorId' => $authorId,
 					'sessionId' => $sessionId,
 					'exception' => $e,
@@ -246,7 +265,6 @@ class ExpiredSessionCollector {
 		if ($deleted > 0 || $remaining > 0) {
 			$this->logger->debug('Collected expired Etherpad sessions.', [
 				'app' => 'etherpad_nextcloud',
-				'uid' => $uid,
 				'deleted' => $deleted,
 				'remaining' => $remaining,
 			]);
@@ -256,7 +274,7 @@ class ExpiredSessionCollector {
 		// listing gets. Without it the job reads "some progress, more to do"
 		// and comes back every minute for good — one call and one warning a
 		// minute against a pad server that has already said no.
-		return ['deleted' => $deleted, 'remaining' => $remaining, 'retry' => $failures > 0];
+		return ['deleted' => $deleted, 'remaining' => $remaining, 'retry' => $failures > 0, 'nextDueAt' => $nextDueAt];
 	}
 
 	/**
@@ -272,7 +290,7 @@ class ExpiredSessionCollector {
 	 * A handful of lookups, in a path that only runs once a backlog has
 	 * built up.
 	 *
-	 * @param array{uid:string,authorId:string} $argument
+	 * @param array{authorId:string} $argument
 	 */
 	private function sweepIsQueued(array $argument): bool {
 		if ($this->jobList->has(CollectExpiredSessionsJob::class, $argument)) {

--- a/lib/Service/PadSessionService.php
+++ b/lib/Service/PadSessionService.php
@@ -169,13 +169,6 @@ class PadSessionService {
 
 		try {
 			$sessions = $this->etherpadClient->listSessionsOfAuthor($authorId);
-			// The open path already pays for this listing, and it is the
-			// path that suffers first when the index gets long: the cost is
-			// one awaited lookup per entry inside Etherpad, expired ones
-			// included. Counting them here is free; deleting them is not,
-			// which is why that goes to a job.
-			$this->collector->noteBacklog($uid, $authorId, $sessions);
-			return $sessions;
 		} catch (EtherpadClientException $e) {
 			// Not fatal: the open goes ahead. But nothing can be attributed
 			// without the listing, so nothing is carried and a second pad
@@ -187,6 +180,15 @@ class PadSessionService {
 			]);
 			return [];
 		}
+
+		// Outside the catch above on purpose. This is housekeeping, and the
+		// catch is about a listing that failed — a throw from here would be
+		// logged as the pad server being unreachable and cost the user the
+		// sessions this listing was fetched to keep, with a diagnostic
+		// pointing at Etherpad for something Etherpad did not do.
+		$this->collector->noteBacklog($uid, $authorId, $sessions);
+
+		return $sessions;
 	}
 
 	/**

--- a/lib/Service/PadSessionService.php
+++ b/lib/Service/PadSessionService.php
@@ -120,11 +120,9 @@ class PadSessionService {
 	 * @return array{url:string,cookie:array{name:string,value:string,expires:int,path:string,domain:string,secure:bool,http_only:bool,same_site:string}}
 	 */
 	private function openContextFor(string $uid, string $authorId, string $groupId, string $padId, int $validUntil): array {
-		// Before anything else, and without asking whether there is anything
-		// to collect: the answer to that is the listing below, which only
-		// happens when the browser carries ids. A first open makes none, and
-		// a public link never does — so a sweep that waited to be told about
-		// a backlog would never hear about either.
+		// Before the listing below, which only happens when the browser
+		// carries ids — a first open makes none, and a public link never
+		// does.
 		$this->collector->noteAuthor($authorId);
 
 		$carriedIds = $this->sessionIdsFromCookie();

--- a/lib/Service/PadSessionService.php
+++ b/lib/Service/PadSessionService.php
@@ -61,6 +61,7 @@ class PadSessionService {
 		private CookieDomainPolicy $cookieDomainPolicy,
 		private EtherpadReleasePolicy $releasePolicy,
 		private IRequest $request,
+		private ExpiredSessionCollector $collector,
 		private LoggerInterface $logger,
 	) {
 	}
@@ -167,7 +168,14 @@ class PadSessionService {
 		}
 
 		try {
-			return $this->etherpadClient->listSessionsOfAuthor($authorId);
+			$sessions = $this->etherpadClient->listSessionsOfAuthor($authorId);
+			// The open path already pays for this listing, and it is the
+			// path that suffers first when the index gets long: the cost is
+			// one awaited lookup per entry inside Etherpad, expired ones
+			// included. Counting them here is free; deleting them is not,
+			// which is why that goes to a job.
+			$this->collector->noteBacklog($uid, $authorId, $sessions);
+			return $sessions;
 		} catch (EtherpadClientException $e) {
 			// Not fatal: the open goes ahead. But nothing can be attributed
 			// without the listing, so nothing is carried and a second pad

--- a/lib/Service/PadSessionService.php
+++ b/lib/Service/PadSessionService.php
@@ -125,7 +125,7 @@ class PadSessionService {
 		// happens when the browser carries ids. A first open makes none, and
 		// a public link never does — so a sweep that waited to be told about
 		// a backlog would never hear about either.
-		$this->collector->noteAuthor($uid, $authorId);
+		$this->collector->noteAuthor($authorId);
 
 		$carriedIds = $this->sessionIdsFromCookie();
 		$sessions = $this->sessionsToAttributeWith($uid, $authorId, $carriedIds);

--- a/lib/Service/PadSessionService.php
+++ b/lib/Service/PadSessionService.php
@@ -120,6 +120,13 @@ class PadSessionService {
 	 * @return array{url:string,cookie:array{name:string,value:string,expires:int,path:string,domain:string,secure:bool,http_only:bool,same_site:string}}
 	 */
 	private function openContextFor(string $uid, string $authorId, string $groupId, string $padId, int $validUntil): array {
+		// Before anything else, and without asking whether there is anything
+		// to collect: the answer to that is the listing below, which only
+		// happens when the browser carries ids. A first open makes none, and
+		// a public link never does — so a sweep that waited to be told about
+		// a backlog would never hear about either.
+		$this->collector->noteAuthor($uid, $authorId);
+
 		$carriedIds = $this->sessionIdsFromCookie();
 		$sessions = $this->sessionsToAttributeWith($uid, $authorId, $carriedIds);
 
@@ -180,13 +187,6 @@ class PadSessionService {
 			]);
 			return [];
 		}
-
-		// Outside the catch above on purpose. This is housekeeping, and the
-		// catch is about a listing that failed — a throw from here would be
-		// logged as the pad server being unreachable and cost the user the
-		// sessions this listing was fetched to keep, with a diagnostic
-		// pointing at Etherpad for something Etherpad did not do.
-		$this->collector->noteBacklog($uid, $authorId, $sessions);
 
 		return $sessions;
 	}

--- a/lib/Util/EtherpadErrorClassifier.php
+++ b/lib/Util/EtherpadErrorClassifier.php
@@ -57,9 +57,11 @@ final class EtherpadErrorClassifier {
 		$current = $error;
 		while ($current !== null) {
 			$message = strtolower(trim($current->getMessage()));
-			foreach ($needles as $needle) {
-				if ($message !== '' && str_contains($message, $needle)) {
-					return true;
+			if ($message !== '') {
+				foreach ($needles as $needle) {
+					if (str_contains($message, $needle)) {
+						return true;
+					}
 				}
 			}
 			$current = $current->getPrevious();
@@ -79,15 +81,6 @@ final class EtherpadErrorClassifier {
 	 * `padID does already exist`.
 	 */
 	public static function isPadAlreadyPresent(\Throwable $error): bool {
-		$current = $error;
-		while ($current !== null) {
-			$message = strtolower(trim($current->getMessage()));
-			if ($message !== '' && str_contains($message, 'does already exist')) {
-				return true;
-			}
-			$current = $current->getPrevious();
-		}
-
-		return false;
+		return self::mentions($error, ['does already exist']);
 	}
 }

--- a/lib/Util/EtherpadErrorClassifier.php
+++ b/lib/Util/EtherpadErrorClassifier.php
@@ -22,18 +22,45 @@ final class EtherpadErrorClassifier {
 	 * every retry for good.
 	 */
 	public static function isPadAlreadyDeleted(\Throwable $error): bool {
+		return self::mentions($error, [
+			'padid does not exist',
+			'pad does not exist',
+			'unknown pad',
+			'groupid does not exist',
+		]);
+	}
+
+	/**
+	 * The same idea for a session, and deliberately a different list.
+	 *
+	 * One shared set of strings would let an answer about a session be read
+	 * as an answer about a pad: a pad delete failing while Etherpad tears
+	 * down that group's sessions could report `sessionID does not exist`
+	 * and be taken for "the pad is gone", which drops a binding row for a
+	 * pad that is still there. Measured: a second delete of the same
+	 * session answers `sessionID does not exist`.
+	 */
+	public static function isSessionAlreadyGone(\Throwable $error): bool {
+		return self::mentions($error, ['sessionid does not exist']);
+	}
+
+	/**
+	 * Walk the cause chain for any of these, case-insensitively.
+	 *
+	 * The chain matters: the client wraps transport errors, so the sentence
+	 * Etherpad actually said is often not the one on the outermost
+	 * exception.
+	 *
+	 * @param list<string> $needles lower-case
+	 */
+	private static function mentions(\Throwable $error, array $needles): bool {
 		$current = $error;
 		while ($current !== null) {
 			$message = strtolower(trim($current->getMessage()));
-			if (
-				$message !== '' && (
-					str_contains($message, 'padid does not exist')
-					|| str_contains($message, 'pad does not exist')
-					|| str_contains($message, 'unknown pad')
-					|| str_contains($message, 'groupid does not exist')
-				)
-			) {
-				return true;
+			foreach ($needles as $needle) {
+				if ($message !== '' && str_contains($message, $needle)) {
+					return true;
+				}
 			}
 			$current = $current->getPrevious();
 		}

--- a/tests/e2e/specs/etherpad-session-index.spec.ts
+++ b/tests/e2e/specs/etherpad-session-index.spec.ts
@@ -1,0 +1,81 @@
+/**
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * Copyright (c) 2026 Jacob Bühler
+ */
+import { test, expect, request as playwrightRequest, type APIRequestContext } from '@playwright/test'
+import { E2E } from '../fixtures/env'
+
+/**
+ * The assumption the expired-session collector rests on: deleting a
+ * session removes its id from the author's index, so the listing that
+ * walks that index gets shorter.
+ *
+ * It is not free to assume. Etherpad's `deleteSession` updates the index
+ * with `setSub(..., undefined)`, and there are reports of the key
+ * surviving on some versions and storage backends — leaving an id the
+ * listing still walks and `deleteSession` will no longer take, because it
+ * answers that the session does not exist. A collector running against
+ * such a server would report clean sweeps forever while the cost it
+ * exists to remove stayed exactly where it was.
+ *
+ * So this asks the pad server directly, and counts the **raw** keys of the
+ * API response rather than what the app's client hands back: the client
+ * drops entries it cannot read, which is precisely what a surviving key
+ * looks like.
+ */
+test.describe('Etherpad session index', () => {
+	const api = async (
+		ctx: APIRequestContext,
+		endpoint: string,
+		form: Record<string, string>,
+	): Promise<Record<string, unknown>> => {
+		const res = await ctx.post(`${E2E.etherpadApi!.url}/api/1.2.15/${endpoint}`, {
+			form: { apikey: E2E.etherpadApi!.key, ...form },
+		})
+		expect(res.status(), endpoint).toBe(200)
+		const payload = await res.json() as { code: number, message: string, data: Record<string, unknown> }
+		expect(payload.code, `${endpoint}: ${payload.message}`).toBe(0)
+		return payload.data
+	}
+
+	test('deleting a session takes its id out of the author index', async () => {
+		test.skip(E2E.etherpadApi === null, 'E2E_ETHERPAD_URL / E2E_ETHERPAD_API_KEY not configured.')
+
+		const ctx = await playwrightRequest.newContext({ storageState: { cookies: [], origins: [] } })
+		let groupId = ''
+		try {
+			groupId = String((await api(ctx, 'createGroup', {})).groupID)
+			const authorId = String((await api(ctx, 'createAuthorIfNotExistsFor', {
+				authorMapper: `nc:index-probe-${Date.now()}`,
+			})).authorID)
+
+			const validUntil = String(Math.floor(Date.now() / 1000) + 3600)
+			const created: string[] = []
+			for (let i = 0; i < 4; i++) {
+				created.push(String((await api(ctx, 'createSession', { groupID: groupId, authorID: authorId, validUntil })).sessionID))
+			}
+
+			// Raw keys, including any the server can no longer describe.
+			const indexKeys = async (): Promise<string[]> =>
+				Object.keys(await api(ctx, 'listSessionsOfAuthor', { authorID: authorId }) ?? {})
+
+			expect(await indexKeys()).toHaveLength(4)
+
+			await api(ctx, 'deleteSession', { sessionID: created[0] })
+
+			const after = await indexKeys()
+			expect(
+				after,
+				'the deleted id is still in the author index — collecting cannot shrink this server\'s listing',
+			).toHaveLength(3)
+			expect(after).not.toContain(created[0])
+		} finally {
+			if (groupId !== '') {
+				await ctx.post(`${E2E.etherpadApi!.url}/api/1.2.15/deleteGroup`, {
+					form: { apikey: E2E.etherpadApi!.key, groupID: groupId },
+				}).catch(() => {})
+			}
+			await ctx.dispose()
+		}
+	})
+})

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 $stubFiles = [
 	__DIR__ . '/stubs/OCA/EtherpadNextcloud/AppInfo/Application.php',
 	__DIR__ . '/stubs/OCP/AppFramework/Controller.php',
+	__DIR__ . '/stubs/OCP/BackgroundJob/IJob.php',
+	__DIR__ . '/stubs/OCP/BackgroundJob/IJobList.php',
+	__DIR__ . '/stubs/OCP/BackgroundJob/QueuedJob.php',
 	__DIR__ . '/stubs/OCP/ISession.php',
 	__DIR__ . '/stubs/OCP/Util.php',
 	__DIR__ . '/stubs/OCP/Files/Template/ICustomTemplateProvider.php',

--- a/tests/phpunit/stubs/OCP/BackgroundJob/IJob.php
+++ b/tests/phpunit/stubs/OCP/BackgroundJob/IJob.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCP\BackgroundJob;
+
+if (!interface_exists(IJob::class)) {
+	interface IJob {
+	}
+}

--- a/tests/phpunit/stubs/OCP/BackgroundJob/IJobList.php
+++ b/tests/phpunit/stubs/OCP/BackgroundJob/IJobList.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCP\BackgroundJob;
+
+if (!interface_exists(IJobList::class)) {
+	interface IJobList {
+		/**
+		 * @param mixed $argument
+		 */
+		public function add(IJob|string $job, mixed $argument = null): void;
+
+		/**
+		 * @param mixed $argument
+		 */
+		public function scheduleAfter(string $job, int $runAfter, mixed $argument = null): void;
+
+		/**
+		 * @param mixed $argument
+		 */
+		public function has(IJob|string $job, mixed $argument): bool;
+
+		/**
+		 * @param mixed $argument
+		 */
+		public function remove(IJob|string $job, mixed $argument = null): void;
+	}
+}

--- a/tests/phpunit/stubs/OCP/BackgroundJob/QueuedJob.php
+++ b/tests/phpunit/stubs/OCP/BackgroundJob/QueuedJob.php
@@ -7,19 +7,32 @@ namespace OCP\BackgroundJob;
 use OCP\AppFramework\Utility\ITimeFactory;
 
 if (!class_exists(QueuedJob::class)) {
+	/**
+	 * Mirrors the production lifecycle in the one respect that matters to
+	 * anything written against it: `start()` removes the job from the list
+	 * **before** running it. A job that wants another pass has to say so
+	 * itself, because by the time it runs, its row is already gone.
+	 *
+	 * A stub that only exposed `run()` would let a job be written as if a
+	 * failed run could simply be left to the queue.
+	 */
 	abstract class QueuedJob implements IJob {
 		public function __construct(protected ITimeFactory $time) {
 		}
 
+		final public function start(IJobList $jobList): void {
+			$jobList->remove($this, $this->argument);
+			$this->run($this->argument);
+		}
+
+		/** @var mixed */
+		protected $argument = null;
+
 		/**
-		 * The production base class runs the job once and removes it from
-		 * the list. Only the argument handling is under test here, so this
-		 * exposes `run` and nothing else.
-		 *
 		 * @param mixed $argument
 		 */
-		public function callRun($argument): void {
-			$this->run($argument);
+		public function setArgument($argument): void {
+			$this->argument = $argument;
 		}
 
 		/**

--- a/tests/phpunit/stubs/OCP/BackgroundJob/QueuedJob.php
+++ b/tests/phpunit/stubs/OCP/BackgroundJob/QueuedJob.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCP\BackgroundJob;
+
+use OCP\AppFramework\Utility\ITimeFactory;
+
+if (!class_exists(QueuedJob::class)) {
+	abstract class QueuedJob implements IJob {
+		public function __construct(protected ITimeFactory $time) {
+		}
+
+		/**
+		 * The production base class runs the job once and removes it from
+		 * the list. Only the argument handling is under test here, so this
+		 * exposes `run` and nothing else.
+		 *
+		 * @param mixed $argument
+		 */
+		public function callRun($argument): void {
+			$this->run($argument);
+		}
+
+		/**
+		 * @param mixed $argument
+		 */
+		abstract protected function run($argument);
+	}
+}

--- a/tests/phpunit/unit/CollectExpiredSessionsJobTest.php
+++ b/tests/phpunit/unit/CollectExpiredSessionsJobTest.php
@@ -108,6 +108,28 @@ class CollectExpiredSessionsJobTest extends TestCase {
 		$job->start($jobList);
 	}
 
+	/**
+	 * A delete that failed is a failure, even when the run deleted plenty
+	 * before it. Read as "progress, more to do" it would reset the attempt
+	 * counter, and a record the pad server will never let go of would cost
+	 * one call and one warning a minute for good.
+	 */
+	public function testBacksOffWhenTheRunEndedOnAFailedDelete(): void {
+		$collector = $this->createMock(ExpiredSessionCollector::class);
+		$collector->method('collect')->willReturn(['deleted' => 40, 'remaining' => 60, 'retry' => true]);
+
+		$jobList = $this->createMock(IJobList::class);
+		$jobList->expects(self::once())->method('scheduleAfter')->with(
+			CollectExpiredSessionsJob::class,
+			1_000_300,
+			['uid' => 'alice', 'authorId' => 'a.author', 'attempt' => 2],
+		);
+
+		$job = $this->job($collector, $jobList);
+		$job->setArgument(['uid' => 'alice', 'authorId' => 'a.author', 'attempt' => 1]);
+		$job->start($jobList);
+	}
+
 	/** A run that did its work continues, it does not retry. */
 	public function testAContinuationIsNotARetry(): void {
 		$collector = $this->createMock(ExpiredSessionCollector::class);

--- a/tests/phpunit/unit/CollectExpiredSessionsJobTest.php
+++ b/tests/phpunit/unit/CollectExpiredSessionsJobTest.php
@@ -12,6 +12,7 @@ use OCA\EtherpadNextcloud\BackgroundJob\CollectExpiredSessionsJob;
 use OCA\EtherpadNextcloud\Service\ExpiredSessionCollector;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\IJobList;
+use Psr\Log\LoggerInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
@@ -109,26 +110,80 @@ class CollectExpiredSessionsJobTest extends TestCase {
 	}
 
 	/**
-	 * A delete that failed is a failure, even when the run deleted plenty
-	 * before it. Read as "progress, more to do" it would reset the attempt
-	 * counter, and a record the pad server will never let go of would cost
-	 * one call and one warning a minute for good.
+	 * A run that deleted something is not an outage.
+	 *
+	 * The server answered and the pile got smaller, so giving up would drop
+	 * thousands of entries because a few were refused. It waits out the
+	 * backoff and then carries on as a fresh attempt — the counter resets,
+	 * because what the counter is for is deciding when to stop asking a
+	 * server that never answers.
 	 */
-	public function testBacksOffWhenTheRunEndedOnAFailedDelete(): void {
+	public function testCarriesOnWhenARefusedRunStillMadeProgress(): void {
 		$collector = $this->createMock(ExpiredSessionCollector::class);
-		$collector->method('collect')->willReturn(['deleted' => 40, 'remaining' => 60, 'retry' => true]);
+		$collector->method('collect')->willReturn(['deleted' => 200, 'remaining' => 3000, 'retry' => true]);
 
 		$jobList = $this->createMock(IJobList::class);
 		$jobList->expects(self::once())->method('scheduleAfter')->with(
 			CollectExpiredSessionsJob::class,
 			1_000_300,
-			['uid' => 'alice', 'authorId' => 'a.author', 'attempt' => 2],
+			['uid' => 'alice', 'authorId' => 'a.author'],
 		);
 
 		$job = $this->job($collector, $jobList);
 		$job->setArgument(['uid' => 'alice', 'authorId' => 'a.author', 'attempt' => 1]);
 		$job->start($jobList);
 	}
+
+	/**
+	 * Losing the continuation must not be silent. This job's row is gone
+	 * before run() is called, so an exception here takes the rest of the
+	 * backlog with it and leaves only Nextcloud's generic job error behind.
+	 */
+	public function testSaysSoWhenItCannotQueueTheNextPass(): void {
+		$collector = $this->createMock(ExpiredSessionCollector::class);
+		$collector->method('collect')->willReturn(['deleted' => 250, 'remaining' => 40, 'retry' => false]);
+
+		$jobList = $this->createMock(IJobList::class);
+		$jobList->method('scheduleAfter')->willThrowException(new \RuntimeException('Deadlock found'));
+		$logger = $this->createMock(LoggerInterface::class);
+		$logger->expects(self::once())->method('warning');
+
+		$job = $this->job($collector, $jobList, $logger);
+		$job->setArgument(['uid' => 'alice', 'authorId' => 'a.author']);
+		$job->start($jobList);
+	}
+
+	/**
+	 * The backoff table is the limit. A second constant saying how long it
+	 * is would be a fact about this array kept somewhere else, and tuning
+	 * the delays without noticing would index past its end — inside a cron
+	 * worker, with the row already removed and the backlog with it.
+	 */
+	public function testTheBackoffTableIsItsOwnLimit(): void {
+		$collector = $this->createMock(ExpiredSessionCollector::class);
+		$collector->method('collect')->willReturn(['deleted' => 0, 'remaining' => 0, 'retry' => true]);
+
+		$jobList = $this->createMock(IJobList::class);
+		$jobList->expects(self::never())->method('scheduleAfter');
+
+		$job = $this->job($collector, $jobList);
+		$job->setArgument([
+			'uid' => 'alice',
+			'authorId' => 'a.author',
+			'attempt' => count(CollectExpiredSessionsJob::attemptArguments(['uid' => 'a', 'authorId' => 'b'])),
+		]);
+		$job->start($jobList);
+	}
+
+	/** Every retry shape the collector has to recognise before queueing one. */
+	public function testNamesEveryRetryArgumentItCanProduce(): void {
+		self::assertSame([
+			['uid' => 'alice', 'authorId' => 'a.author', 'attempt' => 1],
+			['uid' => 'alice', 'authorId' => 'a.author', 'attempt' => 2],
+			['uid' => 'alice', 'authorId' => 'a.author', 'attempt' => 3],
+		], CollectExpiredSessionsJob::attemptArguments(['uid' => 'alice', 'authorId' => 'a.author']));
+	}
+
 
 	/** A run that did its work continues, it does not retry. */
 	public function testAContinuationIsNotARetry(): void {
@@ -194,6 +249,7 @@ class CollectExpiredSessionsJobTest extends TestCase {
 	private function job(
 		ExpiredSessionCollector $collector,
 		?IJobList $jobList = null,
+		?LoggerInterface $logger = null,
 	): CollectExpiredSessionsJob {
 		$time = $this->createMock(ITimeFactory::class);
 		$time->method('getTime')->willReturn(1_000_000);
@@ -202,6 +258,7 @@ class CollectExpiredSessionsJobTest extends TestCase {
 			$time,
 			$collector,
 			$jobList ?? $this->createMock(IJobList::class),
+			$logger ?? $this->createMock(LoggerInterface::class),
 		);
 	}
 }

--- a/tests/phpunit/unit/CollectExpiredSessionsJobTest.php
+++ b/tests/phpunit/unit/CollectExpiredSessionsJobTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * Copyright (c) 2026 Jacob Bühler
+ */
+
+namespace OCA\EtherpadNextcloud\Tests\Unit;
+
+use OCA\EtherpadNextcloud\BackgroundJob\CollectExpiredSessionsJob;
+use OCA\EtherpadNextcloud\Service\ExpiredSessionCollector;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\IJobList;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The sweep runs here rather than in the request that noticed the backlog.
+ * What this class decides is only whether one run was enough.
+ */
+class CollectExpiredSessionsJobTest extends TestCase {
+	public function testComesBackForWhatDidNotFit(): void {
+		$collector = $this->createMock(ExpiredSessionCollector::class);
+		$collector->method('collect')->willReturn(['deleted' => 250, 'remaining' => 150]);
+
+		$jobList = $this->createMock(IJobList::class);
+		$jobList->expects(self::once())->method('scheduleAfter')->with(
+			CollectExpiredSessionsJob::class,
+			1_000_060,
+			['uid' => 'alice', 'authorId' => 'a.author'],
+		);
+
+		$this->job($collector, $jobList)->callRun(['uid' => 'alice', 'authorId' => 'a.author']);
+	}
+
+	/** A finished sweep must not leave a job behind that finds nothing. */
+	public function testStopsWhenThereIsNothingLeft(): void {
+		$collector = $this->createMock(ExpiredSessionCollector::class);
+		$collector->method('collect')->willReturn(['deleted' => 12, 'remaining' => 0]);
+
+		$jobList = $this->createMock(IJobList::class);
+		$jobList->expects(self::never())->method('scheduleAfter');
+
+		$this->job($collector, $jobList)->callRun(['uid' => 'alice', 'authorId' => 'a.author']);
+	}
+
+	/**
+	 * Job arguments outlive the code that wrote them: a row queued by an
+	 * older version, or one whose author was cleared since, must not reach
+	 * Etherpad with an empty id and list somebody else's sessions.
+	 *
+	 * @param mixed $argument
+	 */
+	#[DataProvider('unusableArguments')]
+	public function testIgnoresAnArgumentItCannotUse($argument): void {
+		$collector = $this->createMock(ExpiredSessionCollector::class);
+		$collector->expects(self::never())->method('collect');
+
+		$this->job($collector)->callRun($argument);
+	}
+
+	/** @return iterable<string,array{mixed}> */
+	public static function unusableArguments(): iterable {
+		yield 'null' => [null];
+		yield 'a bare uid from an older queue' => ['alice'];
+		yield 'no author' => [['uid' => 'alice']];
+		yield 'no uid' => [['authorId' => 'a.author']];
+		yield 'empty author' => [['uid' => 'alice', 'authorId' => '']];
+	}
+
+	private function job(
+		ExpiredSessionCollector $collector,
+		?IJobList $jobList = null,
+	): CollectExpiredSessionsJob {
+		$time = $this->createMock(ITimeFactory::class);
+		$time->method('getTime')->willReturn(1_000_000);
+
+		return new CollectExpiredSessionsJob(
+			$time,
+			$collector,
+			$jobList ?? $this->createMock(IJobList::class),
+		);
+	}
+}

--- a/tests/phpunit/unit/CollectExpiredSessionsJobTest.php
+++ b/tests/phpunit/unit/CollectExpiredSessionsJobTest.php
@@ -22,7 +22,7 @@ use PHPUnit\Framework\TestCase;
 class CollectExpiredSessionsJobTest extends TestCase {
 	public function testComesBackForWhatDidNotFit(): void {
 		$collector = $this->createMock(ExpiredSessionCollector::class);
-		$collector->method('collect')->willReturn(['deleted' => 250, 'remaining' => 150]);
+		$collector->method('collect')->willReturn(['deleted' => 250, 'remaining' => 150, 'retry' => false]);
 
 		$jobList = $this->createMock(IJobList::class);
 		$jobList->expects(self::once())->method('scheduleAfter')->with(
@@ -31,18 +31,115 @@ class CollectExpiredSessionsJobTest extends TestCase {
 			['uid' => 'alice', 'authorId' => 'a.author'],
 		);
 
-		$this->job($collector, $jobList)->callRun(['uid' => 'alice', 'authorId' => 'a.author']);
+		$job = $this->job($collector, $jobList);
+		$job->setArgument(['uid' => 'alice', 'authorId' => 'a.author']);
+		$job->start($jobList);
 	}
 
 	/** A finished sweep must not leave a job behind that finds nothing. */
 	public function testStopsWhenThereIsNothingLeft(): void {
 		$collector = $this->createMock(ExpiredSessionCollector::class);
-		$collector->method('collect')->willReturn(['deleted' => 12, 'remaining' => 0]);
+		$collector->method('collect')->willReturn(['deleted' => 12, 'remaining' => 0, 'retry' => false]);
 
 		$jobList = $this->createMock(IJobList::class);
 		$jobList->expects(self::never())->method('scheduleAfter');
 
-		$this->job($collector, $jobList)->callRun(['uid' => 'alice', 'authorId' => 'a.author']);
+		$job = $this->job($collector, $jobList);
+		$job->setArgument(['uid' => 'alice', 'authorId' => 'a.author']);
+		$job->start($jobList);
+	}
+
+	/**
+	 * A listing that failed is not an empty backlog. The row is gone before
+	 * run() is called, so without re-queueing here the pile waits for
+	 * somebody to open a pad and notice it all over again.
+	 */
+	public function testComesBackAfterAFailedListing(): void {
+		$collector = $this->createMock(ExpiredSessionCollector::class);
+		$collector->method('collect')->willReturn(['deleted' => 0, 'remaining' => 0, 'retry' => true]);
+
+		$jobList = $this->createMock(IJobList::class);
+		$jobList->expects(self::once())->method('scheduleAfter')->with(
+			CollectExpiredSessionsJob::class,
+			1_000_060,
+			['uid' => 'alice', 'authorId' => 'a.author', 'attempt' => 1],
+		);
+
+		$job = $this->job($collector, $jobList);
+		$job->setArgument(['uid' => 'alice', 'authorId' => 'a.author']);
+		$job->start($jobList);
+	}
+
+	/**
+	 * The backoff has to grow, and the attempt has to travel in the
+	 * argument: a plain note from a pad open is then a different row, so an
+	 * open cannot reset a retry that is deliberately waiting.
+	 */
+	public function testBacksOffFurtherOnEachFailure(): void {
+		$collector = $this->createMock(ExpiredSessionCollector::class);
+		$collector->method('collect')->willReturn(['deleted' => 0, 'remaining' => 0, 'retry' => true]);
+
+		$jobList = $this->createMock(IJobList::class);
+		$jobList->expects(self::once())->method('scheduleAfter')->with(
+			CollectExpiredSessionsJob::class,
+			1_000_900,
+			['uid' => 'alice', 'authorId' => 'a.author', 'attempt' => 3],
+		);
+
+		$job = $this->job($collector, $jobList);
+		$job->setArgument(['uid' => 'alice', 'authorId' => 'a.author', 'attempt' => 2]);
+		$job->start($jobList);
+	}
+
+	/**
+	 * A pad server that has been unreachable for a quarter of an hour is
+	 * not going to be helped by a fourth try, and the next open queues a
+	 * fresh sweep anyway.
+	 */
+	public function testGivesUpAfterEnoughFailures(): void {
+		$collector = $this->createMock(ExpiredSessionCollector::class);
+		$collector->method('collect')->willReturn(['deleted' => 0, 'remaining' => 0, 'retry' => true]);
+
+		$jobList = $this->createMock(IJobList::class);
+		$jobList->expects(self::never())->method('scheduleAfter');
+
+		$job = $this->job($collector, $jobList);
+		$job->setArgument(['uid' => 'alice', 'authorId' => 'a.author', 'attempt' => 3]);
+		$job->start($jobList);
+	}
+
+	/** A run that did its work continues, it does not retry. */
+	public function testAContinuationIsNotARetry(): void {
+		$collector = $this->createMock(ExpiredSessionCollector::class);
+		$collector->method('collect')->willReturn(['deleted' => 250, 'remaining' => 40, 'retry' => false]);
+
+		$jobList = $this->createMock(IJobList::class);
+		$jobList->expects(self::once())->method('scheduleAfter')->with(
+			CollectExpiredSessionsJob::class,
+			1_000_060,
+			['uid' => 'alice', 'authorId' => 'a.author'],
+		);
+
+		$job = $this->job($collector, $jobList);
+		$job->setArgument(['uid' => 'alice', 'authorId' => 'a.author', 'attempt' => 2]);
+		$job->start($jobList);
+	}
+
+	/** A row is data: an attempt count out of range must not index the backoff table. */
+	public function testTreatsANonsenseAttemptAsTheFirst(): void {
+		$collector = $this->createMock(ExpiredSessionCollector::class);
+		$collector->method('collect')->willReturn(['deleted' => 0, 'remaining' => 0, 'retry' => true]);
+
+		$jobList = $this->createMock(IJobList::class);
+		$jobList->expects(self::once())->method('scheduleAfter')->with(
+			CollectExpiredSessionsJob::class,
+			1_000_060,
+			['uid' => 'alice', 'authorId' => 'a.author', 'attempt' => 1],
+		);
+
+		$job = $this->job($collector, $jobList);
+		$job->setArgument(['uid' => 'alice', 'authorId' => 'a.author', 'attempt' => -5]);
+		$job->start($jobList);
 	}
 
 	/**
@@ -57,7 +154,10 @@ class CollectExpiredSessionsJobTest extends TestCase {
 		$collector = $this->createMock(ExpiredSessionCollector::class);
 		$collector->expects(self::never())->method('collect');
 
-		$this->job($collector)->callRun($argument);
+		$jobList = $this->createMock(IJobList::class);
+		$job = $this->job($collector, $jobList);
+		$job->setArgument($argument);
+		$job->start($jobList);
 	}
 
 	/** @return iterable<string,array{mixed}> */

--- a/tests/phpunit/unit/CollectExpiredSessionsJobTest.php
+++ b/tests/phpunit/unit/CollectExpiredSessionsJobTest.php
@@ -23,30 +23,30 @@ use PHPUnit\Framework\TestCase;
 class CollectExpiredSessionsJobTest extends TestCase {
 	public function testComesBackForWhatDidNotFit(): void {
 		$collector = $this->createMock(ExpiredSessionCollector::class);
-		$collector->method('collect')->willReturn(['deleted' => 250, 'remaining' => 150, 'retry' => false]);
+		$collector->method('collect')->willReturn(['deleted' => 250, 'remaining' => 150, 'retry' => false, 'nextDueAt' => null]);
 
 		$jobList = $this->createMock(IJobList::class);
 		$jobList->expects(self::once())->method('scheduleAfter')->with(
 			CollectExpiredSessionsJob::class,
 			1_000_060,
-			['uid' => 'alice', 'authorId' => 'a.author'],
+			['authorId' => 'a.author'],
 		);
 
 		$job = $this->job($collector, $jobList);
-		$job->setArgument(['uid' => 'alice', 'authorId' => 'a.author']);
+		$job->setArgument(['authorId' => 'a.author']);
 		$job->start($jobList);
 	}
 
 	/** A finished sweep must not leave a job behind that finds nothing. */
 	public function testStopsWhenThereIsNothingLeft(): void {
 		$collector = $this->createMock(ExpiredSessionCollector::class);
-		$collector->method('collect')->willReturn(['deleted' => 12, 'remaining' => 0, 'retry' => false]);
+		$collector->method('collect')->willReturn(['deleted' => 12, 'remaining' => 0, 'retry' => false, 'nextDueAt' => null]);
 
 		$jobList = $this->createMock(IJobList::class);
 		$jobList->expects(self::never())->method('scheduleAfter');
 
 		$job = $this->job($collector, $jobList);
-		$job->setArgument(['uid' => 'alice', 'authorId' => 'a.author']);
+		$job->setArgument(['authorId' => 'a.author']);
 		$job->start($jobList);
 	}
 
@@ -57,17 +57,17 @@ class CollectExpiredSessionsJobTest extends TestCase {
 	 */
 	public function testComesBackAfterAFailedListing(): void {
 		$collector = $this->createMock(ExpiredSessionCollector::class);
-		$collector->method('collect')->willReturn(['deleted' => 0, 'remaining' => 0, 'retry' => true]);
+		$collector->method('collect')->willReturn(['deleted' => 0, 'remaining' => 0, 'retry' => true, 'nextDueAt' => null]);
 
 		$jobList = $this->createMock(IJobList::class);
 		$jobList->expects(self::once())->method('scheduleAfter')->with(
 			CollectExpiredSessionsJob::class,
 			1_000_060,
-			['uid' => 'alice', 'authorId' => 'a.author', 'attempt' => 1],
+			['authorId' => 'a.author', 'attempt' => 1],
 		);
 
 		$job = $this->job($collector, $jobList);
-		$job->setArgument(['uid' => 'alice', 'authorId' => 'a.author']);
+		$job->setArgument(['authorId' => 'a.author']);
 		$job->start($jobList);
 	}
 
@@ -78,17 +78,17 @@ class CollectExpiredSessionsJobTest extends TestCase {
 	 */
 	public function testBacksOffFurtherOnEachFailure(): void {
 		$collector = $this->createMock(ExpiredSessionCollector::class);
-		$collector->method('collect')->willReturn(['deleted' => 0, 'remaining' => 0, 'retry' => true]);
+		$collector->method('collect')->willReturn(['deleted' => 0, 'remaining' => 0, 'retry' => true, 'nextDueAt' => null]);
 
 		$jobList = $this->createMock(IJobList::class);
 		$jobList->expects(self::once())->method('scheduleAfter')->with(
 			CollectExpiredSessionsJob::class,
 			1_000_900,
-			['uid' => 'alice', 'authorId' => 'a.author', 'attempt' => 3],
+			['authorId' => 'a.author', 'attempt' => 3],
 		);
 
 		$job = $this->job($collector, $jobList);
-		$job->setArgument(['uid' => 'alice', 'authorId' => 'a.author', 'attempt' => 2]);
+		$job->setArgument(['authorId' => 'a.author', 'attempt' => 2]);
 		$job->start($jobList);
 	}
 
@@ -99,13 +99,13 @@ class CollectExpiredSessionsJobTest extends TestCase {
 	 */
 	public function testGivesUpAfterEnoughFailures(): void {
 		$collector = $this->createMock(ExpiredSessionCollector::class);
-		$collector->method('collect')->willReturn(['deleted' => 0, 'remaining' => 0, 'retry' => true]);
+		$collector->method('collect')->willReturn(['deleted' => 0, 'remaining' => 0, 'retry' => true, 'nextDueAt' => null]);
 
 		$jobList = $this->createMock(IJobList::class);
 		$jobList->expects(self::never())->method('scheduleAfter');
 
 		$job = $this->job($collector, $jobList);
-		$job->setArgument(['uid' => 'alice', 'authorId' => 'a.author', 'attempt' => 3]);
+		$job->setArgument(['authorId' => 'a.author', 'attempt' => 3]);
 		$job->start($jobList);
 	}
 
@@ -120,17 +120,17 @@ class CollectExpiredSessionsJobTest extends TestCase {
 	 */
 	public function testCarriesOnWhenARefusedRunStillMadeProgress(): void {
 		$collector = $this->createMock(ExpiredSessionCollector::class);
-		$collector->method('collect')->willReturn(['deleted' => 200, 'remaining' => 3000, 'retry' => true]);
+		$collector->method('collect')->willReturn(['deleted' => 200, 'remaining' => 3000, 'retry' => true, 'nextDueAt' => null]);
 
 		$jobList = $this->createMock(IJobList::class);
 		$jobList->expects(self::once())->method('scheduleAfter')->with(
 			CollectExpiredSessionsJob::class,
 			1_000_300,
-			['uid' => 'alice', 'authorId' => 'a.author'],
+			['authorId' => 'a.author'],
 		);
 
 		$job = $this->job($collector, $jobList);
-		$job->setArgument(['uid' => 'alice', 'authorId' => 'a.author', 'attempt' => 1]);
+		$job->setArgument(['authorId' => 'a.author', 'attempt' => 1]);
 		$job->start($jobList);
 	}
 
@@ -141,7 +141,7 @@ class CollectExpiredSessionsJobTest extends TestCase {
 	 */
 	public function testSaysSoWhenItCannotQueueTheNextPass(): void {
 		$collector = $this->createMock(ExpiredSessionCollector::class);
-		$collector->method('collect')->willReturn(['deleted' => 250, 'remaining' => 40, 'retry' => false]);
+		$collector->method('collect')->willReturn(['deleted' => 250, 'remaining' => 40, 'retry' => false, 'nextDueAt' => null]);
 
 		$jobList = $this->createMock(IJobList::class);
 		$jobList->method('scheduleAfter')->willThrowException(new \RuntimeException('Deadlock found'));
@@ -149,7 +149,7 @@ class CollectExpiredSessionsJobTest extends TestCase {
 		$logger->expects(self::once())->method('warning');
 
 		$job = $this->job($collector, $jobList, $logger);
-		$job->setArgument(['uid' => 'alice', 'authorId' => 'a.author']);
+		$job->setArgument(['authorId' => 'a.author']);
 		$job->start($jobList);
 	}
 
@@ -161,61 +161,121 @@ class CollectExpiredSessionsJobTest extends TestCase {
 	 */
 	public function testTheBackoffTableIsItsOwnLimit(): void {
 		$collector = $this->createMock(ExpiredSessionCollector::class);
-		$collector->method('collect')->willReturn(['deleted' => 0, 'remaining' => 0, 'retry' => true]);
+		$collector->method('collect')->willReturn(['deleted' => 0, 'remaining' => 0, 'retry' => true, 'nextDueAt' => null]);
 
 		$jobList = $this->createMock(IJobList::class);
 		$jobList->expects(self::never())->method('scheduleAfter');
 
 		$job = $this->job($collector, $jobList);
 		$job->setArgument([
-			'uid' => 'alice',
 			'authorId' => 'a.author',
-			'attempt' => count(CollectExpiredSessionsJob::attemptArguments(['uid' => 'a', 'authorId' => 'b'])),
+			'attempt' => count(CollectExpiredSessionsJob::attemptArguments(['authorId' => 'b'])),
 		]);
+		$job->start($jobList);
+	}
+
+	/**
+	 * A plain row queued while a run was in progress stands down when a
+	 * retry is waiting.
+	 *
+	 * QueuedJob removes its own row before running, so for the length of a
+	 * run nothing says a sweep exists: an open queues a plain row, the
+	 * failing run then adds its retry behind it, and the plain one would
+	 * run at once — undoing exactly the waiting the backoff is for, during
+	 * the outage it exists for.
+	 */
+	public function testStandsDownWhileABackedOffRetryIsWaiting(): void {
+		$collector = $this->createMock(ExpiredSessionCollector::class);
+		$collector->expects(self::never())->method('collect');
+
+		$jobList = $this->createMock(IJobList::class);
+		$jobList->method('has')->willReturnCallback(
+			static fn (string $job, mixed $argument): bool => is_array($argument)
+				&& ($argument['attempt'] ?? 0) === 2
+		);
+
+		$job = $this->job($collector, $jobList);
+		$job->setArgument(['authorId' => 'a.author']);
+		$job->start($jobList);
+	}
+
+	/** A retry itself must not stand down — it is the one that was waiting. */
+	public function testARetryRunsEvenThoughItIsItselfQueued(): void {
+		$collector = $this->createMock(ExpiredSessionCollector::class);
+		$collector->expects(self::once())->method('collect')
+			->willReturn(['deleted' => 5, 'remaining' => 0, 'retry' => false, 'nextDueAt' => null]);
+
+		$jobList = $this->createMock(IJobList::class);
+		$jobList->method('has')->willReturn(true);
+
+		$job = $this->job($collector, $jobList);
+		$job->setArgument(['authorId' => 'a.author', 'attempt' => 2]);
+		$job->start($jobList);
+	}
+
+	/**
+	 * A finished sweep comes back when the earliest session still standing
+	 * becomes collectable — that row is also what tells an open a sweep is
+	 * already accounted for.
+	 */
+	public function testComesBackWhenTheNextSessionFallsDue(): void {
+		$collector = $this->createMock(ExpiredSessionCollector::class);
+		$collector->method('collect')
+			->willReturn(['deleted' => 3, 'remaining' => 0, 'retry' => false, 'nextDueAt' => 1_000_900]);
+
+		$jobList = $this->createMock(IJobList::class);
+		$jobList->expects(self::once())->method('scheduleAfter')->with(
+			CollectExpiredSessionsJob::class,
+			1_000_900,
+			['authorId' => 'a.author'],
+		);
+
+		$job = $this->job($collector, $jobList);
+		$job->setArgument(['authorId' => 'a.author']);
 		$job->start($jobList);
 	}
 
 	/** Every retry shape the collector has to recognise before queueing one. */
 	public function testNamesEveryRetryArgumentItCanProduce(): void {
 		self::assertSame([
-			['uid' => 'alice', 'authorId' => 'a.author', 'attempt' => 1],
-			['uid' => 'alice', 'authorId' => 'a.author', 'attempt' => 2],
-			['uid' => 'alice', 'authorId' => 'a.author', 'attempt' => 3],
-		], CollectExpiredSessionsJob::attemptArguments(['uid' => 'alice', 'authorId' => 'a.author']));
+			['authorId' => 'a.author', 'attempt' => 1],
+			['authorId' => 'a.author', 'attempt' => 2],
+			['authorId' => 'a.author', 'attempt' => 3],
+		], CollectExpiredSessionsJob::attemptArguments(['authorId' => 'a.author']));
 	}
 
 
 	/** A run that did its work continues, it does not retry. */
 	public function testAContinuationIsNotARetry(): void {
 		$collector = $this->createMock(ExpiredSessionCollector::class);
-		$collector->method('collect')->willReturn(['deleted' => 250, 'remaining' => 40, 'retry' => false]);
+		$collector->method('collect')->willReturn(['deleted' => 250, 'remaining' => 40, 'retry' => false, 'nextDueAt' => null]);
 
 		$jobList = $this->createMock(IJobList::class);
 		$jobList->expects(self::once())->method('scheduleAfter')->with(
 			CollectExpiredSessionsJob::class,
 			1_000_060,
-			['uid' => 'alice', 'authorId' => 'a.author'],
+			['authorId' => 'a.author'],
 		);
 
 		$job = $this->job($collector, $jobList);
-		$job->setArgument(['uid' => 'alice', 'authorId' => 'a.author', 'attempt' => 2]);
+		$job->setArgument(['authorId' => 'a.author', 'attempt' => 2]);
 		$job->start($jobList);
 	}
 
 	/** A row is data: an attempt count out of range must not index the backoff table. */
 	public function testTreatsANonsenseAttemptAsTheFirst(): void {
 		$collector = $this->createMock(ExpiredSessionCollector::class);
-		$collector->method('collect')->willReturn(['deleted' => 0, 'remaining' => 0, 'retry' => true]);
+		$collector->method('collect')->willReturn(['deleted' => 0, 'remaining' => 0, 'retry' => true, 'nextDueAt' => null]);
 
 		$jobList = $this->createMock(IJobList::class);
 		$jobList->expects(self::once())->method('scheduleAfter')->with(
 			CollectExpiredSessionsJob::class,
 			1_000_060,
-			['uid' => 'alice', 'authorId' => 'a.author', 'attempt' => 1],
+			['authorId' => 'a.author', 'attempt' => 1],
 		);
 
 		$job = $this->job($collector, $jobList);
-		$job->setArgument(['uid' => 'alice', 'authorId' => 'a.author', 'attempt' => -5]);
+		$job->setArgument(['authorId' => 'a.author', 'attempt' => -5]);
 		$job->start($jobList);
 	}
 
@@ -240,10 +300,13 @@ class CollectExpiredSessionsJobTest extends TestCase {
 	/** @return iterable<string,array{mixed}> */
 	public static function unusableArguments(): iterable {
 		yield 'null' => [null];
-		yield 'a bare uid from an older queue' => ['alice'];
-		yield 'no author' => [['uid' => 'alice']];
-		yield 'no uid' => [['authorId' => 'a.author']];
-		yield 'empty author' => [['uid' => 'alice', 'authorId' => '']];
+		yield 'a bare string from an older queue' => ['alice'];
+		yield 'no author' => [[]];
+		yield 'empty author' => [['authorId' => '']];
+		// The shape this job used to be queued with, when the argument
+		// still carried a uid — and for a public link that uid was the
+		// share token.
+		yield 'an older row without an author' => [['uid' => 'alice']];
 	}
 
 	private function job(

--- a/tests/phpunit/unit/EtherpadClientTest.php
+++ b/tests/phpunit/unit/EtherpadClientTest.php
@@ -185,6 +185,48 @@ class EtherpadClientTest extends TestCase {
 		self::assertSame(3, $captured['options']['timeout']);
 	}
 
+	/**
+	 * A caller that says how long it may take gets exactly that.
+	 *
+	 * apiCall() takes seven positional parameters, so the timeout reaches
+	 * the request through three nulls; drop or misplace one — the plausible
+	 * edit when some future call needs a host override — and it lands in
+	 * the api-version slot instead. Every delete would then quietly run at
+	 * the default again, and the collector's tests would not notice,
+	 * because they assert against a mocked client.
+	 */
+	public function testPassesACallersTimeoutThroughToTheRequest(): void {
+		$captured = null;
+		$client = $this->clientWithResponse(
+			$this->response(200, '{"code":0,"data":null}'),
+			$captured,
+		);
+
+		$client->deleteSession('s.aaaaaaaaaaaaaaaa', 4);
+
+		self::assertSame(4, $captured['options']['timeout']);
+	}
+
+	/**
+	 * Guzzle reads `timeout => 0` as no timeout at all, so the one
+	 * parameter whose purpose is bounding time must never be able to
+	 * unbound a call. Clamped at both ends: no housekeeping call gets more
+	 * patience than the ones a user waits on either.
+	 */
+	public function testClampsATimeoutThatWouldRemoveTheBound(): void {
+		foreach ([0 => 1, -5 => 1, 900 => 15] as $asked => $expected) {
+			$captured = null;
+			$client = $this->clientWithResponse(
+				$this->response(200, '{"code":0,"data":null}'),
+				$captured,
+			);
+
+			$client->deleteSession('s.aaaaaaaaaaaaaaaa', $asked);
+
+			self::assertSame($expected, $captured['options']['timeout'], "asked for {$asked}");
+		}
+	}
+
 	/** The calls that do matter keep the full patience. */
 	public function testApiCallsKeepTheFullRequestTimeout(): void {
 		$captured = null;

--- a/tests/phpunit/unit/EtherpadClientTest.php
+++ b/tests/phpunit/unit/EtherpadClientTest.php
@@ -227,6 +227,33 @@ class EtherpadClientTest extends TestCase {
 		}
 	}
 
+	/**
+	 * An id the index lists but Etherpad cannot describe is counted, not
+	 * quietly dropped.
+	 *
+	 * Etherpad's listing walks the author index and answers null for a key
+	 * whose session record is gone. Such a key still costs a lookup on
+	 * every listing, and `deleteSession` will not take it — it answers that
+	 * it does not exist. Swallowing them would let a collector report a
+	 * clean sweep while the index it exists to shrink stayed as long.
+	 */
+	public function testCountsTheIndexEntriesEtherpadCannotDescribe(): void {
+		$captured = null;
+		$client = $this->clientWithResponse(
+			$this->response(200, json_encode(['code' => 0, 'data' => [
+				's.aaaaaaaaaaaaaaaa' => ['groupID' => 'g.aaaaaaaaaaaaaaaa', 'validUntil' => 4102444800],
+				's.bbbbbbbbbbbbbbbb' => null,
+				's.cccccccccccccccc' => null,
+			]])),
+			$captured,
+		);
+
+		$sessions = $client->listSessionsOfAuthor('a.aaaaaaaaaaaaaaaa', null, $unreadable);
+
+		self::assertSame(['s.aaaaaaaaaaaaaaaa'], array_keys($sessions));
+		self::assertSame(2, $unreadable);
+	}
+
 	/** The calls that do matter keep the full patience. */
 	public function testApiCallsKeepTheFullRequestTimeout(): void {
 		$captured = null;

--- a/tests/phpunit/unit/EtherpadClientTest.php
+++ b/tests/phpunit/unit/EtherpadClientTest.php
@@ -244,6 +244,11 @@ class EtherpadClientTest extends TestCase {
 				's.aaaaaaaaaaaaaaaa' => ['groupID' => 'g.aaaaaaaaaaaaaaaa', 'validUntil' => 4102444800],
 				's.bbbbbbbbbbbbbbbb' => null,
 				's.cccccccccccccccc' => null,
+				// Malformed rather than null, and just as unusable: still a
+				// key the listing walks that no delete will take.
+				's.dddddddddddddddd' => ['validUntil' => 4102444800],
+				's.eeeeeeeeeeeeeeee' => ['groupID' => 'g.aaaaaaaaaaaaaaaa'],
+				's.ffffffffffffffff' => [],
 			]])),
 			$captured,
 		);
@@ -251,7 +256,7 @@ class EtherpadClientTest extends TestCase {
 		$sessions = $client->listSessionsOfAuthor('a.aaaaaaaaaaaaaaaa', null, $unreadable);
 
 		self::assertSame(['s.aaaaaaaaaaaaaaaa'], array_keys($sessions));
-		self::assertSame(2, $unreadable);
+		self::assertSame(5, $unreadable);
 	}
 
 	/** The calls that do matter keep the full patience. */

--- a/tests/phpunit/unit/EtherpadErrorClassifierSessionTest.php
+++ b/tests/phpunit/unit/EtherpadErrorClassifierSessionTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * Copyright (c) 2026 Jacob Bühler
+ */
+
+namespace OCA\EtherpadNextcloud\Tests\Unit;
+
+use OCA\EtherpadNextcloud\Exception\EtherpadClientException;
+use OCA\EtherpadNextcloud\Util\EtherpadErrorClassifier;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Two questions, two string lists. One shared list would let an answer
+ * about a session be read as an answer about a pad — and a pad delete that
+ * failed while Etherpad tore down that group's sessions would then drop a
+ * binding row for a pad that is still there.
+ */
+class EtherpadErrorClassifierSessionTest extends TestCase {
+	public function testReadsAGoneSession(): void {
+		self::assertTrue(EtherpadErrorClassifier::isSessionAlreadyGone(
+			new EtherpadClientException('sessionID does not exist')
+		));
+	}
+
+	/** The client wraps transport errors, so the sentence Etherpad said is rarely the outermost one. */
+	public function testLooksThroughTheCauseChain(): void {
+		self::assertTrue(EtherpadErrorClassifier::isSessionAlreadyGone(
+			new EtherpadClientException('Etherpad call failed', 0, new \RuntimeException('sessionID does not exist'))
+		));
+	}
+
+	#[DataProvider('padAnswers')]
+	public function testDoesNotReadAPadAnswerAsASession(string $message): void {
+		self::assertFalse(EtherpadErrorClassifier::isSessionAlreadyGone(
+			new EtherpadClientException($message)
+		));
+	}
+
+	/** @return iterable<string,array{string}> */
+	public static function padAnswers(): iterable {
+		yield 'pad' => ['padID does not exist'];
+		yield 'group' => ['groupID does not exist'];
+		yield 'timeout' => ['Connection timed out'];
+	}
+
+	/** And the other way round: a session answer is not a gone pad. */
+	public function testASessionAnswerIsNotAGonePad(): void {
+		self::assertFalse(EtherpadErrorClassifier::isPadAlreadyDeleted(
+			new EtherpadClientException('sessionID does not exist')
+		));
+	}
+}

--- a/tests/phpunit/unit/ExpiredSessionCollectorTest.php
+++ b/tests/phpunit/unit/ExpiredSessionCollectorTest.php
@@ -26,8 +26,16 @@ use Psr\Log\LoggerInterface;
 class ExpiredSessionCollectorTest extends TestCase {
 	private const AUTHOR = 'a.author';
 
-	/** @return array{groupID:string,validUntil:int} */
+	/**
+	 * Long enough past expiry that both clocks must agree. A session that
+	 * ran out a minute ago is deliberately not collected.
+	 */
 	private static function expired(): array {
+		return ['groupID' => 'g.AAAAAAAAAAAAAAAA', 'validUntil' => time() - 3600];
+	}
+
+	/** @return array{groupID:string,validUntil:int} */
+	private static function justExpired(): array {
 		return ['groupID' => 'g.AAAAAAAAAAAAAAAA', 'validUntil' => time() - 60];
 	}
 
@@ -149,6 +157,24 @@ class ExpiredSessionCollectorTest extends TestCase {
 	}
 
 	/**
+	 * A call that cannot finish inside the budget is not started.
+	 *
+	 * Checking only that the deadline has not passed lets the last delete
+	 * begin with a fraction of a second left and then run for its whole
+	 * timeout — the budget wrong by a timeout again, just a smaller one.
+	 * The sessions it did not get to are the next run's business.
+	 */
+	public function testStartsNoCallItCannotFinishInTime(): void {
+		$client = $this->createMock(EtherpadClient::class);
+		$client->method('listSessionsOfAuthor')->willReturn(self::expiredSessions(5));
+		$client->expects(self::never())->method('deleteSession');
+
+		$result = $this->collector($client, budgetSeconds: 0.3)->collect('alice', self::AUTHOR);
+
+		self::assertSame(['deleted' => 0, 'remaining' => 5, 'retry' => false], $result);
+	}
+
+	/**
 	 * The ceiling has to be reported honestly, because the job decides
 	 * whether to come back from this number alone.
 	 */
@@ -231,7 +257,55 @@ class ExpiredSessionCollectorTest extends TestCase {
 		$result = $this->collector($client, logger: $logger)->collect('alice', self::AUTHOR);
 
 		self::assertSame(1, $calls, 'one failure is enough to know the rest will fail too');
-		self::assertSame(['deleted' => 0, 'remaining' => 10, 'retry' => false], $result);
+		self::assertSame(['deleted' => 0, 'remaining' => 10, 'retry' => true], $result);
+	}
+
+	/**
+	 * Nextcloud computes validUntil; Etherpad judges it against its own
+	 * clock. In the window where the two disagree, a session this side
+	 * calls dead is one the pad server still grants — and deleting it
+	 * closes a socket somebody is typing into. Nothing here is urgent
+	 * enough to be worth that.
+	 */
+	public function testWaitsOutTheClockDifferenceBeforeDeleting(): void {
+		$client = $this->createMock(EtherpadClient::class);
+		$client->method('listSessionsOfAuthor')->willReturn([
+			's.justnow' => self::justExpired(),
+			's.longago' => self::expired(),
+		]);
+		$client->expects(self::once())->method('deleteSession')->with('s.longago');
+
+		self::assertSame(1, $this->collector($client)->collect('alice', self::AUTHOR)['deleted']);
+	}
+
+	/** And the same session does not count towards queueing a sweep either. */
+	public function testDoesNotCountAFreshlyExpiredSessionAsBacklog(): void {
+		$jobList = $this->createMock(IJobList::class);
+		$jobList->method('has')->willReturn(false);
+		$jobList->expects(self::never())->method('add');
+
+		$sessions = [];
+		for ($i = 0; $i < 80; $i++) {
+			$sessions['s.just' . $i] = self::justExpired();
+		}
+
+		$this->collector($this->createMock(EtherpadClient::class), $jobList)
+			->noteBacklog('alice', self::AUTHOR, $sessions);
+	}
+
+	/**
+	 * Queueing is housekeeping, and housekeeping may not be why a pad fails
+	 * to open. Both calls behind this touch Nextcloud's database from
+	 * inside a request somebody is waiting on.
+	 */
+	public function testAnUnreachableJobTableDoesNotBreakTheOpen(): void {
+		$jobList = $this->createMock(IJobList::class);
+		$jobList->method('has')->willThrowException(new \RuntimeException('Deadlock found'));
+		$logger = $this->createMock(LoggerInterface::class);
+		$logger->expects(self::once())->method('warning');
+
+		$this->collector($this->createMock(EtherpadClient::class), $jobList, $logger)
+			->noteBacklog('alice', self::AUTHOR, self::expiredSessions(80));
 	}
 
 	/** Nothing about collecting may take a pad server outage further. */
@@ -251,11 +325,13 @@ class ExpiredSessionCollectorTest extends TestCase {
 		EtherpadClient $client,
 		?IJobList $jobList = null,
 		?LoggerInterface $logger = null,
+		?float $budgetSeconds = null,
 	): ExpiredSessionCollector {
 		return new ExpiredSessionCollector(
 			$client,
 			$jobList ?? $this->createMock(IJobList::class),
 			$logger ?? $this->createMock(LoggerInterface::class),
+			...($budgetSeconds === null ? [] : [$budgetSeconds]),
 		);
 	}
 }

--- a/tests/phpunit/unit/ExpiredSessionCollectorTest.php
+++ b/tests/phpunit/unit/ExpiredSessionCollectorTest.php
@@ -1,0 +1,214 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * Copyright (c) 2026 Jacob Bühler
+ */
+
+namespace OCA\EtherpadNextcloud\Tests\Unit;
+
+use OCA\EtherpadNextcloud\BackgroundJob\CollectExpiredSessionsJob;
+use OCA\EtherpadNextcloud\Exception\EtherpadClientException;
+use OCA\EtherpadNextcloud\Service\EtherpadClient;
+use OCA\EtherpadNextcloud\Service\ExpiredSessionCollector;
+use OCP\BackgroundJob\IJobList;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Etherpad never removes an expired session, and listSessionsOfAuthor
+ * walks the author's whole index one awaited lookup at a time. Left alone
+ * the list grows with every pad this user has ever opened, until the
+ * listing alone can spend the revoke budget — at which point a logout
+ * revokes nothing.
+ */
+class ExpiredSessionCollectorTest extends TestCase {
+	private const AUTHOR = 'a.author';
+
+	/** @return array{groupID:string,validUntil:int} */
+	private static function expired(): array {
+		return ['groupID' => 'g.AAAAAAAAAAAAAAAA', 'validUntil' => time() - 60];
+	}
+
+	/** @return array{groupID:string,validUntil:int} */
+	private static function live(): array {
+		return ['groupID' => 'g.AAAAAAAAAAAAAAAA', 'validUntil' => time() + 3600];
+	}
+
+	/** @return array<string,array{groupID:string,validUntil:int}> */
+	private static function expiredSessions(int $count, string $prefix = 's.old'): array {
+		$sessions = [];
+		for ($i = 0; $i < $count; $i++) {
+			$sessions[$prefix . $i] = self::expired();
+		}
+		return $sessions;
+	}
+
+	public function testLeavesANoteOnceTheBacklogIsWorthSweeping(): void {
+		$jobList = $this->createMock(IJobList::class);
+		$jobList->expects(self::once())->method('add')->with(
+			CollectExpiredSessionsJob::class,
+			['uid' => 'alice', 'authorId' => self::AUTHOR],
+		);
+
+		$this->collector($this->createMock(EtherpadClient::class), $jobList)
+			->noteBacklog('alice', self::AUTHOR, self::expiredSessions(50));
+	}
+
+	/**
+	 * A day of ordinary use leaves a handful behind. Queueing a sweep for
+	 * those would put a row in the job table on nearly every logout.
+	 */
+	public function testSaysNothingAboutAHandful(): void {
+		$jobList = $this->createMock(IJobList::class);
+		$jobList->expects(self::never())->method('add');
+
+		$this->collector($this->createMock(EtherpadClient::class), $jobList)
+			->noteBacklog('alice', self::AUTHOR, self::expiredSessions(49));
+	}
+
+	/** Live sessions are not a backlog; they are the thing being protected. */
+	public function testDoesNotCountLiveSessionsAsBacklog(): void {
+		$jobList = $this->createMock(IJobList::class);
+		$jobList->expects(self::never())->method('add');
+
+		$sessions = [];
+		for ($i = 0; $i < 80; $i++) {
+			$sessions['s.live' . $i] = self::live();
+		}
+
+		$this->collector($this->createMock(EtherpadClient::class), $jobList)
+			->noteBacklog('alice', self::AUTHOR, $sessions);
+	}
+
+	public function testDeletesTheExpiredOnesAndLeavesTheLiveOnesAlone(): void {
+		$client = $this->createMock(EtherpadClient::class);
+		$client->method('listSessionsOfAuthor')->willReturn([
+			's.old' => self::expired(),
+			's.live' => self::live(),
+			's.older' => self::expired(),
+		]);
+		$removed = [];
+		$client->method('deleteSession')->willReturnCallback(
+			static function (string $id) use (&$removed): void {
+				$removed[] = $id;
+			}
+		);
+
+		$result = $this->collector($client)->collect('alice', self::AUTHOR);
+
+		self::assertSame(['s.old', 's.older'], $removed);
+		self::assertSame(['deleted' => 2, 'remaining' => 0], $result);
+	}
+
+	/**
+	 * The ceiling has to be reported honestly, because the job decides
+	 * whether to come back from this number alone.
+	 */
+	public function testReportsWhatDidNotFitInOneRun(): void {
+		$client = $this->createMock(EtherpadClient::class);
+		$client->method('listSessionsOfAuthor')->willReturn(self::expiredSessions(400));
+
+		$result = $this->collector($client)->collect('alice', self::AUTHOR);
+
+		self::assertSame(250, $result['deleted']);
+		self::assertSame(150, $result['remaining']);
+	}
+
+	/**
+	 * A session somebody else removed in the meantime is the outcome asked
+	 * for, so it counts as handled — otherwise the job would come back for
+	 * work that no longer exists.
+	 */
+	public function testCountsAnAlreadyGoneSessionAsDone(): void {
+		$client = $this->createMock(EtherpadClient::class);
+		$client->method('listSessionsOfAuthor')->willReturn([
+			's.old' => self::expired(),
+			's.gone' => self::expired(),
+		]);
+		$client->method('deleteSession')->willReturnCallback(
+			static function (string $id): void {
+				if ($id === 's.gone') {
+					throw new EtherpadClientException('sessionID does not exist');
+				}
+			}
+		);
+
+		$result = $this->collector($client)->collect('alice', self::AUTHOR);
+
+		self::assertSame(1, $result['deleted']);
+		self::assertSame(0, $result['remaining'], 'a session that is already gone is not left over');
+	}
+
+	/**
+	 * The ceiling counts what was dealt with, not what this run deleted.
+	 * An author whose backlog was already cleared by somebody else would
+	 * otherwise never reach it and walk the whole index in one run — the
+	 * ceiling would exist only for the happy path.
+	 */
+	public function testAnAlreadyClearedBacklogStillHitsTheCeiling(): void {
+		$client = $this->createMock(EtherpadClient::class);
+		$client->method('listSessionsOfAuthor')->willReturn(self::expiredSessions(400));
+		$calls = 0;
+		$client->method('deleteSession')->willReturnCallback(
+			static function () use (&$calls): void {
+				$calls++;
+				throw new EtherpadClientException('sessionID does not exist');
+			}
+		);
+
+		$result = $this->collector($client)->collect('alice', self::AUTHOR);
+
+		self::assertSame(250, $calls, 'the run should stop at the ceiling, not walk the whole index');
+		self::assertSame(['deleted' => 0, 'remaining' => 150], $result);
+	}
+
+	/**
+	 * A pad server refusing this call refuses the next one too. Stopping
+	 * keeps one broken sweep from writing hundreds of warnings, and the
+	 * count left over is what makes the job try again later.
+	 */
+	public function testStopsAtTheFirstRealFailureAndSaysWhatIsLeft(): void {
+		$client = $this->createMock(EtherpadClient::class);
+		$client->method('listSessionsOfAuthor')->willReturn(self::expiredSessions(10));
+		$calls = 0;
+		$client->method('deleteSession')->willReturnCallback(
+			static function () use (&$calls): void {
+				$calls++;
+				throw new EtherpadClientException('Connection timed out');
+			}
+		);
+		$logger = $this->createMock(LoggerInterface::class);
+		$logger->expects(self::once())->method('warning');
+
+		$result = $this->collector($client, logger: $logger)->collect('alice', self::AUTHOR);
+
+		self::assertSame(1, $calls, 'one failure is enough to know the rest will fail too');
+		self::assertSame(['deleted' => 0, 'remaining' => 10], $result);
+	}
+
+	/** Nothing about collecting may take a pad server outage further. */
+	public function testSurvivesAnUnreachablePadServer(): void {
+		$client = $this->createMock(EtherpadClient::class);
+		$client->method('listSessionsOfAuthor')
+			->willThrowException(new EtherpadClientException('Connection timed out'));
+
+		self::assertSame(
+			['deleted' => 0, 'remaining' => 0],
+			$this->collector($client)->collect('alice', self::AUTHOR),
+		);
+	}
+
+	private function collector(
+		EtherpadClient $client,
+		?IJobList $jobList = null,
+		?LoggerInterface $logger = null,
+	): ExpiredSessionCollector {
+		return new ExpiredSessionCollector(
+			$client,
+			$jobList ?? $this->createMock(IJobList::class),
+			$logger ?? $this->createMock(LoggerInterface::class),
+		);
+	}
+}

--- a/tests/phpunit/unit/ExpiredSessionCollectorTest.php
+++ b/tests/phpunit/unit/ExpiredSessionCollectorTest.php
@@ -53,7 +53,7 @@ class ExpiredSessionCollectorTest extends TestCase {
 		return $sessions;
 	}
 
-	public function testLeavesANoteOnceTheBacklogIsWorthSweeping(): void {
+	public function testQueuesASweepForTheAuthorThatJustOpenedAPad(): void {
 		$jobList = $this->createMock(IJobList::class);
 		$jobList->method('has')->willReturn(false);
 		$jobList->expects(self::once())->method('add')->with(
@@ -62,29 +62,66 @@ class ExpiredSessionCollectorTest extends TestCase {
 		);
 
 		$this->collector($this->createMock(EtherpadClient::class), $jobList)
-			->noteBacklog('alice', self::AUTHOR, self::expiredSessions(50));
+			->noteAuthor('alice', self::AUTHOR);
 	}
 
 	/**
-	 * A day of ordinary use leaves a handful behind. Queueing a sweep for
-	 * those would put a row in the job table on nearly every logout.
+	 * Without asking whether there is anything to collect. Finding that out
+	 * is the listing, and the listing is the call this class exists to keep
+	 * out of a request.
 	 */
-	public function testSaysNothingAboutAHandful(): void {
+	public function testAsksThePadServerNothingWhileQueueing(): void {
+		$client = $this->createMock(EtherpadClient::class);
+		$client->expects(self::never())->method('listSessionsOfAuthor');
+
+		$this->collector($client)->noteAuthor('alice', self::AUTHOR);
+	}
+
+	/**
+	 * A public link has no cached author state, but it does have an author
+	 * id at the moment it opens — and every visitor of one link writes to
+	 * that same index, which makes it the fastest-growing one there is.
+	 */
+	public function testQueuesForAnAnonymousPublicShareAuthorToo(): void {
+		$jobList = $this->createMock(IJobList::class);
+		$jobList->method('has')->willReturn(false);
+		$jobList->expects(self::once())->method('add')->with(
+			CollectExpiredSessionsJob::class,
+			['uid' => 'public-share:tok', 'authorId' => self::AUTHOR],
+		);
+
+		$this->collector($this->createMock(EtherpadClient::class), $jobList)
+			->noteAuthor('public-share:tok', self::AUTHOR);
+	}
+
+	/** No author means nothing was ever issued under one. */
+	public function testQueuesNothingWithoutAnAuthor(): void {
 		$jobList = $this->createMock(IJobList::class);
 		$jobList->expects(self::never())->method('add');
 
 		$this->collector($this->createMock(EtherpadClient::class), $jobList)
-			->noteBacklog('alice', self::AUTHOR, self::expiredSessions(49));
+			->noteAuthor('alice', '');
 	}
 
 	/**
-	 * A retry that is deliberately waiting counts as queued.
-	 *
-	 * It carries its attempt in the argument so an open cannot reset its
-	 * backoff, and the job list matches arguments exactly — so asking only
-	 * about the plain form would miss it and add a second row that the next
-	 * cron runs at once. That is the loop the backoff exists to prevent,
-	 * reached from the other side.
+	 * A second note would not be ignored: Nextcloud updates the row and
+	 * clears last_run and reserved_at, so a sweep deliberately scheduled a
+	 * minute out would be released by the next pad open.
+	 */
+	public function testDoesNotTouchANoteThatIsAlreadyThere(): void {
+		$jobList = $this->createMock(IJobList::class);
+		$jobList->method('has')->willReturn(true);
+		$jobList->expects(self::never())->method('add');
+
+		$this->collector($this->createMock(EtherpadClient::class), $jobList)
+			->noteAuthor('alice', self::AUTHOR);
+	}
+
+	/**
+	 * A retry that is deliberately waiting counts as queued. It carries its
+	 * attempt in the argument so an open cannot reset its backoff, and the
+	 * job list matches arguments exactly — so asking only about the plain
+	 * form would add a second row that the next cron runs at once.
 	 */
 	public function testSeesARetryThatIsAlreadyWaiting(): void {
 		$jobList = $this->createMock(IJobList::class);
@@ -95,35 +132,22 @@ class ExpiredSessionCollectorTest extends TestCase {
 		$jobList->expects(self::never())->method('add');
 
 		$this->collector($this->createMock(EtherpadClient::class), $jobList)
-			->noteBacklog('alice', self::AUTHOR, self::expiredSessions(80));
-	}
-
-	/** Live sessions are not a backlog; they are the thing being protected. */
-	public function testDoesNotCountLiveSessionsAsBacklog(): void {
-		$jobList = $this->createMock(IJobList::class);
-		$jobList->expects(self::never())->method('add');
-
-		$sessions = [];
-		for ($i = 0; $i < 80; $i++) {
-			$sessions['s.live' . $i] = self::live();
-		}
-
-		$this->collector($this->createMock(EtherpadClient::class), $jobList)
-			->noteBacklog('alice', self::AUTHOR, $sessions);
+			->noteAuthor('alice', self::AUTHOR);
 	}
 
 	/**
-	 * A second note would not be ignored: Nextcloud updates the row and
-	 * clears last_run and reserved_at, so a sweep this job deliberately put
-	 * a minute out would be released by the next pad open.
+	 * Queueing is housekeeping, and housekeeping may not be why a pad fails
+	 * to open. Both calls behind it touch Nextcloud's database from inside
+	 * a request somebody is waiting on.
 	 */
-	public function testDoesNotTouchANoteThatIsAlreadyThere(): void {
+	public function testAnUnreachableJobTableDoesNotBreakTheOpen(): void {
 		$jobList = $this->createMock(IJobList::class);
-		$jobList->method('has')->willReturn(true);
-		$jobList->expects(self::never())->method('add');
+		$jobList->method('has')->willThrowException(new \RuntimeException('Deadlock found'));
+		$logger = $this->createMock(LoggerInterface::class);
+		$logger->expects(self::once())->method('warning');
 
-		$this->collector($this->createMock(EtherpadClient::class), $jobList)
-			->noteBacklog('alice', self::AUTHOR, self::expiredSessions(80));
+		$this->collector($this->createMock(EtherpadClient::class), $jobList, $logger)
+			->noteAuthor('alice', self::AUTHOR);
 	}
 
 	public function testDeletesTheExpiredOnesAndLeavesTheLiveOnesAlone(): void {
@@ -356,36 +380,6 @@ class ExpiredSessionCollectorTest extends TestCase {
 		$client->expects(self::once())->method('deleteSession')->with('s.longago');
 
 		self::assertSame(1, $this->collector($client)->collect('alice', self::AUTHOR)['deleted']);
-	}
-
-	/** And the same session does not count towards queueing a sweep either. */
-	public function testDoesNotCountAFreshlyExpiredSessionAsBacklog(): void {
-		$jobList = $this->createMock(IJobList::class);
-		$jobList->method('has')->willReturn(false);
-		$jobList->expects(self::never())->method('add');
-
-		$sessions = [];
-		for ($i = 0; $i < 80; $i++) {
-			$sessions['s.just' . $i] = self::justExpired();
-		}
-
-		$this->collector($this->createMock(EtherpadClient::class), $jobList)
-			->noteBacklog('alice', self::AUTHOR, $sessions);
-	}
-
-	/**
-	 * Queueing is housekeeping, and housekeeping may not be why a pad fails
-	 * to open. Both calls behind this touch Nextcloud's database from
-	 * inside a request somebody is waiting on.
-	 */
-	public function testAnUnreachableJobTableDoesNotBreakTheOpen(): void {
-		$jobList = $this->createMock(IJobList::class);
-		$jobList->method('has')->willThrowException(new \RuntimeException('Deadlock found'));
-		$logger = $this->createMock(LoggerInterface::class);
-		$logger->expects(self::once())->method('warning');
-
-		$this->collector($this->createMock(EtherpadClient::class), $jobList, $logger)
-			->noteBacklog('alice', self::AUTHOR, self::expiredSessions(80));
 	}
 
 	/** Nothing about collecting may take a pad server outage further. */

--- a/tests/phpunit/unit/ExpiredSessionCollectorTest.php
+++ b/tests/phpunit/unit/ExpiredSessionCollectorTest.php
@@ -118,6 +118,37 @@ class ExpiredSessionCollectorTest extends TestCase {
 	}
 
 	/**
+	 * Every delete carries the run's own timeout, not the client's.
+	 *
+	 * A deadline checked between calls says when the last one may start,
+	 * never when it must end. With the client's standard timeout a delete
+	 * begun just under the deadline runs far past it, and the budget stops
+	 * describing the run at all — the number it advertises would be short
+	 * by a whole timeout.
+	 *
+	 * The deadline is taken before the listing, so a slow listing comes out
+	 * of the same budget rather than being added to it.
+	 */
+	public function testGivesEveryDeleteWhatIsLeftOfTheBudget(): void {
+		$client = $this->createMock(EtherpadClient::class);
+		$client->method('listSessionsOfAuthor')->willReturn(self::expiredSessions(3));
+		$timeouts = [];
+		$client->expects(self::exactly(3))->method('deleteSession')->willReturnCallback(
+			static function (string $id, ?int $timeoutSeconds = null) use (&$timeouts): void {
+				$timeouts[] = $timeoutSeconds;
+			}
+		);
+
+		$this->collector($client)->collect('alice', self::AUTHOR);
+
+		foreach ($timeouts as $timeout) {
+			self::assertNotNull($timeout, 'a delete was issued with the client default');
+			self::assertGreaterThanOrEqual(2, $timeout, 'never issue an already-dead timeout');
+			self::assertLessThanOrEqual(20, $timeout, 'never more patient than the whole budget');
+		}
+	}
+
+	/**
 	 * The ceiling has to be reported honestly, because the job decides
 	 * whether to come back from this number alone.
 	 */

--- a/tests/phpunit/unit/ExpiredSessionCollectorTest.php
+++ b/tests/phpunit/unit/ExpiredSessionCollectorTest.php
@@ -287,6 +287,31 @@ class ExpiredSessionCollectorTest extends TestCase {
 	}
 
 	/**
+	 * An Etherpad that keeps index entries it cannot describe says so in
+	 * the log, rather than letting a sweep look clean.
+	 *
+	 * Those keys cost a lookup on every listing and `deleteSession` will
+	 * not take them, so collecting cannot shrink that part of the index —
+	 * on such a server this whole feature is not the remedy it is here, and
+	 * an admin should be able to find that out from the log rather than by
+	 * reading the pad server's source.
+	 */
+	public function testSaysWhenTheIndexHoldsEntriesItCannotCollect(): void {
+		$client = $this->createMock(EtherpadClient::class);
+		$client->method('listSessionsOfAuthor')->willReturnCallback(
+			static function (string $authorId, ?int $timeout = null, ?int &$unreadable = null): array {
+				$unreadable = 7;
+				return [];
+			}
+		);
+		$logger = $this->createMock(LoggerInterface::class);
+		$logger->expects(self::once())->method('warning')
+			->with(self::stringContains('cannot describe'), self::anything());
+
+		$this->collector($client, logger: $logger)->collect(self::AUTHOR);
+	}
+
+	/**
 	 * The ceiling has to be reported honestly, because the job decides
 	 * whether to come back from this number alone.
 	 */

--- a/tests/phpunit/unit/ExpiredSessionCollectorTest.php
+++ b/tests/phpunit/unit/ExpiredSessionCollectorTest.php
@@ -58,11 +58,11 @@ class ExpiredSessionCollectorTest extends TestCase {
 		$jobList->method('has')->willReturn(false);
 		$jobList->expects(self::once())->method('add')->with(
 			CollectExpiredSessionsJob::class,
-			['uid' => 'alice', 'authorId' => self::AUTHOR],
+			['authorId' => self::AUTHOR],
 		);
 
 		$this->collector($this->createMock(EtherpadClient::class), $jobList)
-			->noteAuthor('alice', self::AUTHOR);
+			->noteAuthor(self::AUTHOR);
 	}
 
 	/**
@@ -74,7 +74,7 @@ class ExpiredSessionCollectorTest extends TestCase {
 		$client = $this->createMock(EtherpadClient::class);
 		$client->expects(self::never())->method('listSessionsOfAuthor');
 
-		$this->collector($client)->noteAuthor('alice', self::AUTHOR);
+		$this->collector($client)->noteAuthor(self::AUTHOR);
 	}
 
 	/**
@@ -87,11 +87,11 @@ class ExpiredSessionCollectorTest extends TestCase {
 		$jobList->method('has')->willReturn(false);
 		$jobList->expects(self::once())->method('add')->with(
 			CollectExpiredSessionsJob::class,
-			['uid' => 'public-share:tok', 'authorId' => self::AUTHOR],
+			['authorId' => self::AUTHOR],
 		);
 
 		$this->collector($this->createMock(EtherpadClient::class), $jobList)
-			->noteAuthor('public-share:tok', self::AUTHOR);
+			->noteAuthor(self::AUTHOR);
 	}
 
 	/** No author means nothing was ever issued under one. */
@@ -100,7 +100,7 @@ class ExpiredSessionCollectorTest extends TestCase {
 		$jobList->expects(self::never())->method('add');
 
 		$this->collector($this->createMock(EtherpadClient::class), $jobList)
-			->noteAuthor('alice', '');
+			->noteAuthor('');
 	}
 
 	/**
@@ -114,7 +114,7 @@ class ExpiredSessionCollectorTest extends TestCase {
 		$jobList->expects(self::never())->method('add');
 
 		$this->collector($this->createMock(EtherpadClient::class), $jobList)
-			->noteAuthor('alice', self::AUTHOR);
+			->noteAuthor(self::AUTHOR);
 	}
 
 	/**
@@ -132,7 +132,7 @@ class ExpiredSessionCollectorTest extends TestCase {
 		$jobList->expects(self::never())->method('add');
 
 		$this->collector($this->createMock(EtherpadClient::class), $jobList)
-			->noteAuthor('alice', self::AUTHOR);
+			->noteAuthor(self::AUTHOR);
 	}
 
 	/**
@@ -147,7 +147,7 @@ class ExpiredSessionCollectorTest extends TestCase {
 		$logger->expects(self::once())->method('warning');
 
 		$this->collector($this->createMock(EtherpadClient::class), $jobList, $logger)
-			->noteAuthor('alice', self::AUTHOR);
+			->noteAuthor(self::AUTHOR);
 	}
 
 	public function testDeletesTheExpiredOnesAndLeavesTheLiveOnesAlone(): void {
@@ -164,10 +164,16 @@ class ExpiredSessionCollectorTest extends TestCase {
 			}
 		);
 
-		$result = $this->collector($client)->collect('alice', self::AUTHOR);
+		$result = $this->collector($client)->collect(self::AUTHOR);
 
 		self::assertSame(['s.old', 's.older'], $removed);
-		self::assertSame(['deleted' => 2, 'remaining' => 0, 'retry' => false], $result);
+		self::assertSame(2, $result['deleted']);
+		self::assertSame(0, $result['remaining']);
+		self::assertFalse($result['retry']);
+		self::assertNotNull(
+			$result['nextDueAt'],
+			'the live session it left alone is what the next run comes back for',
+		);
 	}
 
 	/**
@@ -192,7 +198,7 @@ class ExpiredSessionCollectorTest extends TestCase {
 			}
 		);
 
-		$this->collector($client)->collect('alice', self::AUTHOR);
+		$this->collector($client)->collect(self::AUTHOR);
 
 		foreach ($timeouts as $timeout) {
 			self::assertNotNull($timeout, 'a delete was issued with the client default');
@@ -218,9 +224,9 @@ class ExpiredSessionCollectorTest extends TestCase {
 		$client->method('listSessionsOfAuthor')->willReturn(self::expiredSessions(5));
 		$client->expects(self::never())->method('deleteSession');
 
-		$result = $this->collector($client, budgetSeconds: 0.3)->collect('alice', self::AUTHOR);
+		$result = $this->collector($client, budgetSeconds: 0.3)->collect(self::AUTHOR);
 
-		self::assertSame(['deleted' => 0, 'remaining' => 5, 'retry' => false], $result);
+		self::assertSame(['deleted' => 0, 'remaining' => 5, 'retry' => false, 'nextDueAt' => null], $result);
 	}
 
 	/**
@@ -241,12 +247,43 @@ class ExpiredSessionCollectorTest extends TestCase {
 			}
 		);
 
-		$this->collector($client)->collect('alice', self::AUTHOR);
+		$this->collector($client)->collect(self::AUTHOR);
 
 		self::assertNotSame('unset', $seen);
 		self::assertNotNull($seen, 'the listing went out with the client default');
 		self::assertGreaterThanOrEqual(1, $seen);
 		self::assertLessThanOrEqual(15, $seen);
+	}
+
+	/**
+	 * A sweep that found nothing to do says when there will be.
+	 *
+	 * Otherwise the very next open queues another full walk of the index:
+	 * a busy public link would have one behind every visitor, for as long
+	 * as a session lives, over the one author they all share. The answer is
+	 * already in the listing this run paid for.
+	 */
+	public function testSaysWhenTheEarliestSessionBecomesCollectable(): void {
+		$soon = time() + 600;
+		$client = $this->createMock(EtherpadClient::class);
+		$client->method('listSessionsOfAuthor')->willReturn([
+			's.later' => ['groupID' => 'g.AAAAAAAAAAAAAAAA', 'validUntil' => time() + 3600],
+			's.soon' => ['groupID' => 'g.AAAAAAAAAAAAAAAA', 'validUntil' => $soon],
+		]);
+		$client->expects(self::never())->method('deleteSession');
+
+		$result = $this->collector($client)->collect(self::AUTHOR);
+
+		self::assertSame(0, $result['deleted']);
+		self::assertSame($soon + 300, $result['nextDueAt'], 'the earliest one, plus the grace');
+	}
+
+	/** An author holding nothing has nothing to come back for. */
+	public function testHasNoDueTimeWhenTheAuthorHoldsNothing(): void {
+		$client = $this->createMock(EtherpadClient::class);
+		$client->method('listSessionsOfAuthor')->willReturn([]);
+
+		self::assertNull($this->collector($client)->collect(self::AUTHOR)['nextDueAt']);
 	}
 
 	/**
@@ -257,7 +294,7 @@ class ExpiredSessionCollectorTest extends TestCase {
 		$client = $this->createMock(EtherpadClient::class);
 		$client->method('listSessionsOfAuthor')->willReturn(self::expiredSessions(400));
 
-		$result = $this->collector($client)->collect('alice', self::AUTHOR);
+		$result = $this->collector($client)->collect(self::AUTHOR);
 
 		self::assertSame(250, $result['deleted']);
 		self::assertSame(150, $result['remaining']);
@@ -282,7 +319,7 @@ class ExpiredSessionCollectorTest extends TestCase {
 			}
 		);
 
-		$result = $this->collector($client)->collect('alice', self::AUTHOR);
+		$result = $this->collector($client)->collect(self::AUTHOR);
 
 		self::assertSame(1, $result['deleted']);
 		self::assertSame(0, $result['remaining'], 'a session that is already gone is not left over');
@@ -305,10 +342,10 @@ class ExpiredSessionCollectorTest extends TestCase {
 			}
 		);
 
-		$result = $this->collector($client)->collect('alice', self::AUTHOR);
+		$result = $this->collector($client)->collect(self::AUTHOR);
 
 		self::assertSame(250, $calls, 'the run should stop at the ceiling, not walk the whole index');
-		self::assertSame(['deleted' => 0, 'remaining' => 150, 'retry' => false], $result);
+		self::assertSame(['deleted' => 0, 'remaining' => 150, 'retry' => false, 'nextDueAt' => null], $result);
 	}
 
 	/**
@@ -335,7 +372,7 @@ class ExpiredSessionCollectorTest extends TestCase {
 			}
 		);
 
-		$result = $this->collector($client)->collect('alice', self::AUTHOR);
+		$result = $this->collector($client)->collect(self::AUTHOR);
 
 		self::assertSame(2, $result['deleted'], 'the entries behind the poison one should still go');
 		self::assertSame(1, $result['remaining'], 'and the poison one is what is left');
@@ -357,10 +394,10 @@ class ExpiredSessionCollectorTest extends TestCase {
 			}
 		);
 
-		$result = $this->collector($client)->collect('alice', self::AUTHOR);
+		$result = $this->collector($client)->collect(self::AUTHOR);
 
 		self::assertSame(5, $calls, 'a run puts up with a handful of refusals, not a hundred');
-		self::assertSame(['deleted' => 0, 'remaining' => 100, 'retry' => true], $result);
+		self::assertSame(['deleted' => 0, 'remaining' => 100, 'retry' => true, 'nextDueAt' => null], $result);
 	}
 
 
@@ -379,7 +416,7 @@ class ExpiredSessionCollectorTest extends TestCase {
 		]);
 		$client->expects(self::once())->method('deleteSession')->with('s.longago');
 
-		self::assertSame(1, $this->collector($client)->collect('alice', self::AUTHOR)['deleted']);
+		self::assertSame(1, $this->collector($client)->collect(self::AUTHOR)['deleted']);
 	}
 
 	/** Nothing about collecting may take a pad server outage further. */
@@ -389,8 +426,8 @@ class ExpiredSessionCollectorTest extends TestCase {
 			->willThrowException(new EtherpadClientException('Connection timed out'));
 
 		self::assertSame(
-			['deleted' => 0, 'remaining' => 0, 'retry' => true],
-			$this->collector($client)->collect('alice', self::AUTHOR),
+			['deleted' => 0, 'remaining' => 0, 'retry' => true, 'nextDueAt' => null],
+			$this->collector($client)->collect(self::AUTHOR),
 			'a failed listing is a retry, not an empty backlog',
 		);
 	}

--- a/tests/phpunit/unit/ExpiredSessionCollectorTest.php
+++ b/tests/phpunit/unit/ExpiredSessionCollectorTest.php
@@ -444,6 +444,33 @@ class ExpiredSessionCollectorTest extends TestCase {
 		self::assertSame(1, $this->collector($client)->collect(self::AUTHOR)['deleted']);
 	}
 
+	/**
+	 * A session id is the value of the `sessionID` cookie — the credential
+	 * itself — and this branch is reached for sessions the pad server may
+	 * still accept. A digest correlates the same entry across runs without
+	 * writing the credential into a log that outlives it.
+	 */
+	public function testDoesNotWriteASessionIdIntoTheLog(): void {
+		$client = $this->createMock(EtherpadClient::class);
+		$client->method('listSessionsOfAuthor')->willReturn(['s.secretsecret123' => self::expired()]);
+		$client->method('deleteSession')->willThrowException(new EtherpadClientException('internal error'));
+
+		$seen = [];
+		$logger = $this->createMock(LoggerInterface::class);
+		$logger->method('warning')->willReturnCallback(
+			static function (string $message, array $context) use (&$seen): void {
+				$seen[] = json_encode($context);
+			}
+		);
+
+		$this->collector($client, logger: $logger)->collect(self::AUTHOR);
+
+		self::assertNotSame([], $seen, 'the refusal should have been logged at all');
+		foreach ($seen as $context) {
+			self::assertStringNotContainsString('s.secretsecret123', $context);
+		}
+	}
+
 	/** Nothing about collecting may take a pad server outage further. */
 	public function testSurvivesAnUnreachablePadServer(): void {
 		$client = $this->createMock(EtherpadClient::class);

--- a/tests/phpunit/unit/ExpiredSessionCollectorTest.php
+++ b/tests/phpunit/unit/ExpiredSessionCollectorTest.php
@@ -77,6 +77,27 @@ class ExpiredSessionCollectorTest extends TestCase {
 			->noteBacklog('alice', self::AUTHOR, self::expiredSessions(49));
 	}
 
+	/**
+	 * A retry that is deliberately waiting counts as queued.
+	 *
+	 * It carries its attempt in the argument so an open cannot reset its
+	 * backoff, and the job list matches arguments exactly — so asking only
+	 * about the plain form would miss it and add a second row that the next
+	 * cron runs at once. That is the loop the backoff exists to prevent,
+	 * reached from the other side.
+	 */
+	public function testSeesARetryThatIsAlreadyWaiting(): void {
+		$jobList = $this->createMock(IJobList::class);
+		$jobList->method('has')->willReturnCallback(
+			static fn (string $job, mixed $argument): bool => is_array($argument)
+				&& ($argument['attempt'] ?? 0) === 3
+		);
+		$jobList->expects(self::never())->method('add');
+
+		$this->collector($this->createMock(EtherpadClient::class), $jobList)
+			->noteBacklog('alice', self::AUTHOR, self::expiredSessions(80));
+	}
+
 	/** Live sessions are not a backlog; they are the thing being protected. */
 	public function testDoesNotCountLiveSessionsAsBacklog(): void {
 		$jobList = $this->createMock(IJobList::class);
@@ -237,13 +258,43 @@ class ExpiredSessionCollectorTest extends TestCase {
 	}
 
 	/**
-	 * A pad server refusing this call refuses the next one too. Stopping
-	 * keeps one broken sweep from writing hundreds of warnings, and the
-	 * count left over is what makes the job try again later.
+	 * One session Etherpad will never delete must not shadow the rest.
+	 *
+	 * Stopping at the first refusal put that entry in front of everything
+	 * behind it for good: the next run re-lists, meets it first, stops
+	 * again, and the backlog never moves while every pad open re-queues the
+	 * same doomed sweep. The sibling loop in PendingDeleteRetryService
+	 * counts a failure and carries on for the same reason.
 	 */
-	public function testStopsAtTheFirstRealFailureAndSaysWhatIsLeft(): void {
+	public function testAPoisonEntryDoesNotShadowTheOnesBehindIt(): void {
 		$client = $this->createMock(EtherpadClient::class);
-		$client->method('listSessionsOfAuthor')->willReturn(self::expiredSessions(10));
+		$client->method('listSessionsOfAuthor')->willReturn([
+			's.poison' => self::expired(),
+			's.one' => self::expired(),
+			's.two' => self::expired(),
+		]);
+		$client->method('deleteSession')->willReturnCallback(
+			static function (string $id): void {
+				if ($id === 's.poison') {
+					throw new EtherpadClientException('internal error');
+				}
+			}
+		);
+
+		$result = $this->collector($client)->collect('alice', self::AUTHOR);
+
+		self::assertSame(2, $result['deleted'], 'the entries behind the poison one should still go');
+		self::assertSame(1, $result['remaining'], 'and the poison one is what is left');
+		self::assertTrue($result['retry'], 'a refusal still asks for the backoff');
+	}
+
+	/**
+	 * The other reading of a refusal is that the server is down, and then
+	 * there is nothing to be gained by asking two hundred more times.
+	 */
+	public function testGivesUpOnARunThatKeepsBeingRefused(): void {
+		$client = $this->createMock(EtherpadClient::class);
+		$client->method('listSessionsOfAuthor')->willReturn(self::expiredSessions(100));
 		$calls = 0;
 		$client->method('deleteSession')->willReturnCallback(
 			static function () use (&$calls): void {
@@ -251,14 +302,13 @@ class ExpiredSessionCollectorTest extends TestCase {
 				throw new EtherpadClientException('Connection timed out');
 			}
 		);
-		$logger = $this->createMock(LoggerInterface::class);
-		$logger->expects(self::once())->method('warning');
 
-		$result = $this->collector($client, logger: $logger)->collect('alice', self::AUTHOR);
+		$result = $this->collector($client)->collect('alice', self::AUTHOR);
 
-		self::assertSame(1, $calls, 'one failure is enough to know the rest will fail too');
-		self::assertSame(['deleted' => 0, 'remaining' => 10, 'retry' => true], $result);
+		self::assertSame(5, $calls, 'a run puts up with a handful of refusals, not a hundred');
+		self::assertSame(['deleted' => 0, 'remaining' => 100, 'retry' => true], $result);
 	}
+
 
 	/**
 	 * Nextcloud computes validUntil; Etherpad judges it against its own

--- a/tests/phpunit/unit/ExpiredSessionCollectorTest.php
+++ b/tests/phpunit/unit/ExpiredSessionCollectorTest.php
@@ -47,6 +47,7 @@ class ExpiredSessionCollectorTest extends TestCase {
 
 	public function testLeavesANoteOnceTheBacklogIsWorthSweeping(): void {
 		$jobList = $this->createMock(IJobList::class);
+		$jobList->method('has')->willReturn(false);
 		$jobList->expects(self::once())->method('add')->with(
 			CollectExpiredSessionsJob::class,
 			['uid' => 'alice', 'authorId' => self::AUTHOR],
@@ -82,6 +83,20 @@ class ExpiredSessionCollectorTest extends TestCase {
 			->noteBacklog('alice', self::AUTHOR, $sessions);
 	}
 
+	/**
+	 * A second note would not be ignored: Nextcloud updates the row and
+	 * clears last_run and reserved_at, so a sweep this job deliberately put
+	 * a minute out would be released by the next pad open.
+	 */
+	public function testDoesNotTouchANoteThatIsAlreadyThere(): void {
+		$jobList = $this->createMock(IJobList::class);
+		$jobList->method('has')->willReturn(true);
+		$jobList->expects(self::never())->method('add');
+
+		$this->collector($this->createMock(EtherpadClient::class), $jobList)
+			->noteBacklog('alice', self::AUTHOR, self::expiredSessions(80));
+	}
+
 	public function testDeletesTheExpiredOnesAndLeavesTheLiveOnesAlone(): void {
 		$client = $this->createMock(EtherpadClient::class);
 		$client->method('listSessionsOfAuthor')->willReturn([
@@ -99,7 +114,7 @@ class ExpiredSessionCollectorTest extends TestCase {
 		$result = $this->collector($client)->collect('alice', self::AUTHOR);
 
 		self::assertSame(['s.old', 's.older'], $removed);
-		self::assertSame(['deleted' => 2, 'remaining' => 0], $result);
+		self::assertSame(['deleted' => 2, 'remaining' => 0, 'retry' => false], $result);
 	}
 
 	/**
@@ -161,7 +176,7 @@ class ExpiredSessionCollectorTest extends TestCase {
 		$result = $this->collector($client)->collect('alice', self::AUTHOR);
 
 		self::assertSame(250, $calls, 'the run should stop at the ceiling, not walk the whole index');
-		self::assertSame(['deleted' => 0, 'remaining' => 150], $result);
+		self::assertSame(['deleted' => 0, 'remaining' => 150, 'retry' => false], $result);
 	}
 
 	/**
@@ -185,7 +200,7 @@ class ExpiredSessionCollectorTest extends TestCase {
 		$result = $this->collector($client, logger: $logger)->collect('alice', self::AUTHOR);
 
 		self::assertSame(1, $calls, 'one failure is enough to know the rest will fail too');
-		self::assertSame(['deleted' => 0, 'remaining' => 10], $result);
+		self::assertSame(['deleted' => 0, 'remaining' => 10, 'retry' => false], $result);
 	}
 
 	/** Nothing about collecting may take a pad server outage further. */
@@ -195,8 +210,9 @@ class ExpiredSessionCollectorTest extends TestCase {
 			->willThrowException(new EtherpadClientException('Connection timed out'));
 
 		self::assertSame(
-			['deleted' => 0, 'remaining' => 0],
+			['deleted' => 0, 'remaining' => 0, 'retry' => true],
 			$this->collector($client)->collect('alice', self::AUTHOR),
+			'a failed listing is a retry, not an empty backlog',
 		);
 	}
 

--- a/tests/phpunit/unit/ExpiredSessionCollectorTest.php
+++ b/tests/phpunit/unit/ExpiredSessionCollectorTest.php
@@ -173,7 +173,11 @@ class ExpiredSessionCollectorTest extends TestCase {
 		foreach ($timeouts as $timeout) {
 			self::assertNotNull($timeout, 'a delete was issued with the client default');
 			self::assertGreaterThanOrEqual(2, $timeout, 'never issue an already-dead timeout');
-			self::assertLessThanOrEqual(20, $timeout, 'never more patient than the whole budget');
+			self::assertLessThanOrEqual(
+				15,
+				$timeout,
+				'housekeeping must not be more patient than the calls a user waits on',
+			);
 		}
 	}
 
@@ -193,6 +197,32 @@ class ExpiredSessionCollectorTest extends TestCase {
 		$result = $this->collector($client, budgetSeconds: 0.3)->collect('alice', self::AUTHOR);
 
 		self::assertSame(['deleted' => 0, 'remaining' => 5, 'retry' => false], $result);
+	}
+
+	/**
+	 * The listing is inside the budget too.
+	 *
+	 * It was the one call in the run that could ignore it, which is
+	 * backwards: it is the expensive call this whole class exists because
+	 * of, so a slow index could spend the run and leave no time to delete
+	 * anything from it.
+	 */
+	public function testTheListingIsBoundedByTheRunsBudgetAsWell(): void {
+		$client = $this->createMock(EtherpadClient::class);
+		$seen = 'unset';
+		$client->method('listSessionsOfAuthor')->willReturnCallback(
+			static function (string $authorId, ?int $timeoutSeconds = null) use (&$seen): array {
+				$seen = $timeoutSeconds;
+				return [];
+			}
+		);
+
+		$this->collector($client)->collect('alice', self::AUTHOR);
+
+		self::assertNotSame('unset', $seen);
+		self::assertNotNull($seen, 'the listing went out with the client default');
+		self::assertGreaterThanOrEqual(1, $seen);
+		self::assertLessThanOrEqual(15, $seen);
 	}
 
 	/**

--- a/tests/phpunit/unit/PadSessionServiceTest.php
+++ b/tests/phpunit/unit/PadSessionServiceTest.php
@@ -63,7 +63,9 @@ class PadSessionServiceTest extends TestCase {
 		$etherpadClient->method('buildPadUrl')->willReturn('https://pad.example.test/p/x');
 
 		$collector = $this->createMock(\OCA\EtherpadNextcloud\Service\ExpiredSessionCollector::class);
-		$collector->expects($this->once())->method('noteAuthor')->with('admin', 'a.author');
+		// The author id alone. For a public link the uid is the share token,
+		// and this argument is persisted in the jobs table.
+		$collector->expects($this->once())->method('noteAuthor')->with('a.author');
 
 		// No incoming cookie: the case the old trigger could never see.
 		$service = $this->buildService(

--- a/tests/phpunit/unit/PadSessionServiceTest.php
+++ b/tests/phpunit/unit/PadSessionServiceTest.php
@@ -26,6 +26,7 @@ class PadSessionServiceTest extends TestCase {
 		string $nextcloudUrl = 'https://cloud.example.test',
 		?string $incomingSessionCookie = null,
 		bool $httpOnlySupported = false,
+		?\OCA\EtherpadNextcloud\Service\ExpiredSessionCollector $collector = null,
 	): PadSessionService {
 		$urlGenerator = $this->createMock(IURLGenerator::class);
 		$urlGenerator->method('getBaseUrl')->willReturn($nextcloudUrl);
@@ -40,8 +41,39 @@ class PadSessionServiceTest extends TestCase {
 			new CookieDomainPolicy(),
 			$releasePolicy,
 			$request,
+			$collector ?? $this->createMock(\OCA\EtherpadNextcloud\Service\ExpiredSessionCollector::class),
 			$this->createMock(LoggerInterface::class),
 		);
+	}
+
+	/**
+	 * The open path is the one that suffers first when the index gets long,
+	 * and it is already holding the listing — so it is where the backlog is
+	 * counted. Nothing is deleted here; a note is left for a job.
+	 */
+	public function testHandsTheListingToTheCollector(): void {
+		$sessions = [
+			$this->sid('carried') => ['groupID' => 'g.ABCDEFGHIJKLMNOP', 'validUntil' => time() - 60],
+		];
+		$etherpadClient = $this->createMock(EtherpadClient::class);
+		$etherpadClient->method('createSession')->willReturn($this->sid('new'));
+		$etherpadClient->method('listSessionsOfAuthor')->willReturn($sessions);
+		$etherpadClient->method('createAuthorIfNotExistsFor')->willReturn('a.author');
+		$etherpadClient->method('buildPadUrl')->willReturn('https://pad.example.test/p/x');
+
+		$collector = $this->createMock(\OCA\EtherpadNextcloud\Service\ExpiredSessionCollector::class);
+		$collector->expects($this->once())->method('noteBacklog')
+			->with('admin', 'a.author', $sessions);
+
+		$service = $this->buildService(
+			$etherpadClient,
+			$this->createMock(IConfig::class),
+			'https://cloud.example.test',
+			$this->sid('carried'),
+			false,
+			$collector,
+		);
+		$service->createProtectedOpenContext('admin', 'Admin', 'g.ABCDEFGHIJKLMNOP$pad-1');
 	}
 
 	/**
@@ -338,6 +370,7 @@ class PadSessionServiceTest extends TestCase {
 			new CookieDomainPolicy(),
 			$this->createMock(\OCA\EtherpadNextcloud\Service\EtherpadReleasePolicy::class),
 			$request,
+			$this->createMock(\OCA\EtherpadNextcloud\Service\ExpiredSessionCollector::class),
 			$logger,
 		);
 

--- a/tests/phpunit/unit/PadSessionServiceTest.php
+++ b/tests/phpunit/unit/PadSessionServiceTest.php
@@ -47,29 +47,30 @@ class PadSessionServiceTest extends TestCase {
 	}
 
 	/**
-	 * The open path is the one that suffers first when the index gets long,
-	 * and it is already holding the listing — so it is where the backlog is
-	 * counted. Nothing is deleted here; a note is left for a job.
+	 * Every protected open leaves the author's id for the sweep, before
+	 * anything is asked of the pad server.
+	 *
+	 * Not "when a backlog is noticed": noticing one needs the listing, and
+	 * the listing only happens when the browser carries session ids — so a
+	 * first open made none, and neither does a public link. Both were
+	 * invisible to a sweep that had to be told what to look at.
 	 */
-	public function testHandsTheListingToTheCollector(): void {
-		$sessions = [
-			$this->sid('carried') => ['groupID' => 'g.ABCDEFGHIJKLMNOP', 'validUntil' => time() - 60],
-		];
+	public function testTellsTheCollectorWhoOpenedThePad(): void {
 		$etherpadClient = $this->createMock(EtherpadClient::class);
 		$etherpadClient->method('createSession')->willReturn($this->sid('new'));
-		$etherpadClient->method('listSessionsOfAuthor')->willReturn($sessions);
+		$etherpadClient->expects($this->never())->method('listSessionsOfAuthor');
 		$etherpadClient->method('createAuthorIfNotExistsFor')->willReturn('a.author');
 		$etherpadClient->method('buildPadUrl')->willReturn('https://pad.example.test/p/x');
 
 		$collector = $this->createMock(\OCA\EtherpadNextcloud\Service\ExpiredSessionCollector::class);
-		$collector->expects($this->once())->method('noteBacklog')
-			->with('admin', 'a.author', $sessions);
+		$collector->expects($this->once())->method('noteAuthor')->with('admin', 'a.author');
 
+		// No incoming cookie: the case the old trigger could never see.
 		$service = $this->buildService(
 			$etherpadClient,
 			$this->createMock(IConfig::class),
 			'https://cloud.example.test',
-			$this->sid('carried'),
+			null,
 			false,
 			$collector,
 		);


### PR DESCRIPTION
## Why

Every open of a protected pad mints a fresh Etherpad session – that has been true since 1.0.0, and it is deliberate: Etherpad re-checks `validUntil` on every socket message and holds the id it was handed at connect time, so a fresh session per open is what keeps an already-open pad working. Etherpad never removes one once it expires.

The pile was free while nothing read it. Since 1.1.0-alpha.4 something does: keeping several protected pads open at once (#206) means deciding which of the ids in the cookie are still valid, and that asks `listSessionsOfAuthor` –

```js
for (const sessionID of Object.keys(sessions || {})) {
  sessions[sessionID] = await exports.getSessionInfo(sessionID);
}
```

one awaited lookup per entry, sequential, no expiry filter, and no cleanup anywhere in `SessionManager`. So the cost of opening a pad grows with the number of past opens rather than with the sessions that still grant anything. Timed against Etherpad 3.3.3 on PostgreSQL: 7 ms at 100 sessions, 74 ms at 1000, 252 ms at 4000. On an in-memory store it does not scale at all – it only bites where each lookup is a real query, which is what a production install has.

## What it does

An open leaves the author's id in the job table. A queued job then does both halves: finds out whether there is anything to collect, and collects it – 250 per run inside a 20-second budget, requeueing itself for what did not fit.

**The trigger is the author id, not a backlog somebody noticed.** Finding out whether there is a backlog means the listing, and the listing only happens when the browser carries session ids – so the first open after arriving never made one, and a public link never does, while every visitor of one link writes to that same shared author's index. Both were invisible to a sweep that had to be told where to look. An author id is known on every open.

**It is also all that is written down.** A public link's uid is `public-share:<token>` – the credential out of the share URL – and a job argument is persisted, printed by `occ`, and carried into database dumps. Removed from the argument, the signatures and the log lines rather than redacted, so there is nothing left to remember not to write; an author id maps back to a real user through their own stored setting.

Each bound is one that had to be made real rather than asserted:

| Bound | Why it is not obvious |
|---|---|
| 5-minute grace before deleting | `validUntil` is computed here and judged by Etherpad against its own clock; in the gap, deleting closes a socket someone is typing into |
| No call started that cannot finish | a deadline bounds when the last call *starts*, not when it ends |
| Per-call timeout capped at the client's | otherwise a fast listing hands the first delete nearly the whole budget |
| Client clamps what it is given | `timeout => 0` in Guzzle means no timeout at all |
| Five refusals, not one | stopping at the first lets one undeletable record shadow everything behind it for good |
| Progress is not failure | a run that deleted 200 then hit a refusal continues instead of being given up on |
| Attempt in the job argument | `add()` updates an existing row and clears its schedule, so a note from an open must be a different row |
| A plain row stands down while a retry waits | `QueuedJob` removes its row *before* running, so during a run nothing says a sweep exists |
| A finished sweep requeues at the next due time | otherwise the next open queues another full walk – for a busy public link, one per visitor |
| Both job-list calls guarded | one runs inside a request someone is waiting on; the other after this job's row is already gone |

Also here, because the collector has to ask it and it was wrong on its own: `isAlreadyDeleted` was one string list for every delete path, so a pad delete failing while Etherpad tore down that group's sessions could answer `sessionID does not exist` and be read as "the pad is gone", dropping a binding row for a pad still there. Second predicate, own list, and the tests the classifier never had.

## The assumption underneath

All of this rests on deleting a session taking its id out of the author index, so the listing gets shorter. Etherpad updates that index with `setSub(..., undefined)`, and there are reports of the key surviving on some versions and backends – leaving an id the listing still walks and `deleteSession` will no longer take, since it answers that the session does not exist.

Verified rather than assumed: on a test instance running 2.5.3 against PostgreSQL, a swept author's index record is gone from the store altogether – read in the database, not through the API, which filters exactly the entries a survivor produces. An integration test pins the same property against whatever Etherpad the suite runs, counting raw response keys.

And where it does not hold, the app now notices: the client counts entries it cannot read instead of dropping them, and the sweep names the number in the log. No version gate – an Etherpad that keeps the keys still benefits from having its live expired sessions collected, and refusing to collect at all would trade a real improvement for a hypothetical one.

## Scope

No schema, no migration. This reduces the pile; it does not stop sessions being created – that follows from issuing a fresh session per open, and reuse was tried and dropped because it traded editing time away. Noting each session's id and expiry as it is issued would let the sweep skip the listing entirely; renewing a session instead of minting another would remove the reason for the pile. Both are larger, and the second needs an Etherpad-side API that does not exist yet.

One limit is in the docs rather than left to be discovered: an author nobody opens a pad for is never swept. That costs storage and nothing else, since the cost that matters is paid by whoever reads the index.

## Verification

811 tests / 2816 assertions, Psalm 0 at `errorLevel=4`, Playwright 31 green, vitest 221.

Every bound in the table above was counter-checked by reintroducing the bug and confirming a test fails. The budget is a constructor parameter so a test can reach it – not a setting, since nothing configures it and production only sees the default; a limit no test can drive is how it was wrong the first time.

Exercised end to end on a test instance carrying six months of backlog: one pad open queued the sweep, cron ran it unattended, and two authors went from 820 and 300 records down to the ones that still granted access – about 90 per run, fourteen runs, each requeueing itself, the last ending early and leaving no job behind. No refusals and nothing in the log; the final sweep scheduled itself for the exact second the last live session fell due.
