### PR TITLE
Revoke Etherpad sessions on logout

### DIFF
--- a/docs/etherpad-integration.md
+++ b/docs/etherpad-integration.md
@@ -215,15 +215,19 @@ away itself:
   connected – read in 2.7.3, 3.0.0 and 3.3.3 – so a session that expires
   mid-edit rejects the next keystroke, and no later cookie reaches that
   socket. What bounds the window is revocation, not a shorter lifetime.
-- Expired sessions are left to the background sweep described below. They
-  grant nothing, and deleting them one call at a time inside a logout would
-  put that backlog in front of the user. What is still live is revoked
-  within a small budget – 25 calls or two seconds – and the rest is left to
-  expire, because each call carries the full client timeout. The log line
-  says how much was left behind.
+- Expired sessions are left to the background sweep described below. Only
+  what is expired by both clocks counts as expired: Etherpad judges
+  `validUntil` with its own, so a session ours calls dead may still be
+  honoured there, and skipping it would leave exactly the access a logout
+  removes. What is live is revoked within a small budget – 25 calls or two
+  seconds, with each call given what is left of it – and the rest is left
+  to expire. The log line says how much.
 
 No table of our own is involved: sessions belong to an Etherpad author, the
-author is cached per uid, and `listSessionsOfAuthor` answers the rest.
+author is cached per uid, and `listSessionsOfAuthor` answers the rest. That
+cached id is therefore not dropped when an open fails – an emptied cache
+cannot be told from a user who never opened a protected pad, and a logout
+after a brief outage would revoke nothing.
 
 **Only logout.** Losing a share does not revoke anything, and neither does
 a permission downgrade, a deleted or disabled account, or a deleted public

--- a/docs/etherpad-integration.md
+++ b/docs/etherpad-integration.md
@@ -220,8 +220,11 @@ away itself:
   `validUntil` with its own, so a session ours calls dead may still be
   honoured there, and skipping it would leave exactly the access a logout
   removes. What is live is revoked within a small budget – 25 calls or two
-  seconds, with each call given what is left of it – and the rest is left
-  to expire. The log line says how much.
+  seconds, with each call given what is left of it – starting with the
+  sessions this browser is carrying, since the listing arrives oldest
+  first and the ceiling would otherwise spend itself before reaching the
+  one in the cookie of the person who just logged out. What is left over,
+  whether skipped or refused, is counted and logged.
 
 No table of our own is involved: sessions belong to an Etherpad author, the
 author is cached per uid, and `listSessionsOfAuthor` answers the rest. That

--- a/docs/etherpad-integration.md
+++ b/docs/etherpad-integration.md
@@ -200,6 +200,69 @@ Cookie details:
   - derivation is skipped for IP hosts and invalid host values
   - recommendation: use explicit `etherpad_cookie_domain` in multi-subdomain/proxy setups
 
+### Session lifetime and revocation
+
+An Etherpad session is a bearer token for one group with a `validUntil`.
+Nothing about losing the Nextcloud session reaches it, so the app takes it
+away itself:
+
+- **Logout revokes every session of that user** – including ones opened in
+  another browser, which is deliberate: a cookie copied off the machine
+  cannot be narrowed down by the cookie you can see, and a shared computer
+  is exactly the case where the copy you can see is not the only one.
+- **Every open mints a fresh session.** Etherpad re-checks `validUntil` on
+  every socket message and keeps the session id it was handed when the pad
+  connected – read in 2.7.3, 3.0.0 and 3.3.3 – so a session that expires
+  mid-edit rejects the next keystroke, and no later cookie reaches that
+  socket. What bounds the window is revocation, not a shorter lifetime.
+- Expired sessions are left to the background sweep described below. They
+  grant nothing, and deleting them one call at a time inside a logout would
+  put that backlog in front of the user. What is still live is revoked
+  within a small budget – 25 calls or two seconds – and the rest is left to
+  expire, because each call carries the full client timeout. The log line
+  says how much was left behind.
+
+No table of our own is involved: sessions belong to an Etherpad author, the
+author is cached per uid, and `listSessionsOfAuthor` answers the rest.
+
+**Only logout.** Losing a share does not revoke anything, and neither does
+a permission downgrade, a deleted or disabled account, or a deleted public
+link. A session issued before any of those stays valid until `validUntil`.
+Covering them one event at a time means enumerating every way access can
+end, and that list has no natural end – a public link in particular opens
+under its own Etherpad author whose id is deliberately never cached, so
+there is nothing to look the sessions up by. The direction that does close
+them is the other one: short sessions that have to be renewed against a
+live permission check.
+
+**A session can still expire while someone is editing.** Etherpad rejects
+the next message rather than the next reload, and nothing renews a session
+mid-edit – the pad talks to Etherpad directly once it is open. The window
+is the configured TTL, counted from when the pad was opened.
+
+**Reopening a pad leaves the earlier session behind.** Every open mints one
+and only the cookie forgets the previous, so a pad reopened often carries
+several live sessions for one group. A logout is one more reader of an
+index whose length is the subject of the next section.
+
+**Revocation cannot outrun an open that is already in flight.** A request
+that has passed its permission check can issue a session after a revoke has
+listed what to remove. The window is short and the outcome is one more
+session of the configured lifetime.
+
+**Two Nextclouds pointed at one Etherpad share an author.** The mapper is
+`nc:<uid>`, which Etherpad stores globally, so one instance's logout can
+end the other's sessions. Naming it per instance needs a migration – the
+mapper is asked for on every open, so changing its shape re-issues an
+author for every existing user and orphans their live sessions – and is not
+done here.
+
+**A failed revoke is not retried.** If the pad server cannot be reached the
+listing fails, nothing is removed, and the logout carries on regardless –
+deliberately, since a logout may not fail because Etherpad is down. On a
+shared machine that leaves live sessions behind and a cookie still naming
+them; a listener has no response, so the cookie is never cleared either.
+
 ### Expired Etherpad sessions
 
 Every open of a protected pad mints a session – since 1.0.0 – and Etherpad
@@ -240,6 +303,7 @@ Not covered: sessions still being created – that is what keeps an open pad
 working – and authors nobody opens a pad for, whose leftovers cost storage
 only. Recording each session's id at issue time would remove the listing;
 renewing sessions instead of minting them would remove the pile.
+
 
 ### `SameSite=Lax`
 

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -90,6 +90,13 @@ class Application extends App implements IBootstrap {
 			);
 		}
 
+		// The Etherpad session cookie outlives a Nextcloud logout, so the
+		// sessions behind it are taken away explicitly.
+		$context->registerEventListener(
+			\OCP\User\Events\UserLoggedOutEvent::class,
+			\OCA\EtherpadNextcloud\Listeners\UserLoggedOutListener::class,
+		);
+
 		$context->registerEventListener(
 			'OCA\\Files_Trashbin\\Events\\MoveToTrashEvent',
 			\OCA\EtherpadNextcloud\Listeners\MoveToTrashListener::class,

--- a/lib/Listeners/UserLoggedOutListener.php
+++ b/lib/Listeners/UserLoggedOutListener.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Copyright (c) 2026 Jacob Bühler
+ */
+
+namespace OCA\EtherpadNextcloud\Listeners;
+
+use OCA\EtherpadNextcloud\Service\PadSessionRevoker;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use OCP\User\Events\UserLoggedOutEvent;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Logging out takes the Etherpad sessions with it.
+ *
+ * The Etherpad session cookie outlives a Nextcloud logout: it is a
+ * separate cookie on a separate host with its own lifetime, and Etherpad
+ * has never been told that the person is gone.
+ *
+ * Every session, not only the ones this browser is carrying. Narrowing to
+ * the cookie would fit the shared-machine case better — that is this
+ * browser — but it would miss the case that cannot be narrowed: a cookie
+ * copied off the machine, or left on one the user no longer controls. The
+ * cost is that logging out on a laptop ends an open pad on a desktop —
+ * and not at its next reload: Etherpad re-checks the session on every
+ * socket message, so it is the next keystroke that is rejected. The same
+ * mid-edit rejection that made a reused, shorter session unusable.
+ *
+ * Note what this cannot do: an event listener has no response, so the
+ * cookie itself stays in the browser that logged out. Once the revoke has
+ * gone through the ids in it are dead — the next user's author does not
+ * own them — but the cookie is not cleared here, and if the revoke did not
+ * get through, nothing comes back to either of them.
+ *
+ * @template-implements IEventListener<Event>
+ * @psalm-api
+ */
+class UserLoggedOutListener implements IEventListener {
+	public function __construct(
+		private PadSessionRevoker $revoker,
+		private LoggerInterface $logger,
+	) {
+	}
+
+	public function handle(Event $event): void {
+		if (!$event instanceof UserLoggedOutEvent) {
+			return;
+		}
+
+		$user = $event->getUser();
+		if ($user === null) {
+			return;
+		}
+
+		try {
+			$this->revoker->revokeAll($user->getUID());
+		} catch (\Throwable $e) {
+			// A logout does not fail because a pad server is unreachable.
+			$this->logger->warning('Could not revoke Etherpad sessions on logout.', [
+				'app' => 'etherpad_nextcloud',
+				'exception' => $e,
+			]);
+		}
+	}
+}

--- a/lib/Service/EtherpadClient.php
+++ b/lib/Service/EtherpadClient.php
@@ -30,6 +30,20 @@ class EtherpadClient {
 	public const REQUEST_TIMEOUT_SECONDS = 15;
 
 	/**
+	 * How far the two clocks are allowed to disagree.
+	 *
+	 * `validUntil` is a number Nextcloud computes and Etherpad judges
+	 * against its own clock, so around expiry the two sides can hold
+	 * different opinions about the same session. Both users of this margin
+	 * stay out of that window from opposite directions: revoking treats a
+	 * session as live until it is past, collecting waits until it is past
+	 * before deleting. One constant, because the invariant is that they
+	 * tile — a smaller margin on one side alone opens a band in which one
+	 * says gone and the other says not yet.
+	 */
+	public const CLOCK_SKEW_ALLOWANCE_SECONDS = 300;
+
+	/**
 	 * `/health` gets far less patience than an API call.
 	 *
 	 * Nothing depends on the answer: the caller falls back to the last known

--- a/lib/Service/ExpiredSessionCollector.php
+++ b/lib/Service/ExpiredSessionCollector.php
@@ -33,8 +33,6 @@ class ExpiredSessionCollector {
 	/** Refusals a run puts up with before reading them as an outage. */
 	private const MAX_FAILURES_PER_RUN = 5;
 
-
-
 	/** Below this, a call cannot finish inside the budget and is not made. */
 	private const MIN_CALL_TIMEOUT_SECONDS = 2;
 

--- a/lib/Service/ExpiredSessionCollector.php
+++ b/lib/Service/ExpiredSessionCollector.php
@@ -33,12 +33,7 @@ class ExpiredSessionCollector {
 	/** Refusals a run puts up with before reading them as an outage. */
 	private const MAX_FAILURES_PER_RUN = 5;
 
-	/**
-	 * Nextcloud computes `validUntil`; Etherpad judges it against its own
-	 * clock. In the window where the two disagree, deleting would close a
-	 * socket somebody is typing into.
-	 */
-	private const EXPIRY_GRACE_SECONDS = 300;
+
 
 	/** Below this, a call cannot finish inside the budget and is not made. */
 	private const MIN_CALL_TIMEOUT_SECONDS = 2;
@@ -122,7 +117,7 @@ class ExpiredSessionCollector {
 			]);
 		}
 
-		$cutoff = time() - self::EXPIRY_GRACE_SECONDS;
+		$cutoff = time() - EtherpadClient::CLOCK_SKEW_ALLOWANCE_SECONDS;
 		$expired = [];
 		$nextDueAt = null;
 		foreach ($sessions as $sessionId => $info) {
@@ -135,7 +130,7 @@ class ExpiredSessionCollector {
 
 			// When the earliest becomes collectable — without it, a sweep
 			// that found nothing is queued again by the very next open.
-			$dueAt = (int)$info['validUntil'] + self::EXPIRY_GRACE_SECONDS;
+			$dueAt = (int)$info['validUntil'] + EtherpadClient::CLOCK_SKEW_ALLOWANCE_SECONDS;
 			$nextDueAt = $nextDueAt === null ? $dueAt : min($nextDueAt, $dueAt);
 		}
 

--- a/lib/Service/PadSessionRevoker.php
+++ b/lib/Service/PadSessionRevoker.php
@@ -37,16 +37,7 @@ class PadSessionRevoker {
 	private const BUDGET_SECONDS = 2.0;
 	private const MAX_PER_REQUEST = 25;
 
-	/**
-	 * How far past expiry a session has to be before it counts as gone.
-	 *
-	 * Etherpad judges `validUntil` against its own clock. If ours runs
-	 * ahead, a session we call expired is one it still honours — and
-	 * skipping that leaves exactly the access this exists to take away.
-	 * The collector uses the same margin in the opposite direction, so that
-	 * neither side acts inside the window where the clocks disagree.
-	 */
-	private const EXPIRY_GRACE_SECONDS = 300;
+
 
 	/** Below this, a call cannot finish inside the budget and is not made. */
 	private const MIN_CALL_TIMEOUT_SECONDS = 1;
@@ -99,6 +90,18 @@ class PadSessionRevoker {
 			return 0;
 		}
 
+		// The same check every delete gets. Reading the cached author is a
+		// database round trip, and if it took the budget then starting a
+		// listing on top of it would overrun by a whole call — the floor
+		// under callTimeout() would hand it a second it does not have.
+		if ($deadline - microtime(true) < self::MIN_CALL_TIMEOUT_SECONDS) {
+			$this->logger->warning('No time left to revoke Etherpad sessions; they will expire on their own.', [
+				'app' => 'etherpad_nextcloud',
+				'uid' => $uid,
+			]);
+			return 0;
+		}
+
 		try {
 			$sessions = $this->etherpadClient->listSessionsOfAuthor(
 				$authorId,
@@ -113,16 +116,14 @@ class PadSessionRevoker {
 			return 0;
 		}
 
-		// Someone has to notice the backlog, and this is the one place that
-		// already holds the whole list. Leaving a note is a row in the job
-		// table; working through it here would be the thing this budget
-		// exists to prevent.
 		// Only what is expired on both clocks. Anything newer is treated as
 		// live and revoked, which at worst deletes something already gone.
-		$expiredBefore = time() - self::EXPIRY_GRACE_SECONDS;
+		$expiredBefore = time() - EtherpadClient::CLOCK_SKEW_ALLOWANCE_SECONDS;
+		$sessions = $this->carriedFirst($sessions);
 		$attempted = 0;
 		$revoked = 0;
 		$skipped = 0;
+		$failed = 0;
 		foreach ($sessions as $sessionId => $info) {
 			if ($info['validUntil'] <= $expiredBefore) {
 				// Grants nothing already. Etherpad keeps expired sessions
@@ -156,6 +157,11 @@ class PadSessionRevoker {
 					// Already gone, which is the outcome asked for.
 					continue;
 				}
+				// Counted as left behind, not merely warned about: the
+				// summary below is what says whether a logout finished its
+				// job, and a live session the pad server refused to delete
+				// is exactly as left behind as one the budget never reached.
+				$failed++;
 				$this->logger->warning('Could not revoke an Etherpad session; it will expire on its own.', [
 					'app' => 'etherpad_nextcloud',
 					'uid' => $uid,
@@ -165,12 +171,23 @@ class PadSessionRevoker {
 			}
 		}
 
-		if ($revoked > 0 || $skipped > 0) {
+		$leftToExpire = $skipped + $failed;
+		if ($revoked > 0) {
 			$this->logger->info('Revoked Etherpad sessions.', [
 				'app' => 'etherpad_nextcloud',
 				'uid' => $uid,
 				'count' => $revoked,
-				'leftToExpire' => $skipped,
+				'leftToExpire' => $leftToExpire,
+			]);
+		} elseif ($leftToExpire > 0) {
+			// Not "revoked" with a count of zero. That line is the shape of
+			// the failure an admin would be grepping for — a logout that
+			// removed nothing because the pad server was slow — and it must
+			// not read like the opposite.
+			$this->logger->warning('Revoked no Etherpad sessions; they will expire on their own.', [
+				'app' => 'etherpad_nextcloud',
+				'uid' => $uid,
+				'leftToExpire' => $leftToExpire,
 			]);
 		}
 
@@ -182,6 +199,30 @@ class PadSessionRevoker {
 			self::MIN_CALL_TIMEOUT_SECONDS,
 			min(floor($left), EtherpadClient::REQUEST_TIMEOUT_SECONDS),
 		);
+	}
+
+	/**
+	 * The same sessions, with the ones this browser is carrying first.
+	 *
+	 * The listing arrives in the author index's order, which is roughly the
+	 * order the sessions were made — so the ceiling would spend itself on
+	 * the oldest and leave the newest, and the newest is the one in the
+	 * cookie of the person who just logged out. Twenty-six opens of one pad
+	 * were enough to revoke twenty-five sessions and leave the only one that
+	 * mattered. The set is unchanged; only the order is.
+	 *
+	 * @param array<string,array{groupID:string,validUntil:int}> $sessions
+	 * @return array<string,array{groupID:string,validUntil:int}>
+	 */
+	private function carriedFirst(array $sessions): array {
+		$carried = [];
+		foreach ($this->padSessionService->carriedSessionIds() as $sessionId) {
+			if (isset($sessions[$sessionId])) {
+				$carried[$sessionId] = $sessions[$sessionId];
+			}
+		}
+
+		return $carried === [] ? $sessions : $carried + $sessions;
 	}
 
 }

--- a/lib/Service/PadSessionRevoker.php
+++ b/lib/Service/PadSessionRevoker.php
@@ -35,9 +35,18 @@ class PadSessionRevoker {
 	 * would spend the client timeout on the first few.
 	 */
 	private const BUDGET_SECONDS = 2.0;
-	private const MAX_PER_REQUEST = 25;
 
-
+	/**
+	 * At least every id a cookie can hold.
+	 *
+	 * Taking the carried sessions first only guarantees they are reached if
+	 * the ceiling covers a full cookie: a lower one would revoke a prefix
+	 * of what the browser is holding and leave the tail, which is the same
+	 * shared-computer failure the ordering was introduced to fix. Derived
+	 * rather than repeated, because two 25s in two classes are a
+	 * coincidence a reader has to verify and a maintainer can break.
+	 */
+	private const MAX_PER_REQUEST = PadSessionService::MAX_SESSION_IDS;
 
 	/** Below this, a call cannot finish inside the budget and is not made. */
 	private const MIN_CALL_TIMEOUT_SECONDS = 1;

--- a/lib/Service/PadSessionRevoker.php
+++ b/lib/Service/PadSessionRevoker.php
@@ -115,6 +115,7 @@ class PadSessionRevoker {
 			$sessions = $this->etherpadClient->listSessionsOfAuthor(
 				$authorId,
 				$this->callTimeout($deadline - microtime(true)),
+				$unreadable,
 			);
 		} catch (\Throwable $e) {
 			$this->logger->warning('Could not list the Etherpad sessions to revoke; they will expire on their own.', [
@@ -124,6 +125,12 @@ class PadSessionRevoker {
 			]);
 			return 0;
 		}
+
+		// Ids the index lists that Etherpad cannot describe. They cannot be
+		// revoked — deleteSession answers that they do not exist — so they
+		// belong in the number that says this logout did not finish, not
+		// dropped on the way in.
+		$unclassified = $unreadable ?? 0;
 
 		// Only what is expired on both clocks. Anything newer is treated as
 		// live and revoked, which at worst deletes something already gone.
@@ -180,7 +187,7 @@ class PadSessionRevoker {
 			}
 		}
 
-		$leftToExpire = $skipped + $failed;
+		$leftToExpire = $skipped + $failed + $unclassified;
 		if ($revoked > 0) {
 			$this->logger->info('Revoked Etherpad sessions.', [
 				'app' => 'etherpad_nextcloud',

--- a/lib/Service/PadSessionRevoker.php
+++ b/lib/Service/PadSessionRevoker.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Copyright (c) 2026 Jacob Bühler
+ */
+
+namespace OCA\EtherpadNextcloud\Service;
+
+use OCA\EtherpadNextcloud\Util\EtherpadErrorClassifier;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Takes a user's Etherpad sessions away again.
+ *
+ * An Etherpad session is a bearer token with a lifetime: once issued, it
+ * grants access to its group until `validUntil`, and nothing about losing
+ * the share, the file or the account reaches it. Until this existed the
+ * only thing that ever removed one was deleting its whole group.
+ *
+ * No table of our own is needed for it. Sessions are issued to an Etherpad
+ * author, the author for a user is cached against the uid, and Etherpad
+ * will list an author's sessions on request — so a uid is enough to find
+ * and remove them.
+ *
+ * @psalm-api
+ */
+class PadSessionRevoker {
+	/**
+	 * How much of a user-facing request this may take, and how many calls
+	 * it may make in it. Two numbers because either alone leaves the other
+	 * unbounded: a fast pad server would run through hundreds, a slow one
+	 * would spend the client timeout on the first few.
+	 */
+	private const BUDGET_SECONDS = 2.0;
+	private const MAX_PER_REQUEST = 25;
+
+	public function __construct(
+		private EtherpadClient $etherpadClient,
+		private PadSessionService $padSessionService,
+		private LoggerInterface $logger,
+	) {
+	}
+
+	/**
+	 * Every session this user holds, for every group.
+	 *
+	 * Every one, not only the ones this browser is carrying. A cookie that
+	 * has left the machine cannot be narrowed down by the cookie you can
+	 * see, and the case this exists for — a shared computer — is exactly
+	 * the case where the copy you can see is not the only one.
+	 *
+	 * @return int how many were removed
+	 */
+	public function revokeAll(string $uid): int {
+		return $this->revoke($uid);
+	}
+
+	/**
+	 * Best effort throughout, and bounded. This runs from event listeners
+	 * beside things the user asked for — a logout, an unshare — so it may
+	 * neither fail nor hang because a pad server is unreachable.
+	 *
+	 * Bounded matters as much as best effort. Each delete is its own call
+	 * with the client's full timeout behind it, and a user who has opened
+	 * pads all morning holds one live session per open: a half-broken
+	 * Etherpad could otherwise hold a logout for minutes. What does not fit
+	 * in the budget is left to expire, which is what would have happened
+	 * before any of this existed.
+	 *
+	 * The budget starts before the listing, because the listing is a call
+	 * with the same timeout behind it and counting only the deletes would
+	 * bound the wrong half. It still cannot cap the request: the check
+	 * happens between calls, so one that stalls runs to the client timeout
+	 * before the budget is consulted again.
+	 */
+	private function revoke(string $uid): int {
+		$deadline = microtime(true) + self::BUDGET_SECONDS;
+		$authorId = $this->padSessionService->cachedAuthorId($uid);
+		if ($authorId === '') {
+			// Never opened a protected pad, so nothing was ever issued.
+			return 0;
+		}
+
+		try {
+			$sessions = $this->etherpadClient->listSessionsOfAuthor($authorId);
+		} catch (\Throwable $e) {
+			$this->logger->warning('Could not list the Etherpad sessions to revoke; they will expire on their own.', [
+				'app' => 'etherpad_nextcloud',
+				'uid' => $uid,
+				'exception' => $e,
+			]);
+			return 0;
+		}
+
+		// Someone has to notice the backlog, and this is the one place that
+		// already holds the whole list. Leaving a note is a row in the job
+		// table; working through it here would be the thing this budget
+		// exists to prevent.
+		$now = time();
+		$attempted = 0;
+		$revoked = 0;
+		$skipped = 0;
+		foreach ($sessions as $sessionId => $info) {
+			if ($info['validUntil'] <= $now) {
+				// Grants nothing already. Etherpad keeps expired sessions
+				// until something deletes them, so an author who has used
+				// protected pads for a while carries hundreds — and this
+				// runs inside a logout the user is waiting for. Collecting
+				// them is a background job's problem, not this one's.
+				//
+				// Checked before the budget so that what is reported as left
+				// behind is only ever a live session. Counting the expired
+				// tail there made the one number that says "this revoke was
+				// incomplete" useless.
+				continue;
+			}
+			// Attempts, not successes. An Etherpad that fails fast — a
+			// rotated api key, a 500 — would otherwise never reach a ceiling
+			// counted in completed deletes, and spend one call and one
+			// warning per live session.
+			if ($attempted >= self::MAX_PER_REQUEST || microtime(true) >= $deadline) {
+				$skipped++;
+				continue;
+			}
+			$attempted++;
+
+			try {
+				$this->etherpadClient->deleteSession($sessionId);
+				$revoked++;
+			} catch (\Throwable $e) {
+				if (EtherpadErrorClassifier::isSessionAlreadyGone($e)) {
+					// Already gone, which is the outcome asked for.
+					continue;
+				}
+				$this->logger->warning('Could not revoke an Etherpad session; it will expire on its own.', [
+					'app' => 'etherpad_nextcloud',
+					'uid' => $uid,
+					'groupId' => $info['groupID'],
+					'exception' => $e,
+				]);
+			}
+		}
+
+		if ($revoked > 0 || $skipped > 0) {
+			$this->logger->info('Revoked Etherpad sessions.', [
+				'app' => 'etherpad_nextcloud',
+				'uid' => $uid,
+				'count' => $revoked,
+				'leftToExpire' => $skipped,
+			]);
+		}
+
+		return $revoked;
+	}
+}

--- a/lib/Service/PadSessionRevoker.php
+++ b/lib/Service/PadSessionRevoker.php
@@ -37,6 +37,20 @@ class PadSessionRevoker {
 	private const BUDGET_SECONDS = 2.0;
 	private const MAX_PER_REQUEST = 25;
 
+	/**
+	 * How far past expiry a session has to be before it counts as gone.
+	 *
+	 * Etherpad judges `validUntil` against its own clock. If ours runs
+	 * ahead, a session we call expired is one it still honours — and
+	 * skipping that leaves exactly the access this exists to take away.
+	 * The collector uses the same margin in the opposite direction, so that
+	 * neither side acts inside the window where the clocks disagree.
+	 */
+	private const EXPIRY_GRACE_SECONDS = 300;
+
+	/** Below this, a call cannot finish inside the budget and is not made. */
+	private const MIN_CALL_TIMEOUT_SECONDS = 1;
+
 	public function __construct(
 		private EtherpadClient $etherpadClient,
 		private PadSessionService $padSessionService,
@@ -72,9 +86,10 @@ class PadSessionRevoker {
 	 *
 	 * The budget starts before the listing, because the listing is a call
 	 * with the same timeout behind it and counting only the deletes would
-	 * bound the wrong half. It still cannot cap the request: the check
-	 * happens between calls, so one that stalls runs to the client timeout
-	 * before the budget is consulted again.
+	 * bound the wrong half. Each call is given what is left of it, and one
+	 * that no longer fits is not made: a deadline checked between calls
+	 * would otherwise say when the last call may start, not when it must
+	 * end.
 	 */
 	private function revoke(string $uid): int {
 		$deadline = microtime(true) + self::BUDGET_SECONDS;
@@ -85,7 +100,10 @@ class PadSessionRevoker {
 		}
 
 		try {
-			$sessions = $this->etherpadClient->listSessionsOfAuthor($authorId);
+			$sessions = $this->etherpadClient->listSessionsOfAuthor(
+				$authorId,
+				$this->callTimeout($deadline - microtime(true)),
+			);
 		} catch (\Throwable $e) {
 			$this->logger->warning('Could not list the Etherpad sessions to revoke; they will expire on their own.', [
 				'app' => 'etherpad_nextcloud',
@@ -99,12 +117,14 @@ class PadSessionRevoker {
 		// already holds the whole list. Leaving a note is a row in the job
 		// table; working through it here would be the thing this budget
 		// exists to prevent.
-		$now = time();
+		// Only what is expired on both clocks. Anything newer is treated as
+		// live and revoked, which at worst deletes something already gone.
+		$expiredBefore = time() - self::EXPIRY_GRACE_SECONDS;
 		$attempted = 0;
 		$revoked = 0;
 		$skipped = 0;
 		foreach ($sessions as $sessionId => $info) {
-			if ($info['validUntil'] <= $now) {
+			if ($info['validUntil'] <= $expiredBefore) {
 				// Grants nothing already. Etherpad keeps expired sessions
 				// until something deletes them, so an author who has used
 				// protected pads for a while carries hundreds — and this
@@ -121,14 +141,15 @@ class PadSessionRevoker {
 			// rotated api key, a 500 — would otherwise never reach a ceiling
 			// counted in completed deletes, and spend one call and one
 			// warning per live session.
-			if ($attempted >= self::MAX_PER_REQUEST || microtime(true) >= $deadline) {
+			$left = $deadline - microtime(true);
+			if ($attempted >= self::MAX_PER_REQUEST || $left < self::MIN_CALL_TIMEOUT_SECONDS) {
 				$skipped++;
 				continue;
 			}
 			$attempted++;
 
 			try {
-				$this->etherpadClient->deleteSession($sessionId);
+				$this->etherpadClient->deleteSession($sessionId, $this->callTimeout($left));
 				$revoked++;
 			} catch (\Throwable $e) {
 				if (EtherpadErrorClassifier::isSessionAlreadyGone($e)) {
@@ -155,4 +176,12 @@ class PadSessionRevoker {
 
 		return $revoked;
 	}
+	/** The rest of the budget, never more than any other call in this app. */
+	private function callTimeout(float $left): int {
+		return (int)max(
+			self::MIN_CALL_TIMEOUT_SECONDS,
+			min(floor($left), EtherpadClient::REQUEST_TIMEOUT_SECONDS),
+		);
+	}
+
 }

--- a/lib/Service/PadSessionService.php
+++ b/lib/Service/PadSessionService.php
@@ -78,7 +78,14 @@ class PadSessionService {
 			try {
 				return $this->openContextFor($uid, $authorId, $groupId, $padId, $validUntil);
 			} catch (EtherpadClientException) {
-				$this->clearCachedAuthorState($uid);
+				// The name only. The author id is the one thing that can find
+				// this user's live sessions again, and dropping it because an
+				// open failed would mean a logout after a brief pad-server
+				// outage revokes nothing — it cannot tell an emptied cache
+				// from a user who never opened a protected pad. A stale id is
+				// the lesser risk: the listing simply answers that it does not
+				// exist, and the next successful open overwrites it anyway.
+				$this->clearCachedAuthorName($uid);
 			}
 		}
 
@@ -525,11 +532,10 @@ class PadSessionService {
 		);
 	}
 
-	private function clearCachedAuthorState(string $uid): void {
+	private function clearCachedAuthorName(string $uid): void {
 		if (!$this->shouldPersistAuthorState($uid)) {
 			return;
 		}
-		$this->config->deleteUserValue($uid, 'etherpad_nextcloud', self::USER_CONFIG_AUTHOR_ID_KEY);
 		$this->config->deleteUserValue($uid, 'etherpad_nextcloud', self::USER_CONFIG_AUTHOR_NAME_KEY);
 	}
 

--- a/lib/Service/PadSessionService.php
+++ b/lib/Service/PadSessionService.php
@@ -78,14 +78,13 @@ class PadSessionService {
 			try {
 				return $this->openContextFor($uid, $authorId, $groupId, $padId, $validUntil);
 			} catch (EtherpadClientException) {
-				// The name only. The author id is the one thing that can find
-				// this user's live sessions again, and dropping it because an
-				// open failed would mean a logout after a brief pad-server
-				// outage revokes nothing — it cannot tell an emptied cache
-				// from a user who never opened a protected pad. A stale id is
-				// the lesser risk: the listing simply answers that it does not
-				// exist, and the next successful open overwrites it anyway.
-				$this->clearCachedAuthorName($uid);
+				// Nothing is cleared. The author id is the one route from a
+				// uid to that user's live sessions, and dropping it because
+				// an open failed would leave a cache indistinguishable from a
+				// user who never opened a protected pad — a logout after a
+				// brief outage would then revoke nothing. A stale id is the
+				// lesser risk: the listing answers that it does not exist,
+				// and the bootstrap below overwrites it on the next open.
 			}
 		}
 
@@ -497,6 +496,19 @@ class PadSessionService {
 	 * Empty when the user has never opened a protected pad — then there is
 	 * nothing to revoke either.
 	 */
+	/**
+	 * The session ids this browser is carrying.
+	 *
+	 * Public so a revoke can take them first. Which sessions exist is a
+	 * question for the pad server, but which one is in front of the person
+	 * at this keyboard is only answerable here.
+	 *
+	 * @return list<string>
+	 */
+	public function carriedSessionIds(): array {
+		return $this->sessionIdsFromCookie();
+	}
+
 	public function cachedAuthorId(string $uid): string {
 		return $this->resolveCachedAuthorId($uid);
 	}
@@ -530,13 +542,6 @@ class PadSessionService {
 			self::USER_CONFIG_AUTHOR_NAME_KEY,
 			trim($displayName)
 		);
-	}
-
-	private function clearCachedAuthorName(string $uid): void {
-		if (!$this->shouldPersistAuthorState($uid)) {
-			return;
-		}
-		$this->config->deleteUserValue($uid, 'etherpad_nextcloud', self::USER_CONFIG_AUTHOR_NAME_KEY);
 	}
 
 	private function shouldPersistAuthorState(string $uid): bool {

--- a/lib/Service/PadSessionService.php
+++ b/lib/Service/PadSessionService.php
@@ -38,7 +38,7 @@ class PadSessionService {
 	 * soonest to expire is the one a user is least likely to still be
 	 * looking at.
 	 */
-	private const MAX_SESSION_IDS = 25;
+	public const MAX_SESSION_IDS = 25;
 
 	/** `lax` (default) or `none`; see sameSiteMode(). */
 	public const SAME_SITE_KEY = 'etherpad_session_cookie_samesite';
@@ -496,6 +496,10 @@ class PadSessionService {
 	 * Empty when the user has never opened a protected pad — then there is
 	 * nothing to revoke either.
 	 */
+	public function cachedAuthorId(string $uid): string {
+		return $this->resolveCachedAuthorId($uid);
+	}
+
 	/**
 	 * The session ids this browser is carrying.
 	 *
@@ -507,10 +511,6 @@ class PadSessionService {
 	 */
 	public function carriedSessionIds(): array {
 		return $this->sessionIdsFromCookie();
-	}
-
-	public function cachedAuthorId(string $uid): string {
-		return $this->resolveCachedAuthorId($uid);
 	}
 
 	private function resolveCachedAuthorId(string $uid): string {

--- a/lib/Service/PadSessionService.php
+++ b/lib/Service/PadSessionService.php
@@ -128,6 +128,14 @@ class PadSessionService {
 		$carriedIds = $this->sessionIdsFromCookie();
 		$sessions = $this->sessionsToAttributeWith($uid, $authorId, $carriedIds);
 
+		// Deliberately a fresh session, not the one the browser is carrying.
+		// Etherpad re-checks validUntil on every socket message and holds the
+		// session id it was given at CLIENT_READY — read in 2.7.3, 3.0.0 and
+		// 3.3.3, so both majors and the boundary between them. A session that
+		// expires mid-edit therefore rejects the next keystroke, and no later
+		// cookie can reach that socket. Reusing a shorter one traded editing
+		// time for a renewal property that a client arriving without a cookie
+		// does not have anyway. What bounds the window is revocation.
 		$chosenSessionId = $this->etherpadClient->createSession($groupId, $authorId, $validUntil);
 		if (preg_match(self::SESSION_ID_PATTERN, $chosenSessionId) !== 1) {
 			// The id is about to be written into a cookie that the next open
@@ -463,6 +471,27 @@ class PadSessionService {
 			self::USER_CONFIG_AUTHOR_NAME_KEY,
 			''
 		));
+	}
+
+	/**
+	 * The Etherpad author this user writes as, if one has been made.
+	 *
+	 * The mapper is `nc:<uid>`, which Etherpad stores globally — two
+	 * Nextclouds pointed at one pad server share the author, and with it
+	 * each other's sessions. Naming it per instance is the fix and is not
+	 * done here: `syncAuthorMapping` asks for the mapper on every open, so
+	 * changing its shape re-issues an author for every existing user at
+	 * once, and their live sessions become invisible to the revoking this
+	 * branch is for. It needs a migration, not a one-line change.
+	 *
+	 * Public because it is what makes revoking possible without a table of
+	 * our own: Etherpad already knows which sessions belong to an author,
+	 * and this is the only step between a Nextcloud uid and that answer.
+	 * Empty when the user has never opened a protected pad — then there is
+	 * nothing to revoke either.
+	 */
+	public function cachedAuthorId(string $uid): string {
+		return $this->resolveCachedAuthorId($uid);
 	}
 
 	private function resolveCachedAuthorId(string $uid): string {

--- a/tests/e2e/fixtures/auth.ts
+++ b/tests/e2e/fixtures/auth.ts
@@ -91,3 +91,26 @@ export const loginAs = async (page: Page, user: string, password: string): Promi
 	// stored session (and the server-side "seen" flag) start clean.
 	await dismissFirstRunWizard(page)
 }
+
+/**
+ * Log the page's user out of Nextcloud, the way the header menu does.
+ *
+ * Driven by URL rather than by clicking through the avatar menu: the menu
+ * is markup that NC rewrites between versions, and a spec that fails
+ * because a button moved says nothing about what it meant to test. The
+ * request token is what makes this a real logout — `/logout` without one
+ * is rejected as a forgery, which would leave the session standing and
+ * the assertion afterwards passing for the wrong reason.
+ *
+ * The page must already be on a Nextcloud page; the token is rendered
+ * into `<head>` of every one of them.
+ */
+export const logout = async (page: Page): Promise<void> => {
+	const token = await page.evaluate(() => document.head.getAttribute('data-requesttoken') ?? '')
+	if (token === '') {
+		throw new Error('No data-requesttoken in <head>; is the page on a logged-in Nextcloud page?')
+	}
+
+	await page.goto(`${E2E.baseURL}/logout?requesttoken=${encodeURIComponent(token)}`)
+	await page.waitForURL(/\/login/, { timeout: 30_000 })
+}

--- a/tests/e2e/fixtures/etherpad.ts
+++ b/tests/e2e/fixtures/etherpad.ts
@@ -1,0 +1,97 @@
+/**
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * Copyright (c) 2026 Jacob Bühler
+ */
+import { E2E } from './env'
+
+/**
+ * The pad server's own API, for the questions only it can answer.
+ *
+ * Whether a session still grants access is not visible from Nextcloud:
+ * sessions live in Etherpad, nothing in our schema mirrors them, and the
+ * app learns about them only by asking. A spec that wants to assert a
+ * revocation therefore has to ask here.
+ *
+ * POST, not GET: a query string carries the api key into proxy and access
+ * logs, and — with `trace: 'retain-on-failure'` — into the report CI
+ * uploads as an artifact. EtherpadClient posts for the same reason. Not a
+ * secret-safe channel either way, since a trace can hold the body too;
+ * what makes it acceptable is the key, which comes from the checked-in
+ * APIKEY.txt of a throwaway stack.
+ */
+export const etherpadApiPost = async <T>(endpoint: string, form: Record<string, string>): Promise<T> => {
+	const api = E2E.etherpadApi
+	if (api === null) {
+		throw new Error('E2E_ETHERPAD_URL / E2E_ETHERPAD_API_KEY are not configured.')
+	}
+
+	const res = await fetch(`${api.url}/api/1.2.15/${endpoint}`, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8' },
+		body: new URLSearchParams({ apikey: api.key, ...form }),
+	})
+	const text = await res.text()
+	if (!res.ok) {
+		throw new Error(`Etherpad ${endpoint} answered HTTP ${res.status}: ${text.slice(0, 200)}`)
+	}
+
+	let payload: { code?: number, message?: string, data?: T } | null = null
+	try {
+		payload = JSON.parse(text) as typeof payload
+	} catch {
+		throw new Error(`Etherpad ${endpoint} answered with a non-JSON body: ${text.slice(0, 200)}`)
+	}
+	if (payload?.code !== 0) {
+		throw new Error(`Etherpad ${endpoint} failed: ${payload?.message ?? text.slice(0, 200)}`)
+	}
+	return payload.data as T
+}
+
+/**
+ * The Etherpad author a Nextcloud user writes under.
+ *
+ * `nc:<uid>` is the mapper the app uses, and asking for it twice returns
+ * the same id — so this is a lookup, not a side effect, as long as no name
+ * is passed along with it.
+ *
+ * That the mapper is spelled out here rather than read from the app is
+ * deliberate. Its shape is load-bearing: Etherpad issues a new author for
+ * a mapper it has not seen, and an author nobody can name is an author
+ * whose sessions nobody can revoke. A change to it should break a test.
+ */
+export const authorIdForUid = async (uid: string): Promise<string> => {
+	const data = await etherpadApiPost<{ authorID: string }>(
+		'createAuthorIfNotExistsFor',
+		{ authorMapper: `nc:${uid}` },
+	)
+	return data.authorID
+}
+
+/** The group half of a protected pad's id, read off the pad URL. */
+export const groupIdOfPadUrl = (padUrl: string): string => {
+	const padId = decodeURIComponent(padUrl.split('/p/').pop() ?? '')
+	const groupId = padId.split('$')[0] ?? ''
+	if (!groupId.startsWith('g.')) {
+		throw new Error(`Not a protected pad URL: ${padUrl}`)
+	}
+	return groupId
+}
+
+/**
+ * How many sessions this author still holds on this group that would
+ * actually grant access.
+ *
+ * Live ones only. Etherpad keeps expired sessions until something deletes
+ * them, and the app leaves them alone on purpose — counting them would
+ * make a successful revoke look like a failed one.
+ */
+export const liveSessionCount = async (groupId: string, authorId: string): Promise<number> => {
+	const data = await etherpadApiPost<Record<string, { authorID: string, validUntil: number } | null>>(
+		'listSessionsOfGroup',
+		{ groupID: groupId },
+	)
+	const now = Math.floor(Date.now() / 1000)
+	return Object.values(data ?? {})
+		.filter((info) => info !== null && info.authorID === authorId && info.validUntil > now)
+		.length
+}

--- a/tests/e2e/fixtures/nextcloud.ts
+++ b/tests/e2e/fixtures/nextcloud.ts
@@ -264,9 +264,34 @@ export const expectFilesRouteWithoutOpenFlag = async (page: Page): Promise<void>
 	await expect.poll(() => page.url(), { timeout: 10_000 }).not.toMatch(/[?&]openfile=true\b/)
 }
 
+/**
+ * Open a pad by clicking its row, and make sure the click landed.
+ *
+ * Nextcloud's file list renders lazily — it says so itself in the table's
+ * description — so a row can be resolved and then replaced underneath the
+ * click, which then hits nothing. The result is a list still on screen and
+ * a viewer that never opens, and the failure surfaces thirty seconds later
+ * in whatever waits for the viewer, pointing at the viewer rather than at
+ * the click that never happened.
+ *
+ * The retry is on the interaction, not on the assertion: a viewer that
+ * fails to mount for any other reason still fails, in the caller, with its
+ * full timeout.
+ */
 export const openPadFromFileList = async (page: Page, fileName: string): Promise<void> => {
 	await expectFileInList(page, fileName)
-	await page.locator(`[data-cy-files-list-row-name="${fileName}"], [title="${fileName}"]`).first().click()
+	const row = page.locator(`[data-cy-files-list-row-name="${fileName}"], [title="${fileName}"]`).first()
+	const viewer = page.locator('.viewer__content, .viewer, [data-cy-viewer]').first()
+
+	for (let attempt = 0; attempt < 3; attempt++) {
+		await row.click()
+		try {
+			await viewer.waitFor({ state: 'visible', timeout: 5_000 })
+			return
+		} catch {
+			// The click did not take. Leave the verdict to the caller.
+		}
+	}
 }
 
 /**

--- a/tests/e2e/specs/protected-session-revocation.spec.ts
+++ b/tests/e2e/specs/protected-session-revocation.spec.ts
@@ -127,6 +127,13 @@ test.describe('protected pad session revocation', () => {
 			// clear it with, and the app says so. Asserting it is still here
 			// is what makes the next line about revocation rather than about
 			// a browser that happens to have forgotten something.
+			//
+			// It also settles what the unit tests cannot: they hand the
+			// revoker its carried ids directly, so nothing there shows the
+			// cookie actually reaching Nextcloud. This one is set for the
+			// parent domain of both hosts, and the logout is a same-site
+			// top-level GET — so a cookie still present here is a cookie the
+			// logout request carried.
 			const cookies = await context.cookies(padUrl)
 			expect(
 				cookies.some((cookie) => cookie.name === 'sessionID'),

--- a/tests/e2e/specs/protected-session-revocation.spec.ts
+++ b/tests/e2e/specs/protected-session-revocation.spec.ts
@@ -1,0 +1,142 @@
+/**
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * Copyright (c) 2026 Jacob Bühler
+ */
+import { test, expect, type BrowserContext } from '@playwright/test'
+import {
+	closeViewer,
+	expectEtherpadViewerMounted,
+	gotoFiles,
+	openPadFromFileList,
+	readEtherpadUrlFromViewer,
+	uniquePadName,
+} from '../fixtures/nextcloud'
+import {
+	createPadAtPath,
+	deleteViaDav,
+} from '../fixtures/dav'
+import { authorIdForUid, groupIdOfPadUrl, liveSessionCount } from '../fixtures/etherpad'
+import { E2E } from '../fixtures/env'
+import { loginAs, logout } from '../fixtures/auth'
+
+/**
+ * An Etherpad session is a bearer token with its own lifetime, on its own
+ * host. A Nextcloud logout does not reach it, so the app takes it away
+ * itself — and whether it did is a question only the pad server can
+ * answer. The unit tests pin which call is made; this asks Etherpad
+ * whether the access is actually gone.
+ *
+ * The test ends at the pad URL rather than at a session count, because the
+ * count is the mechanism and the URL is the claim: someone who knows the
+ * address of a pad they may no longer open must not get in.
+ *
+ * `#permissionDenied` is Etherpad's own marker for a refused pad. It is
+ * shown on `accessStatus: 'deny'` from the socket handshake, which is
+ * where a group pad without a valid session lands.
+ */
+test.describe('protected pad session revocation', () => {
+	// A form login, an Etherpad mount and the create flow, which is
+	// several UI steps on its own.
+	test.describe.configure({ timeout: 120_000 })
+
+	const expectDeniedAt = async (context: BrowserContext, padUrl: string): Promise<void> => {
+		const page = await context.newPage()
+		try {
+			await page.goto(padUrl)
+			await expect(
+				page.locator('#permissionDenied'),
+				`Etherpad still let ${padUrl} be opened`,
+			).toBeVisible({ timeout: 30_000 })
+		} finally {
+			await page.close()
+		}
+	}
+
+	/**
+	 * The same check in the other direction, run before the logout.
+	 *
+	 * `#permissionDenied` is in Etherpad's markup on every pad page and is
+	 * only shown when the handshake is refused, so asserting that it is
+	 * visible would also pass against a pad server that refuses everyone,
+	 * or a stack where the pad never loaded at all. Asserting first that
+	 * this same context reaches an editable pad rules both out — and it
+	 * pins the premise the test rests on: the access was there to lose.
+	 */
+	const expectReachableAt = async (context: BrowserContext, padUrl: string): Promise<void> => {
+		const page = await context.newPage()
+		try {
+			await page.goto(padUrl)
+			await expect(
+				page.locator('#editorcontainer .ace_outer, iframe[name="ace_outer"]').first(),
+				`Etherpad did not open ${padUrl}`,
+			).toBeVisible({ timeout: 30_000 })
+			await expect(page.locator('#permissionDenied')).toBeHidden()
+		} finally {
+			await page.close()
+		}
+	}
+
+	/**
+	 * On its own login, not the stored one every other spec shares.
+	 * Logging out ends the Nextcloud session behind whatever cookie the
+	 * browser is carrying, and the setup project mints that cookie once for
+	 * the whole run — so logging out of it would leave every spec after
+	 * this one unauthenticated. Costs one form login; buys a suite that
+	 * does not depend on file order.
+	 */
+	test('logging out of Nextcloud closes the pad the browser still has a cookie for', async ({ browser }) => {
+		test.skip(E2E.etherpadApi === null, 'E2E_ETHERPAD_URL / E2E_ETHERPAD_API_KEY not configured; Etherpad-side spec skipped.')
+
+		const padName = uniquePadName('revoke-logout')
+		// Explicitly empty, not merely "new": a context created inside a test
+		// picks up the project's stored session, and the login form would
+		// then never be reached — the request would land on the dashboard
+		// already signed in.
+		const context = await browser.newContext({ storageState: { cookies: [], origins: [] } })
+		const page = await context.newPage()
+		try {
+			await loginAs(page, E2E.user, E2E.password)
+			await createPadAtPath(`/${padName}`, 'protected')
+
+			// Through the UI, not the API: the session is minted when the pad
+			// is opened, and the cookie has to end up in this browser for the
+			// last assertion to mean anything.
+			await gotoFiles(page)
+			await openPadFromFileList(page, padName)
+			await expectEtherpadViewerMounted(page)
+			const padUrl = await readEtherpadUrlFromViewer(page)
+			await closeViewer(page)
+
+			const groupId = groupIdOfPadUrl(padUrl)
+			const authorId = await authorIdForUid(E2E.user)
+			expect(
+				await liveSessionCount(groupId, authorId),
+				'opening a protected pad should have issued a session',
+			).toBeGreaterThan(0)
+
+			await expectReachableAt(context, padUrl)
+
+			await logout(page)
+
+			await expect.poll(
+				() => liveSessionCount(groupId, authorId),
+				{ timeout: 30_000, message: 'logout should have revoked the sessions for this pad' },
+			).toBe(0)
+
+			// The cookie outlives the logout — a listener has no response to
+			// clear it with, and the app says so. Asserting it is still here
+			// is what makes the next line about revocation rather than about
+			// a browser that happens to have forgotten something.
+			const cookies = await context.cookies(padUrl)
+			expect(
+				cookies.some((cookie) => cookie.name === 'sessionID'),
+				'the Etherpad cookie is expected to survive the logout',
+			).toBe(true)
+
+			await expectDeniedAt(context, padUrl)
+		} finally {
+			await context.close()
+			await deleteViaDav(padName).catch(() => {})
+		}
+	})
+})

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -59,7 +59,6 @@ $stubFiles = [
 	__DIR__ . '/stubs/OCP/IURLGenerator.php',
 	__DIR__ . '/stubs/OCP/IUser.php',
 	__DIR__ . '/stubs/OCP/User/Events/UserLoggedOutEvent.php',
-	__DIR__ . '/stubs/OCP/Share/Events/ShareDeletedEvent.php',
 	__DIR__ . '/stubs/OCP/IUserSession.php',
 	__DIR__ . '/stubs/OCP/Files/InvalidPathException.php',
 	__DIR__ . '/stubs/OCP/Files/IFilenameValidator.php',

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -58,6 +58,8 @@ $stubFiles = [
 	__DIR__ . '/stubs/OCP/IGroupManager.php',
 	__DIR__ . '/stubs/OCP/IURLGenerator.php',
 	__DIR__ . '/stubs/OCP/IUser.php',
+	__DIR__ . '/stubs/OCP/User/Events/UserLoggedOutEvent.php',
+	__DIR__ . '/stubs/OCP/Share/Events/ShareDeletedEvent.php',
 	__DIR__ . '/stubs/OCP/IUserSession.php',
 	__DIR__ . '/stubs/OCP/Files/InvalidPathException.php',
 	__DIR__ . '/stubs/OCP/Files/IFilenameValidator.php',

--- a/tests/phpunit/stubs/OCP/User/Events/UserLoggedOutEvent.php
+++ b/tests/phpunit/stubs/OCP/User/Events/UserLoggedOutEvent.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCP\User\Events;
+
+use OCP\EventDispatcher\Event;
+use OCP\IUser;
+
+if (!class_exists(UserLoggedOutEvent::class)) {
+	class UserLoggedOutEvent extends Event {
+		public function __construct(private ?IUser $user = null) {
+		}
+
+		public function getUser(): ?IUser {
+			return $this->user;
+		}
+	}
+}

--- a/tests/phpunit/unit/EtherpadErrorClassifierTest.php
+++ b/tests/phpunit/unit/EtherpadErrorClassifierTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * Copyright (c) 2026 Jacob Bühler
+ */
+
+namespace OCA\EtherpadNextcloud\Tests\Unit;
+
+use OCA\EtherpadNextcloud\Util\EtherpadErrorClassifier;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The one Etherpad answer a delete may treat as success — and only about
+ * the thing that was actually being deleted.
+ */
+class EtherpadErrorClassifierTest extends TestCase {
+	/**
+	 * @param string $message
+	 * @param bool $expected
+	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('padAnswers')]
+	public function testReadsAPadAsGone(string $message, bool $expected): void {
+		self::assertSame($expected, EtherpadErrorClassifier::isPadAlreadyDeleted(new \RuntimeException($message)));
+	}
+
+	/** @return array<string,array{string,bool}> */
+	public static function padAnswers(): array {
+		return [
+			'public pad' => ['padID does not exist', true],
+			'group of a protected pad' => ['groupID does not exist', true],
+			'older spelling' => ['unknown pad', true],
+			// deleteGroup tears down that group's sessions, so a failing pad
+			// delete can answer about one. Reading that as "the pad is gone"
+			// drops a binding row over a sentence about a session.
+			'a session answer is not about the pad' => ['sessionID does not exist', false],
+			'anything else' => ['Connection timed out', false],
+		];
+	}
+
+	public function testReadsASessionAsGoneOnlyForASessionAnswer(): void {
+		self::assertTrue(EtherpadErrorClassifier::isSessionAlreadyGone(new \RuntimeException('sessionID does not exist')));
+		self::assertFalse(EtherpadErrorClassifier::isSessionAlreadyGone(new \RuntimeException('padID does not exist')));
+		self::assertFalse(EtherpadErrorClassifier::isSessionAlreadyGone(new \RuntimeException('Connection timed out')));
+	}
+
+	/** The client wraps Etherpad's text, so the answer arrives as a cause. */
+	public function testLooksThroughTheWrapping(): void {
+		$wrapped = new \RuntimeException('Etherpad API request failed: deletePad', 0, new \RuntimeException('padID does not exist'));
+
+		self::assertTrue(EtherpadErrorClassifier::isPadAlreadyDeleted($wrapped));
+	}
+}

--- a/tests/phpunit/unit/PadSessionRevokerTest.php
+++ b/tests/phpunit/unit/PadSessionRevokerTest.php
@@ -217,13 +217,131 @@ class PadSessionRevokerTest extends TestCase {
 		}
 	}
 
+	/**
+	 * The ceiling must not spend itself on the oldest sessions and leave
+	 * the one in front of the person who just logged out.
+	 *
+	 * The listing arrives in the author index's order, roughly oldest
+	 * first, so twenty-six opens of one pad meant revoking twenty-five and
+	 * leaving the only one that mattered — the shared-computer case failing
+	 * against a perfectly healthy pad server.
+	 */
+	public function testTakesTheSessionThisBrowserIsCarryingFirst(): void {
+		$sessions = [];
+		for ($i = 0; $i < 30; $i++) {
+			$sessions['s.old' . $i] = ['groupID' => 'g.AAAAAAAAAAAAAAAA', 'validUntil' => time() + 3600];
+		}
+		$sessions['s.inthecookie'] = ['groupID' => 'g.AAAAAAAAAAAAAAAA', 'validUntil' => time() + 3600];
+
+		$client = $this->createMock(EtherpadClient::class);
+		$client->method('listSessionsOfAuthor')->willReturn($sessions);
+		$removed = [];
+		$client->method('deleteSession')->willReturnCallback(
+			static function (string $id) use (&$removed): void {
+				$removed[] = $id;
+			}
+		);
+
+		$this->revoker($client, carriedIds: ['s.inthecookie'])->revokeAll('alice');
+
+		self::assertContains('s.inthecookie', $removed, 'the cookie session outlived the ceiling');
+		self::assertSame('s.inthecookie', $removed[0], 'and it should have gone first');
+	}
+
+	/** An id the cookie carries for some other author changes nothing. */
+	public function testIgnoresCarriedIdsThatAreNotThisAuthorsSessions(): void {
+		$client = $this->createMock(EtherpadClient::class);
+		$client->method('listSessionsOfAuthor')->willReturn([
+			's.mine' => ['groupID' => 'g.AAAAAAAAAAAAAAAA', 'validUntil' => time() + 3600],
+		]);
+		$client->expects(self::once())->method('deleteSession')->with('s.mine');
+
+		self::assertSame(1, $this->revoker($client, carriedIds: ['s.somebodyelse'])->revokeAll('alice'));
+	}
+
+	/**
+	 * Reading the cached author is a database round trip. If it took the
+	 * budget, starting a listing on top of it overruns by a whole call,
+	 * because the floor under callTimeout() hands it a second it has not
+	 * got.
+	 */
+	public function testDoesNotStartTheListingWithoutTimeForIt(): void {
+		$client = $this->createMock(EtherpadClient::class);
+		$client->expects(self::never())->method('listSessionsOfAuthor');
+
+		$sessions = $this->createMock(PadSessionService::class);
+		$sessions->method('cachedAuthorId')->willReturnCallback(
+			static function (): string {
+				usleep(2_100_000);
+				return self::AUTHOR;
+			}
+		);
+		$logger = $this->createMock(LoggerInterface::class);
+		$logger->expects(self::once())->method('warning');
+
+		$revoker = new PadSessionRevoker($client, $sessions, $logger);
+
+		self::assertSame(0, $revoker->revokeAll('alice'));
+	}
+
+	/**
+	 * A live session the pad server refused is exactly as left behind as
+	 * one the budget never reached, and the summary is what says whether a
+	 * logout finished its job.
+	 */
+	public function testCountsARefusedDeleteAsLeftBehind(): void {
+		$client = $this->createMock(EtherpadClient::class);
+		$client->method('listSessionsOfAuthor')->willReturn([
+			's.ok' => ['groupID' => 'g.AAAAAAAAAAAAAAAA', 'validUntil' => time() + 3600],
+			's.refused' => ['groupID' => 'g.AAAAAAAAAAAAAAAA', 'validUntil' => time() + 3600],
+		]);
+		$client->method('deleteSession')->willReturnCallback(
+			static function (string $id): void {
+				if ($id === 's.refused') {
+					throw new EtherpadClientException('internal error');
+				}
+			}
+		);
+
+		$reported = null;
+		$logger = $this->createMock(LoggerInterface::class);
+		$logger->method('info')->willReturnCallback(
+			static function (string $message, array $context) use (&$reported): void {
+				$reported = $context['leftToExpire'] ?? null;
+			}
+		);
+
+		self::assertSame(1, $this->revoker($client, logger: $logger)->revokeAll('alice'));
+		self::assertSame(1, $reported, 'the refused session is left behind, not merely warned about');
+	}
+
+	/**
+	 * A run that removed nothing must not be logged as one that revoked.
+	 * That line is the shape of the failure an admin greps for.
+	 */
+	public function testDoesNotClaimToHaveRevokedWhenItDidNot(): void {
+		$client = $this->createMock(EtherpadClient::class);
+		$client->method('listSessionsOfAuthor')->willReturn([
+			's.refused' => ['groupID' => 'g.AAAAAAAAAAAAAAAA', 'validUntil' => time() + 3600],
+		]);
+		$client->method('deleteSession')->willThrowException(new EtherpadClientException('internal error'));
+
+		$logger = $this->createMock(LoggerInterface::class);
+		$logger->expects(self::never())->method('info');
+		$logger->expects(self::exactly(2))->method('warning');
+
+		self::assertSame(0, $this->revoker($client, logger: $logger)->revokeAll('alice'));
+	}
+
 	private function revoker(
 		EtherpadClient $client,
 		string $author = self::AUTHOR,
 		?LoggerInterface $logger = null,
+		array $carriedIds = [],
 	): PadSessionRevoker {
 		$sessions = $this->createMock(PadSessionService::class);
 		$sessions->method('cachedAuthorId')->willReturn($author);
+		$sessions->method('carriedSessionIds')->willReturn($carriedIds);
 
 		return new PadSessionRevoker(
 			$client,

--- a/tests/phpunit/unit/PadSessionRevokerTest.php
+++ b/tests/phpunit/unit/PadSessionRevokerTest.php
@@ -372,6 +372,33 @@ class PadSessionRevokerTest extends TestCase {
 		self::assertSame(0, $this->revoker($client, logger: $logger)->revokeAll('alice'));
 	}
 
+	/**
+	 * An index entry Etherpad cannot describe cannot be revoked either —
+	 * deleteSession answers that it does not exist — so it belongs in the
+	 * number that says a logout did not finish. The client counts them; the
+	 * revoke must not drop the count on the way in.
+	 */
+	public function testCountsIndexEntriesItCannotClassify(): void {
+		$client = $this->createMock(EtherpadClient::class);
+		$client->method('listSessionsOfAuthor')->willReturnCallback(
+			static function (string $authorId, ?int $timeout = null, ?int &$unreadable = null): array {
+				$unreadable = 3;
+				return ['s.live' => ['groupID' => 'g.AAAAAAAAAAAAAAAA', 'validUntil' => time() + 3600]];
+			}
+		);
+
+		$reported = null;
+		$logger = $this->createMock(LoggerInterface::class);
+		$logger->method('info')->willReturnCallback(
+			static function (string $message, array $context) use (&$reported): void {
+				$reported = $context['leftToExpire'] ?? null;
+			}
+		);
+
+		self::assertSame(1, $this->revoker($client, logger: $logger)->revokeAll('alice'));
+		self::assertSame(3, $reported, 'the entries it could not read are left behind too');
+	}
+
 	private function revoker(
 		EtherpadClient $client,
 		string $author = self::AUTHOR,

--- a/tests/phpunit/unit/PadSessionRevokerTest.php
+++ b/tests/phpunit/unit/PadSessionRevokerTest.php
@@ -1,0 +1,182 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * Copyright (c) 2026 Jacob Bühler
+ */
+
+namespace OCA\EtherpadNextcloud\Tests\Unit;
+
+use OCA\EtherpadNextcloud\Exception\EtherpadClientException;
+use OCA\EtherpadNextcloud\Service\EtherpadClient;
+use OCA\EtherpadNextcloud\Service\PadSessionRevoker;
+use OCA\EtherpadNextcloud\Service\PadSessionService;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * An Etherpad session is a bearer token with a lifetime: nothing about
+ * losing the share, the file or the account reaches it, and the only thing
+ * that ever removed one was deleting its whole group.
+ */
+class PadSessionRevokerTest extends TestCase {
+	private const AUTHOR = 'a.author';
+
+	public function testRemovesEverySessionOfTheUser(): void {
+		$client = $this->createMock(EtherpadClient::class);
+		$client->method('listSessionsOfAuthor')->with(self::AUTHOR)->willReturn([
+			's.one' => ['groupID' => 'g.AAAAAAAAAAAAAAAA', 'validUntil' => time() + 3600],
+			's.two' => ['groupID' => 'g.BBBBBBBBBBBBBBBB', 'validUntil' => time() + 3600],
+		]);
+		$removed = [];
+		$client->method('deleteSession')->willReturnCallback(
+			static function (string $id) use (&$removed): void {
+				$removed[] = $id;
+			}
+		);
+
+		self::assertSame(2, $this->revoker($client)->revokeAll('alice'));
+		self::assertSame(['s.one', 's.two'], $removed);
+	}
+
+	/** No author means no session was ever issued, and no round trip. */
+	public function testAsksNothingForAUserWhoNeverOpenedAProtectedPad(): void {
+		$client = $this->createMock(EtherpadClient::class);
+		$client->expects(self::never())->method('listSessionsOfAuthor');
+
+		self::assertSame(0, $this->revoker($client, author: '')->revokeAll('alice'));
+	}
+
+	/**
+	 * Best effort: this runs beside a logout or an unshare, and neither may
+	 * fail because a pad server is unreachable.
+	 */
+	public function testSurvivesAnUnreachablePadServer(): void {
+		$client = $this->createMock(EtherpadClient::class);
+		$client->method('listSessionsOfAuthor')
+			->willThrowException(new EtherpadClientException('Connection timed out'));
+
+		self::assertSame(0, $this->revoker($client)->revokeAll('alice'));
+	}
+
+	/** A session already gone is the outcome asked for, not a failure. */
+	public function testCountsOnlyWhatItActuallyRemoved(): void {
+		$client = $this->createMock(EtherpadClient::class);
+		$client->method('listSessionsOfAuthor')->willReturn([
+			's.gone' => ['groupID' => 'g.AAAAAAAAAAAAAAAA', 'validUntil' => time() + 3600],
+			's.here' => ['groupID' => 'g.AAAAAAAAAAAAAAAA', 'validUntil' => time() + 3600],
+		]);
+		$client->method('deleteSession')->willReturnCallback(
+			static function (string $id): void {
+				if ($id === 's.gone') {
+					throw new EtherpadClientException('sessionID does not exist');
+				}
+			}
+		);
+
+		$logger = $this->createMock(LoggerInterface::class);
+		$logger->expects(self::never())->method('warning');
+
+		self::assertSame(1, $this->revoker($client, logger: $logger)->revokeAll('alice'));
+	}
+
+	/**
+	 * Etherpad keeps expired sessions until something deletes them, so an
+	 * author who has used protected pads for a while carries hundreds of
+	 * them. They grant nothing, and this runs inside a logout the user is
+	 * waiting for — one round trip each would put the whole backlog in
+	 * front of them.
+	 */
+	public function testLeavesExpiredSessionsToABackgroundJob(): void {
+		$client = $this->createMock(EtherpadClient::class);
+		$client->method('listSessionsOfAuthor')->willReturn([
+			's.old' => ['groupID' => 'g.AAAAAAAAAAAAAAAA', 'validUntil' => time() - 1],
+			's.live' => ['groupID' => 'g.AAAAAAAAAAAAAAAA', 'validUntil' => time() + 3600],
+		]);
+		$client->expects(self::once())->method('deleteSession')->with('s.live');
+
+		self::assertSame(1, $this->revoker($client)->revokeAll('alice'));
+	}
+
+	/**
+	 * Each delete is its own call with the client's full timeout behind it,
+	 * and a user who has opened pads all morning holds one live session per
+	 * open. Without a ceiling a half-broken Etherpad holds the logout for
+	 * minutes; what does not fit is left to expire.
+	 */
+	public function testLeavesTheTailToExpireRatherThanHoldingTheRequest(): void {
+		$live = [];
+		for ($i = 0; $i < 40; $i++) {
+			$live['s.' . $i] = ['groupID' => 'g.AAAAAAAAAAAAAAAA', 'validUntil' => time() + 3600];
+		}
+		$client = $this->createMock(EtherpadClient::class);
+		$client->method('listSessionsOfAuthor')->willReturn($live);
+		$client->expects(self::exactly(25))->method('deleteSession');
+
+		self::assertSame(25, $this->revoker($client)->revokeAll('alice'));
+	}
+
+	/**
+	 * The ceiling counts attempts, not successes. An Etherpad that fails
+	 * fast — a rotated api key, a 500 — would otherwise never reach a limit
+	 * counted in completed deletes, and spend one call and one warning per
+	 * live session.
+	 */
+	public function testAFastFailingPadServerStillHitsTheCeiling(): void {
+		$live = [];
+		for ($i = 0; $i < 400; $i++) {
+			$live['s.' . $i] = ['groupID' => 'g.AAAAAAAAAAAAAAAA', 'validUntil' => time() + 3600];
+		}
+		$client = $this->createMock(EtherpadClient::class);
+		$client->method('listSessionsOfAuthor')->willReturn($live);
+		$client->expects(self::exactly(25))
+			->method('deleteSession')
+			->willThrowException(new EtherpadClientException('Etherpad API error: internal error'));
+
+		self::assertSame(0, $this->revoker($client)->revokeAll('alice'));
+	}
+
+	/**
+	 * And what is reported as left behind is only ever a live session. The
+	 * expired tail is hundreds of entries; counting it there made the one
+	 * number that says "this revoke was incomplete" useless.
+	 */
+	public function testTheExpiredTailIsNotReportedAsLeftBehind(): void {
+		$sessions = [];
+		for ($i = 0; $i < 30; $i++) {
+			$sessions['live.' . $i] = ['groupID' => 'g.AAAAAAAAAAAAAAAA', 'validUntil' => time() + 3600];
+		}
+		for ($i = 0; $i < 800; $i++) {
+			$sessions['dead.' . $i] = ['groupID' => 'g.AAAAAAAAAAAAAAAA', 'validUntil' => time() - 10];
+		}
+		$client = $this->createMock(EtherpadClient::class);
+		$client->method('listSessionsOfAuthor')->willReturn($sessions);
+
+		$reported = null;
+		$logger = $this->createMock(LoggerInterface::class);
+		$logger->method('info')->willReturnCallback(
+			static function (string $message, array $context) use (&$reported): void {
+				$reported = $context['leftToExpire'] ?? null;
+			}
+		);
+
+		self::assertSame(25, $this->revoker($client, logger: $logger)->revokeAll('alice'));
+		self::assertSame(5, $reported);
+	}
+
+	private function revoker(
+		EtherpadClient $client,
+		string $author = self::AUTHOR,
+		?LoggerInterface $logger = null,
+	): PadSessionRevoker {
+		$sessions = $this->createMock(PadSessionService::class);
+		$sessions->method('cachedAuthorId')->willReturn($author);
+
+		return new PadSessionRevoker(
+			$client,
+			$sessions,
+			$logger ?? $this->createMock(LoggerInterface::class),
+		);
+	}
+}

--- a/tests/phpunit/unit/PadSessionRevokerTest.php
+++ b/tests/phpunit/unit/PadSessionRevokerTest.php
@@ -248,6 +248,45 @@ class PadSessionRevokerTest extends TestCase {
 		self::assertSame('s.inthecookie', $removed[0], 'and it should have gone first');
 	}
 
+	/**
+	 * A full cookie is revoked in full.
+	 *
+	 * Taking the carried ids first only reaches all of them if the ceiling
+	 * covers a whole cookie. A lower one would revoke a prefix and leave
+	 * the tail — the same shared-computer failure as before, one step
+	 * further along. This asks for the property rather than the number, so
+	 * it stays green while the two move together and falls when they part.
+	 */
+	public function testRevokesEveryIdAFullCookieCanHold(): void {
+		$carried = [];
+		$sessions = [];
+		for ($i = 0; $i < PadSessionService::MAX_SESSION_IDS; $i++) {
+			$id = 's.carried' . $i;
+			$carried[] = $id;
+			$sessions[$id] = ['groupID' => 'g.AAAAAAAAAAAAAAAA', 'validUntil' => time() + 3600];
+		}
+		// Plenty more behind them, so the ceiling is the only thing that
+		// could stop the carried ones being reached.
+		for ($i = 0; $i < 200; $i++) {
+			$sessions['s.other' . $i] = ['groupID' => 'g.BBBBBBBBBBBBBBBB', 'validUntil' => time() + 3600];
+		}
+
+		$client = $this->createMock(EtherpadClient::class);
+		$client->method('listSessionsOfAuthor')->willReturn($sessions);
+		$removed = [];
+		$client->method('deleteSession')->willReturnCallback(
+			static function (string $id) use (&$removed): void {
+				$removed[] = $id;
+			}
+		);
+
+		$this->revoker($client, carriedIds: $carried)->revokeAll('alice');
+
+		foreach ($carried as $id) {
+			self::assertContains($id, $removed, "{$id} was in the cookie and survived the logout");
+		}
+	}
+
 	/** An id the cookie carries for some other author changes nothing. */
 	public function testIgnoresCarriedIdsThatAreNotThisAuthorsSessions(): void {
 		$client = $this->createMock(EtherpadClient::class);

--- a/tests/phpunit/unit/PadSessionRevokerTest.php
+++ b/tests/phpunit/unit/PadSessionRevokerTest.php
@@ -91,7 +91,7 @@ class PadSessionRevokerTest extends TestCase {
 	public function testLeavesExpiredSessionsToABackgroundJob(): void {
 		$client = $this->createMock(EtherpadClient::class);
 		$client->method('listSessionsOfAuthor')->willReturn([
-			's.old' => ['groupID' => 'g.AAAAAAAAAAAAAAAA', 'validUntil' => time() - 1],
+			's.old' => ['groupID' => 'g.AAAAAAAAAAAAAAAA', 'validUntil' => time() - 3600],
 			's.live' => ['groupID' => 'g.AAAAAAAAAAAAAAAA', 'validUntil' => time() + 3600],
 		]);
 		$client->expects(self::once())->method('deleteSession')->with('s.live');
@@ -147,8 +147,11 @@ class PadSessionRevokerTest extends TestCase {
 		for ($i = 0; $i < 30; $i++) {
 			$sessions['live.' . $i] = ['groupID' => 'g.AAAAAAAAAAAAAAAA', 'validUntil' => time() + 3600];
 		}
+		// Well past expiry: a session that ran out ten seconds ago is
+		// treated as live here, because Etherpad's clock decides and ours
+		// may be ahead of it.
 		for ($i = 0; $i < 800; $i++) {
-			$sessions['dead.' . $i] = ['groupID' => 'g.AAAAAAAAAAAAAAAA', 'validUntil' => time() - 10];
+			$sessions['dead.' . $i] = ['groupID' => 'g.AAAAAAAAAAAAAAAA', 'validUntil' => time() - 3600];
 		}
 		$client = $this->createMock(EtherpadClient::class);
 		$client->method('listSessionsOfAuthor')->willReturn($sessions);
@@ -163,6 +166,55 @@ class PadSessionRevokerTest extends TestCase {
 
 		self::assertSame(25, $this->revoker($client, logger: $logger)->revokeAll('alice'));
 		self::assertSame(5, $reported);
+	}
+
+	/**
+	 * Etherpad judges `validUntil` against its own clock. If ours runs
+	 * ahead, a session we would call expired is one it still honours, and
+	 * skipping it leaves exactly the access a logout is meant to take away.
+	 */
+	public function testRevokesASessionThatOnlyOurClockCallsExpired(): void {
+		$client = $this->createMock(EtherpadClient::class);
+		$client->method('listSessionsOfAuthor')->willReturn([
+			's.justexpired' => ['groupID' => 'g.AAAAAAAAAAAAAAAA', 'validUntil' => time() - 30],
+			's.longgone' => ['groupID' => 'g.AAAAAAAAAAAAAAAA', 'validUntil' => time() - 3600],
+		]);
+		$client->expects(self::once())->method('deleteSession')->with('s.justexpired');
+
+		self::assertSame(1, $this->revoker($client)->revokeAll('alice'));
+	}
+
+	/**
+	 * The budget only describes the run if it reaches the calls it bounds.
+	 * A deadline checked between them says when the last one may start, not
+	 * when it must end – with the client's own timeout that is two seconds
+	 * promised and seventeen possible, inside a logout somebody is waiting
+	 * for.
+	 */
+	public function testGivesEveryCallWhatIsLeftOfTheBudget(): void {
+		$client = $this->createMock(EtherpadClient::class);
+		$listingTimeout = 'unset';
+		$client->method('listSessionsOfAuthor')->willReturnCallback(
+			static function (string $authorId, ?int $timeout = null) use (&$listingTimeout): array {
+				$listingTimeout = $timeout;
+				return ['s.one' => ['groupID' => 'g.AAAAAAAAAAAAAAAA', 'validUntil' => time() + 3600]];
+			}
+		);
+		$deleteTimeout = 'unset';
+		$client->method('deleteSession')->willReturnCallback(
+			static function (string $id, ?int $timeout = null) use (&$deleteTimeout): void {
+				$deleteTimeout = $timeout;
+			}
+		);
+
+		$this->revoker($client)->revokeAll('alice');
+
+		foreach (['listing' => $listingTimeout, 'delete' => $deleteTimeout] as $what => $timeout) {
+			self::assertNotSame('unset', $timeout, "the {$what} was never made");
+			self::assertNotNull($timeout, "the {$what} went out with the client default");
+			self::assertLessThanOrEqual(2, $timeout, "the {$what} may not outlast the budget");
+			self::assertGreaterThanOrEqual(1, $timeout);
+		}
 	}
 
 	private function revoker(

--- a/tests/phpunit/unit/PadSessionServiceTest.php
+++ b/tests/phpunit/unit/PadSessionServiceTest.php
@@ -201,12 +201,19 @@ class PadSessionServiceTest extends TestCase {
 		$this->assertSame($this->sid('new'), $value);
 	}
 
-	public function testDropsTheOldSessionOfTheGroupBeingOpened(): void {
-		$stale = $this->sid('stale');
+	/**
+	 * An open always mints. Etherpad re-checks validUntil on every socket
+	 * message and keeps the session id it was handed at CLIENT_READY, so a
+	 * session that expires mid-edit rejects the next keystroke and no later
+	 * cookie reaches that socket — reusing a shorter one would hand out
+	 * less editing time than the caller asked for.
+	 */
+	public function testAlwaysIssuesAFreshSessionForThePadBeingOpened(): void {
+		$held = $this->sid('held');
 
 		$value = $this->openContextCookie(
-			[$stale => ['groupID' => 'g.ABCDEFGHIJKLMNOP', 'validUntil' => time() + 3600]],
-			$stale,
+			[$held => ['groupID' => 'g.ABCDEFGHIJKLMNOP', 'validUntil' => time() + 3600]],
+			$held,
 		)['value'];
 
 		$this->assertSame($this->sid('new'), $value);

--- a/tests/phpunit/unit/PadSessionServiceTest.php
+++ b/tests/phpunit/unit/PadSessionServiceTest.php
@@ -100,15 +100,7 @@ class PadSessionServiceTest extends TestCase {
 			['admin', 'etherpad_nextcloud', 'etherpad_author_id', '', 'a.author'],
 			['admin', 'etherpad_nextcloud', 'etherpad_author_display_name', '', 'Admin'],
 		]);
-		$config->method('deleteUserValue')->willReturnCallback(
-			static function (string $uid, string $app, string $key): void {
-				TestCase::assertNotSame(
-					'etherpad_author_id',
-					$key,
-					'the id is what makes revoking possible at all',
-				);
-			}
-		);
+		$config->expects($this->never())->method('deleteUserValue');
 
 		$service = $this->buildService($etherpadClient, $config);
 		$this->expectException(EtherpadClientException::class);
@@ -823,12 +815,10 @@ class PadSessionServiceTest extends TestCase {
 				[$uid, 'etherpad_nextcloud', 'etherpad_author_id', '', $cachedAuthorId],
 				[$uid, 'etherpad_nextcloud', 'etherpad_author_display_name', '', $displayName],
 			]);
-		// The name goes, the id stays: the id is the only way to find this
-		// user's live sessions again, and a failed open must not take the
-		// ability to revoke them with it.
-		$config->expects($this->once())
-			->method('deleteUserValue')
-			->with($uid, 'etherpad_nextcloud', 'etherpad_author_display_name');
+		// Nothing is cleared: the id is the only way to find this user's
+		// live sessions again, and the name is rewritten by the bootstrap
+		// below in any case.
+		$config->expects($this->never())->method('deleteUserValue');
 		$config->expects($this->exactly(2))
 			->method('setUserValue')
 			->willReturnCallback(static function (string $actualUid, string $appName, string $key, string $value) use ($uid, $freshAuthorId, $displayName): void {

--- a/tests/phpunit/unit/PadSessionServiceTest.php
+++ b/tests/phpunit/unit/PadSessionServiceTest.php
@@ -80,6 +80,42 @@ class PadSessionServiceTest extends TestCase {
 	}
 
 	/**
+	 * A failed open must not take the ability to revoke with it.
+	 *
+	 * The author id is the only route from a uid to that user's live
+	 * sessions. Dropping it when an open fails leaves a cache that cannot
+	 * be told apart from a user who never opened a protected pad – so a
+	 * logout after a brief pad-server outage would revoke nothing while
+	 * sessions from before it were still valid.
+	 */
+	public function testKeepsTheAuthorIdWhenAnOpenFails(): void {
+		$etherpadClient = $this->createMock(EtherpadClient::class);
+		$etherpadClient->method('createSession')
+			->willThrowException(new EtherpadClientException('unavailable'));
+		$etherpadClient->method('createAuthorIfNotExistsFor')
+			->willThrowException(new EtherpadClientException('unavailable'));
+
+		$config = $this->createMock(IConfig::class);
+		$config->method('getUserValue')->willReturnMap([
+			['admin', 'etherpad_nextcloud', 'etherpad_author_id', '', 'a.author'],
+			['admin', 'etherpad_nextcloud', 'etherpad_author_display_name', '', 'Admin'],
+		]);
+		$config->method('deleteUserValue')->willReturnCallback(
+			static function (string $uid, string $app, string $key): void {
+				TestCase::assertNotSame(
+					'etherpad_author_id',
+					$key,
+					'the id is what makes revoking possible at all',
+				);
+			}
+		);
+
+		$service = $this->buildService($etherpadClient, $config);
+		$this->expectException(EtherpadClientException::class);
+		$service->createProtectedOpenContext('admin', 'Admin', 'g.ABCDEFGHIJKLMNOP$pad-1');
+	}
+
+	/**
 	 * Etherpad's real shape: `s.` plus 16 characters. The `x` separates the
 	 * label from the padding, so `g1` and `g10` do not collide.
 	 */
@@ -787,20 +823,12 @@ class PadSessionServiceTest extends TestCase {
 				[$uid, 'etherpad_nextcloud', 'etherpad_author_id', '', $cachedAuthorId],
 				[$uid, 'etherpad_nextcloud', 'etherpad_author_display_name', '', $displayName],
 			]);
-		$config->expects($this->exactly(2))
+		// The name goes, the id stays: the id is the only way to find this
+		// user's live sessions again, and a failed open must not take the
+		// ability to revoke them with it.
+		$config->expects($this->once())
 			->method('deleteUserValue')
-			->willReturnCallback(static function (string $actualUid, string $appName, string $key) use ($uid): void {
-				static $call = 0;
-				$call++;
-				TestCase::assertSame($uid, $actualUid);
-				TestCase::assertSame('etherpad_nextcloud', $appName);
-				if ($call === 1) {
-					TestCase::assertSame('etherpad_author_id', $key);
-					return;
-				}
-
-				TestCase::assertSame('etherpad_author_display_name', $key);
-			});
+			->with($uid, 'etherpad_nextcloud', 'etherpad_author_display_name');
 		$config->expects($this->exactly(2))
 			->method('setUserValue')
 			->willReturnCallback(static function (string $actualUid, string $appName, string $key, string $value) use ($uid, $freshAuthorId, $displayName): void {

--- a/tests/phpunit/unit/UserLoggedOutListenerTest.php
+++ b/tests/phpunit/unit/UserLoggedOutListenerTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * Copyright (c) 2026 Jacob Bühler
+ */
+
+namespace OCA\EtherpadNextcloud\Tests\Unit;
+
+use OCA\EtherpadNextcloud\Listeners\UserLoggedOutListener;
+use OCA\EtherpadNextcloud\Service\PadSessionRevoker;
+use OCP\EventDispatcher\Event;
+use OCP\IUser;
+use OCP\User\Events\UserLoggedOutEvent;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * The Etherpad session cookie is a separate cookie on a separate host with
+ * its own lifetime, and a Nextcloud logout never reached it. On a shared
+ * machine the next person's browser still carried it.
+ */
+class UserLoggedOutListenerTest extends TestCase {
+	public function testTakesTheSessionsWithTheLogout(): void {
+		$revoker = $this->createMock(PadSessionRevoker::class);
+		$revoker->expects(self::once())->method('revokeAll')->with('alice')->willReturn(2);
+
+		$this->listener($revoker)->handle(new UserLoggedOutEvent($this->user('alice')));
+	}
+
+	public function testIgnoresAnEventWithoutAUser(): void {
+		$revoker = $this->createMock(PadSessionRevoker::class);
+		$revoker->expects(self::never())->method('revokeAll');
+
+		$this->listener($revoker)->handle(new UserLoggedOutEvent(null));
+	}
+
+	public function testIgnoresAnyOtherEvent(): void {
+		$revoker = $this->createMock(PadSessionRevoker::class);
+		$revoker->expects(self::never())->method('revokeAll');
+
+		$this->listener($revoker)->handle(new Event());
+	}
+
+	/** A logout does not fail because a pad server is unreachable. */
+	public function testALogoutSurvivesAFailedRevoke(): void {
+		$revoker = $this->createMock(PadSessionRevoker::class);
+		$revoker->method('revokeAll')->willThrowException(new \RuntimeException('etherpad down'));
+
+		$this->listener($revoker)->handle(new UserLoggedOutEvent($this->user('alice')));
+		$this->addToAssertionCount(1);
+	}
+
+	private function user(string $uid): IUser {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn($uid);
+		return $user;
+	}
+
+	private function listener(PadSessionRevoker $revoker): UserLoggedOutListener {
+		return new UserLoggedOutListener($revoker, $this->createMock(LoggerInterface::class));
+	}
+}


### PR DESCRIPTION
## Why

An Etherpad session is a bearer token for one group with a `validUntil`, on another host with its own cookie. A Nextcloud logout never reached it. So anyone who had a protected pad open once could keep opening it through the direct pad URL after logging out – on a shared computer, that means the next person at the machine.

## What it does

**Logout revokes every session that user holds**, not only the ones this browser carries. Deliberately broad: the shared-machine case is exactly the one where the cookie you can see is not the only copy, and a cookie that has left the machine cannot be narrowed down by the one that has not.

**The sessions the browser is carrying go first.** `listSessionsOfAuthor` returns the author index's order, roughly oldest first, so a ceiling counted from the front of that list spends itself on the sessions least likely to be the one in the hand of the person logging out – twenty-six opens of one pad meant revoking twenty-five and leaving the twenty-sixth. The set is unchanged; only the order is. And the ceiling is derived from the cookie's own cap rather than repeating its value, so the two cannot drift apart.

**Bounded**, because it runs inside a logout somebody is waiting for: 25 calls or two seconds, whichever comes first. The budget starts before the listing, each call is given what is left of it, and a call that no longer fits is not made. What does not fit is left to expire – what would have happened without any of this – and the summary line says how much, counting refusals as well as what the budget never reached. A run that revoked nothing is logged as a warning rather than as a revoke with a count of zero.

**Only what is expired on both clocks is skipped.** Etherpad judges `validUntil` against its own, so a session ours calls dead may still be honoured there. The margin lives on `EtherpadClient` and the background collector uses the same one in the opposite direction, so neither side acts inside the window where the clocks disagree.

**No schema.** Sessions belong to an Etherpad author, the author is already cached per uid, and `listSessionsOfAuthor` answers the rest. That cached id is therefore not dropped when an open fails: an emptied cache cannot be told apart from a user who never opened a protected pad, so a logout after a brief pad-server outage would have revoked nothing.

## Scope, on purpose

Only logout. Unshare, folder and group shares, permission downgrades, disabled or deleted accounts and public links revoke nothing, and the docs say so plainly.

Covering them one listener at a time means enumerating every way access can end, and that list has no natural end – a public link opens under its own Etherpad author whose id is deliberately never cached, so there is nothing to look its sessions up by at all. The direction that does close them is the opposite one: short sessions renewed against a live permission check, which needs an Etherpad-side API. This branch is the part that stays correct either way, and the only one that acts immediately rather than within a session lifetime.

Known and written down: logging out on a laptop makes an open pad on a desktop reject the next keystroke, since Etherpad re-checks on every socket message; a failed revoke is not retried and the cookie is never cleared; revocation cannot outrun an open already in flight; `nc:<uid>` is global, so two Nextclouds against one pad server share an author and each other's revocations.

## Verification

840 tests / 2898 assertions, Psalm 0 at `errorLevel=4`, Playwright 32 green.

Each decision above was counter-checked by reintroducing the bug and confirming a test fails: the ordering, the ceiling against a full cookie, the clock margin on both sides at once, the pre-listing budget check, refusals counted as left behind, the summary that must not claim a revoke, and the author id surviving a failed open.

The e2e spec ends where the claim is – at the pad URL, not at a session count. It opens a protected pad, asserts it is reachable, logs out, then requires Etherpad's own `#permissionDenied`, and checks the Etherpad cookie is **still present** afterwards: without that, the last step would pass just as well for a browser that had simply forgotten it. It is also the only layer that can show the cookie reaching Nextcloud at all, since the unit tests hand the revoker its carried ids directly. The test logs in on its own rather than using the suite's stored session, which logging out of would leave every spec after it unauthenticated.
