### PR TITLE
Address created files by identity, not by the node the create was handed

### DIFF
--- a/l10n/de.js
+++ b/l10n/de.js
@@ -166,6 +166,7 @@ OC.L10N.register(
     "The cookie domain is empty, so the session cookie stays on the Nextcloud host and never reaches Etherpad.": "Die Cookie-Domain ist leer, daher bleibt das Sitzungscookie beim Nextcloud-Host und erreicht Etherpad nie.",
     "The server did not say where to load this pad from.": "Der Server hat nicht mitgeteilt, woher dieses Pad geladen werden soll.",
     "The session cookie domain could not be verified.": "Die Domain des Sitzungscookies konnte nicht geprüft werden.",
+    "The target file changed while the pad was being created. Try again with a new name.": "Die Zieldatei hat sich geändert, während das Pad erstellt wurde. Versuche es mit einem neuen Namen erneut.",
     "This .pad file has no matching pad in this Nextcloud.": "Für diese .pad-Datei existiert in dieser Nextcloud kein passendes Pad.",
     "This file looks like a copy of an existing .pad file in your account. Open the original to keep editing the linked pad, or create a new pad to fork the content stored in this file.": "Diese Datei sieht aus wie eine Kopie einer bereits vorhandenen .pad-Datei in deinem Konto. Öffne das Original, um am verknüpften Pad weiterzuarbeiten, oder erstelle aus dem in dieser Datei gespeicherten Inhalt ein neues Pad als eigene Kopie.",
     "This file may have been moved or replaced since the list was loaded. Reload the page and open it again.": "Diese Datei wurde seit dem Laden der Liste möglicherweise verschoben oder ersetzt. Lade die Seite neu und öffne die Datei erneut.",

--- a/l10n/de.json
+++ b/l10n/de.json
@@ -165,6 +165,7 @@
         "The cookie domain is empty, so the session cookie stays on the Nextcloud host and never reaches Etherpad.": "Die Cookie-Domain ist leer, daher bleibt das Sitzungscookie beim Nextcloud-Host und erreicht Etherpad nie.",
         "The server did not say where to load this pad from.": "Der Server hat nicht mitgeteilt, woher dieses Pad geladen werden soll.",
         "The session cookie domain could not be verified.": "Die Domain des Sitzungscookies konnte nicht geprüft werden.",
+        "The target file changed while the pad was being created. Try again with a new name.": "Die Zieldatei hat sich geändert, während das Pad erstellt wurde. Versuche es mit einem neuen Namen erneut.",
         "This .pad file has no matching pad in this Nextcloud.": "Für diese .pad-Datei existiert in dieser Nextcloud kein passendes Pad.",
         "This file looks like a copy of an existing .pad file in your account. Open the original to keep editing the linked pad, or create a new pad to fork the content stored in this file.": "Diese Datei sieht aus wie eine Kopie einer bereits vorhandenen .pad-Datei in deinem Konto. Öffne das Original, um am verknüpften Pad weiterzuarbeiten, oder erstelle aus dem in dieser Datei gespeicherten Inhalt ein neues Pad als eigene Kopie.",
         "This file may have been moved or replaced since the list was loaded. Reload the page and open it again.": "Diese Datei wurde seit dem Laden der Liste möglicherweise verschoben oder ersetzt. Lade die Seite neu und öffne die Datei erneut.",

--- a/l10n/es.js
+++ b/l10n/es.js
@@ -166,6 +166,7 @@ OC.L10N.register(
     "The cookie domain is empty, so the session cookie stays on the Nextcloud host and never reaches Etherpad.": "El dominio de la cookie está vacío, por lo que la cookie de sesión se queda en el host de Nextcloud y nunca llega a Etherpad.",
     "The server did not say where to load this pad from.": "El servidor no indicó desde dónde cargar este pad.",
     "The session cookie domain could not be verified.": "No se pudo verificar el dominio de la cookie de sesión.",
+    "The target file changed while the pad was being created. Try again with a new name.": "El archivo de destino cambió mientras se creaba el pad. Inténtalo de nuevo con otro nombre.",
     "This .pad file has no matching pad in this Nextcloud.": "Este archivo .pad no tiene ningún pad correspondiente en este Nextcloud.",
     "This file looks like a copy of an existing .pad file in your account. Open the original to keep editing the linked pad, or create a new pad to fork the content stored in this file.": "Este archivo parece ser una copia de un archivo .pad existente en tu cuenta. Abre el original para seguir editando el pad enlazado, o crea un nuevo pad para crear una copia independiente del contenido almacenado en este archivo.",
     "This file may have been moved or replaced since the list was loaded. Reload the page and open it again.": "Es posible que este archivo se haya movido o reemplazado desde que se cargó la lista. Recarga la página y vuelve a abrir el archivo.",

--- a/l10n/es.json
+++ b/l10n/es.json
@@ -165,6 +165,7 @@
         "The cookie domain is empty, so the session cookie stays on the Nextcloud host and never reaches Etherpad.": "El dominio de la cookie está vacío, por lo que la cookie de sesión se queda en el host de Nextcloud y nunca llega a Etherpad.",
         "The server did not say where to load this pad from.": "El servidor no indicó desde dónde cargar este pad.",
         "The session cookie domain could not be verified.": "No se pudo verificar el dominio de la cookie de sesión.",
+        "The target file changed while the pad was being created. Try again with a new name.": "El archivo de destino cambió mientras se creaba el pad. Inténtalo de nuevo con otro nombre.",
         "This .pad file has no matching pad in this Nextcloud.": "Este archivo .pad no tiene ningún pad correspondiente en este Nextcloud.",
         "This file looks like a copy of an existing .pad file in your account. Open the original to keep editing the linked pad, or create a new pad to fork the content stored in this file.": "Este archivo parece ser una copia de un archivo .pad existente en tu cuenta. Abre el original para seguir editando el pad enlazado, o crea un nuevo pad para crear una copia independiente del contenido almacenado en este archivo.",
         "This file may have been moved or replaced since the list was loaded. Reload the page and open it again.": "Es posible que este archivo se haya movido o reemplazado desde que se cargó la lista. Recarga la página y vuelve a abrir el archivo.",

--- a/l10n/fr.js
+++ b/l10n/fr.js
@@ -166,6 +166,7 @@ OC.L10N.register(
     "The cookie domain is empty, so the session cookie stays on the Nextcloud host and never reaches Etherpad.": "Le domaine du cookie est vide : le cookie de session reste sur l'hôte Nextcloud et n'atteint jamais Etherpad.",
     "The server did not say where to load this pad from.": "Le serveur n'a pas indiqué d'où charger ce pad.",
     "The session cookie domain could not be verified.": "Le domaine du cookie de session n'a pas pu être vérifié.",
+    "The target file changed while the pad was being created. Try again with a new name.": "Le fichier cible a changé pendant la création du pad. Réessayez avec un autre nom.",
     "This .pad file has no matching pad in this Nextcloud.": "Ce fichier .pad n'a pas de pad correspondant dans ce Nextcloud.",
     "This file looks like a copy of an existing .pad file in your account. Open the original to keep editing the linked pad, or create a new pad to fork the content stored in this file.": "Ce fichier ressemble à une copie d'un fichier .pad existant dans votre compte. Ouvrez l'original pour continuer à modifier le pad lié, ou créez un nouveau pad pour dupliquer le contenu stocké dans ce fichier.",
     "This file may have been moved or replaced since the list was loaded. Reload the page and open it again.": "Ce fichier a peut-être été déplacé ou remplacé depuis le chargement de la liste. Rechargez la page et rouvrez le fichier.",

--- a/l10n/fr.json
+++ b/l10n/fr.json
@@ -165,6 +165,7 @@
         "The cookie domain is empty, so the session cookie stays on the Nextcloud host and never reaches Etherpad.": "Le domaine du cookie est vide : le cookie de session reste sur l'hôte Nextcloud et n'atteint jamais Etherpad.",
         "The server did not say where to load this pad from.": "Le serveur n'a pas indiqué d'où charger ce pad.",
         "The session cookie domain could not be verified.": "Le domaine du cookie de session n'a pas pu être vérifié.",
+        "The target file changed while the pad was being created. Try again with a new name.": "Le fichier cible a changé pendant la création du pad. Réessayez avec un autre nom.",
         "This .pad file has no matching pad in this Nextcloud.": "Ce fichier .pad n'a pas de pad correspondant dans ce Nextcloud.",
         "This file looks like a copy of an existing .pad file in your account. Open the original to keep editing the linked pad, or create a new pad to fork the content stored in this file.": "Ce fichier ressemble à une copie d'un fichier .pad existant dans votre compte. Ouvrez l'original pour continuer à modifier le pad lié, ou créez un nouveau pad pour dupliquer le contenu stocké dans ce fichier.",
         "This file may have been moved or replaced since the list was loaded. Reload the page and open it again.": "Ce fichier a peut-être été déplacé ou remplacé depuis le chargement de la liste. Rechargez la page et rouvrez le fichier.",

--- a/l10n/it.js
+++ b/l10n/it.js
@@ -166,6 +166,7 @@ OC.L10N.register(
     "The cookie domain is empty, so the session cookie stays on the Nextcloud host and never reaches Etherpad.": "Il dominio del cookie è vuoto, quindi il cookie di sessione resta sull'host Nextcloud e non raggiunge mai Etherpad.",
     "The server did not say where to load this pad from.": "Il server non ha indicato da dove caricare questo pad.",
     "The session cookie domain could not be verified.": "Non è stato possibile verificare il dominio del cookie di sessione.",
+    "The target file changed while the pad was being created. Try again with a new name.": "Il file di destinazione è cambiato durante la creazione del pad. Riprova con un altro nome.",
     "This .pad file has no matching pad in this Nextcloud.": "Questo file .pad non ha alcun pad corrispondente in questo Nextcloud.",
     "This file looks like a copy of an existing .pad file in your account. Open the original to keep editing the linked pad, or create a new pad to fork the content stored in this file.": "Questo file sembra una copia di un file .pad già esistente nel tuo account. Apri l'originale per continuare a modificare il pad collegato, oppure crea un nuovo pad per creare una copia indipendente del contenuto memorizzato in questo file.",
     "This file may have been moved or replaced since the list was loaded. Reload the page and open it again.": "Questo file potrebbe essere stato spostato o sostituito da quando l’elenco è stato caricato. Ricarica la pagina e riapri il file.",

--- a/l10n/it.json
+++ b/l10n/it.json
@@ -165,6 +165,7 @@
         "The cookie domain is empty, so the session cookie stays on the Nextcloud host and never reaches Etherpad.": "Il dominio del cookie è vuoto, quindi il cookie di sessione resta sull'host Nextcloud e non raggiunge mai Etherpad.",
         "The server did not say where to load this pad from.": "Il server non ha indicato da dove caricare questo pad.",
         "The session cookie domain could not be verified.": "Non è stato possibile verificare il dominio del cookie di sessione.",
+        "The target file changed while the pad was being created. Try again with a new name.": "Il file di destinazione è cambiato durante la creazione del pad. Riprova con un altro nome.",
         "This .pad file has no matching pad in this Nextcloud.": "Questo file .pad non ha alcun pad corrispondente in questo Nextcloud.",
         "This file looks like a copy of an existing .pad file in your account. Open the original to keep editing the linked pad, or create a new pad to fork the content stored in this file.": "Questo file sembra una copia di un file .pad già esistente nel tuo account. Apri l'originale per continuare a modificare il pad collegato, oppure crea un nuovo pad per creare una copia indipendente del contenuto memorizzato in questo file.",
         "This file may have been moved or replaced since the list was loaded. Reload the page and open it again.": "Questo file potrebbe essere stato spostato o sostituito da quando l’elenco è stato caricato. Ricarica la pagina e riapri il file.",

--- a/lib/Controller/PadControllerErrorMapper.php
+++ b/lib/Controller/PadControllerErrorMapper.php
@@ -17,6 +17,7 @@ use OCA\EtherpadNextcloud\Exception\EtherpadClientException;
 use OCA\EtherpadNextcloud\Exception\EtherpadTooLargeException;
 use OCA\EtherpadNextcloud\Exception\PadAlreadyHasBindingException;
 use OCA\EtherpadNextcloud\Exception\PadFileAlreadyExistsException;
+use OCA\EtherpadNextcloud\Exception\PadFileChangedException;
 use OCA\EtherpadNextcloud\Exception\PadFileFormatException;
 use OCA\EtherpadNextcloud\Exception\PadParentFolderNotWritableException;
 use OCA\EtherpadNextcloud\Exception\PadTypeDisabledException;
@@ -48,6 +49,7 @@ class PadControllerErrorMapper {
 	 *   invalid_argument?: string,
 	 *   not_found?: string,
 	 *   too_large?: string,
+	 *   file_changed?: string,
 	 *   binding_message?: string,
 	 *   binding_status?: int,
 	 *   generic?: string,
@@ -93,6 +95,15 @@ class PadControllerErrorMapper {
 				'message' => 'Pad file is temporarily locked. Please retry.',
 				'retryable' => true,
 			], Http::STATUS_SERVICE_UNAVAILABLE);
+		} catch (PadFileChangedException $e) {
+			// A conflict, not a server fault: the file this create claimed is
+			// not the file that is there now, so it refused to write. Its own
+			// code, because the caller's retry has to target a fresh name
+			// rather than repeat the same request.
+			return new DataResponse([
+				'message' => $options['file_changed'] ?? 'The target file changed while the pad was being created.',
+				'code' => 'pad_file_changed',
+			], Http::STATUS_CONFLICT);
 		} catch (PadFileAlreadyExistsException) {
 			return new DataResponse([
 				'message' => 'A file with this name already exists.',

--- a/lib/Controller/PadControllerErrorMapper.php
+++ b/lib/Controller/PadControllerErrorMapper.php
@@ -96,10 +96,6 @@ class PadControllerErrorMapper {
 				'retryable' => true,
 			], Http::STATUS_SERVICE_UNAVAILABLE);
 		} catch (PadFileChangedException $e) {
-			// A conflict, not a server fault: the file this create claimed is
-			// not the file that is there now, so it refused to write. Its own
-			// code, because the caller's retry has to target a fresh name
-			// rather than repeat the same request.
 			return new DataResponse([
 				'message' => $options['file_changed'] ?? 'The target file changed while the pad was being created.',
 				'code' => 'pad_file_changed',

--- a/lib/Controller/PadCreateController.php
+++ b/lib/Controller/PadCreateController.php
@@ -48,6 +48,7 @@ class PadCreateController extends AbstractPadController {
 				'invalid_argument' => $this->l10n->t('Invalid file path.'),
 				'binding_message' => $this->l10n->t('A file with this name already exists.'),
 				'binding_status' => Http::STATUS_CONFLICT,
+				'file_changed' => $this->l10n->t('The target file changed while the pad was being created. Try again with a new name.'),
 				'generic' => $this->l10n->t('Could not create pad'),
 			],
 		);
@@ -68,6 +69,7 @@ class PadCreateController extends AbstractPadController {
 				'not_found' => $this->l10n->t('Cannot resolve selected parent folder.'),
 				'binding_message' => $this->l10n->t('A file with this name already exists.'),
 				'binding_status' => Http::STATUS_CONFLICT,
+				'file_changed' => $this->l10n->t('The target file changed while the pad was being created. Try again with a new name.'),
 				'generic' => $this->l10n->t('Could not create pad'),
 			],
 		);
@@ -88,6 +90,7 @@ class PadCreateController extends AbstractPadController {
 				'not_found' => $this->l10n->t('Template file not found.'),
 				'binding_message' => $this->l10n->t('A file with this name already exists.'),
 				'binding_status' => Http::STATUS_CONFLICT,
+				'file_changed' => $this->l10n->t('The target file changed while the pad was being created. Try again with a new name.'),
 				'generic' => $this->l10n->t('Could not create pad from template.'),
 			],
 		);
@@ -100,6 +103,7 @@ class PadCreateController extends AbstractPadController {
 			fn(array $result): DataResponse => new DataResponse($this->padResponses->withViewerUrl($result)),
 			[
 				'invalid_argument' => $this->l10n->t('Invalid input.'),
+				'file_changed' => $this->l10n->t('The target file changed while the pad was being created. Try again with a new name.'),
 				'generic' => $this->l10n->t('Could not import external pad.'),
 			],
 		);

--- a/lib/Exception/PadFileChangedException.php
+++ b/lib/Exception/PadFileChangedException.php
@@ -10,11 +10,8 @@ declare(strict_types=1);
 namespace OCA\EtherpadNextcloud\Exception;
 
 /**
- * The target file is no longer what this create claimed.
- *
- * Its own type because the only correct response is to stop touching the
- * file. A caller that treats it as a generic failure and "recovers" by
- * emptying the target destroys exactly the content this check found.
+ * The target content differs from the create's expected state.
+ * Recovery must not blank or delete that content.
  */
 class PadFileChangedException extends \RuntimeException {
 }

--- a/lib/Exception/PadFileChangedException.php
+++ b/lib/Exception/PadFileChangedException.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Copyright (c) 2026 Jacob Bühler
+ */
+
+namespace OCA\EtherpadNextcloud\Exception;
+
+/**
+ * The target file is no longer what this create claimed.
+ *
+ * Its own type because the only correct response is to stop touching the
+ * file. A caller that treats it as a generic failure and "recovers" by
+ * emptying the target destroys exactly the content this check found.
+ */
+class PadFileChangedException extends \RuntimeException {
+}

--- a/lib/Listeners/FileCreatedFromTemplateListener.php
+++ b/lib/Listeners/FileCreatedFromTemplateListener.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace OCA\EtherpadNextcloud\Listeners;
 
+use OCA\EtherpadNextcloud\Exception\PadFileChangedException;
 use OCA\EtherpadNextcloud\Exception\PadTypeDisabledException;
 use OCA\EtherpadNextcloud\Service\PadBootstrapService;
 use OCA\EtherpadNextcloud\Service\ExternalPadSeeder;
@@ -102,6 +103,17 @@ class FileCreatedFromTemplateListener implements IEventListener {
 			]);
 			$this->deleteTarget($target);
 			throw $e;
+		} catch (PadFileChangedException $e) {
+			// Somebody else wrote into this file while the pad was being
+			// provisioned. The blank fallback below would empty exactly the
+			// content that check just refused to overwrite, so this failure
+			// ends here without touching the file at all.
+			$this->logger->warning('Pad template create stopped: the target file changed while the pad was provisioned.', [
+				'app' => 'etherpad_nextcloud',
+				'targetFileId' => (int)$target->getId(),
+				'exception' => $e,
+			]);
+			return;
 		} catch (\Throwable $e) {
 			$this->logger->error('Pad template materialization failed — falling back to blank-pad init.', [
 				'app' => 'etherpad_nextcloud',

--- a/lib/Listeners/FileCreatedFromTemplateListener.php
+++ b/lib/Listeners/FileCreatedFromTemplateListener.php
@@ -89,8 +89,22 @@ class FileCreatedFromTemplateListener implements IEventListener {
 			return;
 		}
 
+		// Made before anything can fail, and used by every recovery below.
+		// A failure says nothing about who owns the file afterwards: the pad
+		// call may have failed *because* the file moved, and the name it
+		// left behind may belong to somebody else by the time we look.
 		try {
-			$this->padCreationService->materializeTemplateInto($target, $template, $user);
+			$claim = $this->padCreationService->claimTemplateTarget($target, $user);
+		} catch (\Throwable $e) {
+			$this->logger->warning('Pad template create skipped: the target could not be identified.', [
+				'app' => 'etherpad_nextcloud',
+				'exception' => $e,
+			]);
+			return;
+		}
+
+		try {
+			$this->padCreationService->materializeTemplateInto($target, $template, $user, $claim);
 		} catch (PadTypeDisabledException $e) {
 			// Not a hiccup to retry around: the instance creates no pads at all
 			// right now, which happens when the setting changes while the
@@ -101,7 +115,10 @@ class FileCreatedFromTemplateListener implements IEventListener {
 				'targetFileId' => (int)$target->getId(),
 				'exception' => $e,
 			]);
-			$this->deleteTarget($target);
+			$unchanged = $this->padCreationService->resolveUnchangedClaim($claim);
+			if ($unchanged !== null) {
+				$this->deleteTarget($unchanged);
+			}
 			throw $e;
 		} catch (PadFileChangedException $e) {
 			// Somebody else wrote into this file while the pad was being
@@ -121,11 +138,23 @@ class FileCreatedFromTemplateListener implements IEventListener {
 				'templateFileId' => (int)$template->getId(),
 				'exception' => $e,
 			]);
-			$this->resetTargetToEmpty($target);
+			// Only onto the file this listener was handed, and only while it
+			// is still that file. Otherwise the recovery would empty
+			// somebody else's document — the very thing the write refused to
+			// do a moment earlier.
+			$unchanged = $this->padCreationService->resolveUnchangedClaim($claim);
+			if ($unchanged === null) {
+				$this->logger->warning('Left the template target alone: it is no longer the file this create was given.', [
+					'app' => 'etherpad_nextcloud',
+					'targetFileId' => $claim->fileId,
+				]);
+				return;
+			}
+			$this->resetTargetToEmpty($unchanged);
 			// Re-initialise after the wipe so the user still gets a clean,
 			// openable pad even though the template path failed. A disabled
 			// pad type travels on from here as well.
-			$this->initializeBlankPad($user->getUID(), $target);
+			$this->initializeBlankPad($user->getUID(), $unchanged);
 		}
 	}
 

--- a/lib/Listeners/FileCreatedFromTemplateListener.php
+++ b/lib/Listeners/FileCreatedFromTemplateListener.php
@@ -89,12 +89,14 @@ class FileCreatedFromTemplateListener implements IEventListener {
 			return;
 		}
 
-		// Made before anything can fail, and used by every recovery below.
-		// A failure says nothing about who owns the file afterwards: the pad
-		// call may have failed *because* the file moved, and the name it
-		// left behind may belong to somebody else by the time we look.
+		// Capture identity and content before materialization; recovery uses the same claim.
+		// Both ids read once, here, and used by every log line below. Reading
+		// them again inside a catch is the stale-node re-read this whole
+		// change is about: it answers for whatever holds the path by then,
+		// and it can throw while an error is already being handled.
 		try {
 			$claim = $this->padCreationService->claimTemplateTarget($target, $user);
+			$templateFileId = (int)$template->getId();
 		} catch (\Throwable $e) {
 			$this->logger->warning('Pad template create skipped: the target could not be identified.', [
 				'app' => 'etherpad_nextcloud',
@@ -112,36 +114,30 @@ class FileCreatedFromTemplateListener implements IEventListener {
 			// reason and leave an empty .pad nobody can open.
 			$this->logger->warning('Pad template create refused: no pad type is enabled.', [
 				'app' => 'etherpad_nextcloud',
-				'targetFileId' => (int)$target->getId(),
+				'targetFileId' => $claim->fileId,
 				'exception' => $e,
 			]);
 			$unchanged = $this->padCreationService->resolveUnchangedClaim($claim);
 			if ($unchanged !== null) {
-				$this->deleteTarget($unchanged);
+				$this->deleteTarget($unchanged, $claim->fileId);
 			}
 			throw $e;
 		} catch (PadFileChangedException $e) {
-			// Somebody else wrote into this file while the pad was being
-			// provisioned. The blank fallback below would empty exactly the
-			// content that check just refused to overwrite, so this failure
-			// ends here without touching the file at all.
+			// Do not blank content that the guarded write refused to overwrite.
 			$this->logger->warning('Pad template create stopped: the target file changed while the pad was provisioned.', [
 				'app' => 'etherpad_nextcloud',
-				'targetFileId' => (int)$target->getId(),
+				'targetFileId' => $claim->fileId,
 				'exception' => $e,
 			]);
 			return;
 		} catch (\Throwable $e) {
 			$this->logger->error('Pad template materialization failed — falling back to blank-pad init.', [
 				'app' => 'etherpad_nextcloud',
-				'targetFileId' => (int)$target->getId(),
-				'templateFileId' => (int)$template->getId(),
+				'targetFileId' => $claim->fileId,
+				'templateFileId' => $templateFileId,
 				'exception' => $e,
 			]);
-			// Only onto the file this listener was handed, and only while it
-			// is still that file. Otherwise the recovery would empty
-			// somebody else's document — the very thing the write refused to
-			// do a moment earlier.
+			// Other failures do not imply unchanged content: check before resetting.
 			$unchanged = $this->padCreationService->resolveUnchangedClaim($claim);
 			if ($unchanged === null) {
 				$this->logger->warning('Left the template target alone: it is no longer the file this create was given.', [
@@ -150,7 +146,7 @@ class FileCreatedFromTemplateListener implements IEventListener {
 				]);
 				return;
 			}
-			$this->resetTargetToEmpty($unchanged);
+			$this->resetTargetToEmpty($unchanged, $claim->fileId);
 			// Re-initialise after the wipe so the user still gets a clean,
 			// openable pad even though the template path failed. A disabled
 			// pad type travels on from here as well.
@@ -243,25 +239,40 @@ class FileCreatedFromTemplateListener implements IEventListener {
 		return is_string($field) ? trim($field) : '';
 	}
 
-	private function deleteTarget(File $target): void {
+	/**
+	 * `$fileId` is passed in rather than read here: this runs while an error
+	 * is already being handled, and `Node::getId()` re-reads through the
+	 * node's path — it can throw, and on a replaced path it answers for the
+	 * wrong file.
+	 */
+	private function deleteTarget(File $target, ?int $fileId = null): void {
 		try {
 			$target->delete();
 		} catch (\Throwable $e) {
 			$this->logger->warning('Could not remove the .pad file of a failed template create.', [
 				'app' => 'etherpad_nextcloud',
-				'fileId' => (int)$target->getId(),
+				'fileId' => $fileId ?? $this->idOrNull($target),
 				'exception' => $e,
 			]);
 		}
 	}
 
-	private function resetTargetToEmpty(File $target): void {
+	private function idOrNull(File $file): ?int {
+		try {
+			return (int)$file->getId();
+		} catch (\Throwable) {
+			return null;
+		}
+	}
+
+	/** See deleteTarget() for why the id is a parameter. */
+	private function resetTargetToEmpty(File $target, ?int $fileId = null): void {
 		try {
 			$target->putContent('');
 		} catch (\Throwable $e) {
 			$this->logger->warning('Could not reset target file content after rejected template.', [
 				'app' => 'etherpad_nextcloud',
-				'fileId' => (int)$target->getId(),
+				'fileId' => $fileId ?? $this->idOrNull($target),
 				'exception' => $e,
 			]);
 		}

--- a/lib/Service/CreatedFileClaim.php
+++ b/lib/Service/CreatedFileClaim.php
@@ -10,16 +10,10 @@ declare(strict_types=1);
 namespace OCA\EtherpadNextcloud\Service;
 
 /**
- * What one create attempt knows about the file it claimed.
+ * Identity, expected content and write evidence for one create attempt.
  *
- * Held together on purpose. Each of these was being re-derived at the point
- * of use — the id read again from a node, the prior content read again
- * inside a helper, the written hash returned through a value that a failing
- * caller never received — and every one of those re-derivations was a way
- * to act on the wrong file or with the wrong expectation.
- *
- * Carried by reference, so a write that succeeds reaches the rollback of a
- * step that fails afterwards.
+ * Pass the same instance through writing and recovery so a later failure
+ * retains the write evidence. A claim does not lock the file.
  */
 class CreatedFileClaim {
 	public ?string $writtenHash = null;
@@ -27,8 +21,7 @@ class CreatedFileClaim {
 	public function __construct(
 		public readonly string $uid,
 		public readonly int $fileId,
-		/** What the file held when this attempt claimed it: empty for a file
-		 *  we created, the template's bytes for Nextcloud's template hook. */
+		/** Initially empty for API creates; copied template content for the hook. */
 		public readonly string $expectedBefore = '',
 	) {
 	}

--- a/lib/Service/CreatedFileClaim.php
+++ b/lib/Service/CreatedFileClaim.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Copyright (c) 2026 Jacob Bühler
+ */
+
+namespace OCA\EtherpadNextcloud\Service;
+
+/**
+ * What one create attempt knows about the file it claimed.
+ *
+ * Held together on purpose. Each of these was being re-derived at the point
+ * of use — the id read again from a node, the prior content read again
+ * inside a helper, the written hash returned through a value that a failing
+ * caller never received — and every one of those re-derivations was a way
+ * to act on the wrong file or with the wrong expectation.
+ *
+ * Carried by reference, so a write that succeeds reaches the rollback of a
+ * step that fails afterwards.
+ */
+class CreatedFileClaim {
+	public ?string $writtenHash = null;
+
+	public function __construct(
+		public readonly string $uid,
+		public readonly int $fileId,
+		/** What the file held when this attempt claimed it: empty for a file
+		 *  we created, the template's bytes for Nextcloud's template hook. */
+		public readonly string $expectedBefore = '',
+	) {
+	}
+}

--- a/lib/Service/ExternalPadSeeder.php
+++ b/lib/Service/ExternalPadSeeder.php
@@ -31,10 +31,7 @@ class ExternalPadSeeder {
 
 	/**
 	 * Fetch the remote export and build the document, without writing it.
-	 *
-	 * Split out because the fetch is slow, and a caller that created the
-	 * target itself must write by id afterwards rather than through the
-	 * node it was holding when the fetch began.
+	 * Lets callers re-resolve and check their target after the remote fetch.
 	 *
 	 * @return array{content:string,result:array{file_id:int,pad_id:string,access_mode:string,pad_url:string,snapshot_warning_code?:string}}
 	 */
@@ -79,8 +76,7 @@ class ExternalPadSeeder {
 	}
 
 	/**
-	 * Prepare and write in one step, for callers handed a file they did not
-	 * create and so have no id of their own to write by.
+	 * Prepare and write through the supplied node without re-resolving or checking it.
 	 *
 	 * @return array{file_id:int,pad_id:string,access_mode:string,pad_url:string,snapshot_warning_code?:string}
 	 */

--- a/lib/Service/ExternalPadSeeder.php
+++ b/lib/Service/ExternalPadSeeder.php
@@ -30,9 +30,15 @@ class ExternalPadSeeder {
 	}
 
 	/**
-	 * @return array{file_id:int,pad_id:string,access_mode:string,pad_url:string,snapshot_warning_code?:string}
+	 * Fetch the remote export and build the document, without writing it.
+	 *
+	 * Split out because the fetch is slow, and a caller that created the
+	 * target itself must write by id afterwards rather than through the
+	 * node it was holding when the fetch began.
+	 *
+	 * @return array{content:string,result:array{file_id:int,pad_id:string,access_mode:string,pad_url:string,snapshot_warning_code?:string}}
 	 */
-	public function seed(File $file, int $fileId, string $padUrl): array {
+	public function prepare(int $fileId, string $padUrl): array {
 		$external = $this->externalPadExportFetcher->normalizeAndFetchExternalPublicPadTextOrEmpty($padUrl);
 		// External pads aren't DB-bound (we don't own their lifecycle), so the
 		// local `ext.*` pad-id is just a marker distinguishing them from
@@ -51,7 +57,6 @@ class ExternalPadSeeder {
 			]
 		);
 		$content = $this->padFileService->withExportSnapshot($content, $external['text'], '', 0, false);
-		$file->putContent($content);
 
 		$result = [
 			'file_id' => $fileId,
@@ -69,6 +74,20 @@ class ExternalPadSeeder {
 			// the frontend translates into a toast.
 			$result['snapshot_warning_code'] = 'remote_export_unavailable';
 		}
-		return $result;
+
+		return ['content' => $content, 'result' => $result];
+	}
+
+	/**
+	 * Prepare and write in one step, for callers handed a file they did not
+	 * create and so have no id of their own to write by.
+	 *
+	 * @return array{file_id:int,pad_id:string,access_mode:string,pad_url:string,snapshot_warning_code?:string}
+	 */
+	public function seed(File $file, int $fileId, string $padUrl): array {
+		$prepared = $this->prepare($fileId, $padUrl);
+		$file->putContent($prepared['content']);
+
+		return $prepared['result'];
 	}
 }

--- a/lib/Service/PadBootstrapService.php
+++ b/lib/Service/PadBootstrapService.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace OCA\EtherpadNextcloud\Service;
 
+use OCA\EtherpadNextcloud\Exception\PadFileChangedException;
 use OCA\EtherpadNextcloud\Exception\PadFileFormatException;
 use OCP\Files\File;
 use OCP\Security\ISecureRandom;
@@ -23,6 +24,7 @@ class PadBootstrapService {
 		private LoggerInterface $logger,
 		private PadLegacyMigrationService $legacyMigrationService,
 		private PadTypePolicy $padTypePolicy,
+		private UserNodeResolver $userNodeResolver,
 	) {
 	}
 
@@ -123,7 +125,13 @@ class PadBootstrapService {
 
 			$padUrl = $this->etherpadClient->buildPadUrl($padId);
 			$doc = $this->padFileService->buildInitialDocument($fileId, $padId, $accessMode, '', $padUrl);
-			$file->putContent($doc);
+			// By id, and only while the file still holds what the caller
+			// read: provisioning the pad above is a full round trip to
+			// another host, and `File::putContent()` writes to the path its
+			// object remembers. The file can be moved and its name taken in
+			// that time, and this document names a file id — writing it into
+			// somebody else's file mislabels theirs and loses their content.
+			$this->writeInitialDocument($uid, $fileId, $existingContent, $doc);
 		} catch (\Throwable $e) {
 			if ($createdNewPad) {
 				$this->rollbackProvisionedPad($fileId, $padId);
@@ -131,6 +139,18 @@ class PadBootstrapService {
 			throw $e;
 		}
 		return false;
+	}
+
+	/**
+	 * @throws PadFileChangedException when the file is no longer the one the
+	 *                                 caller read
+	 */
+	private function writeInitialDocument(string $uid, int $fileId, string $expectedBefore, string $doc): void {
+		$node = $this->userNodeResolver->resolveUserFileNodeById($uid, $fileId);
+		if ((string)$node->getContent() !== $expectedBefore) {
+			throw new PadFileChangedException('The .pad file changed while its pad was being provisioned.');
+		}
+		$node->putContent($doc);
 	}
 
 	/**

--- a/lib/Service/PadBootstrapService.php
+++ b/lib/Service/PadBootstrapService.php
@@ -125,12 +125,7 @@ class PadBootstrapService {
 
 			$padUrl = $this->etherpadClient->buildPadUrl($padId);
 			$doc = $this->padFileService->buildInitialDocument($fileId, $padId, $accessMode, '', $padUrl);
-			// By id, and only while the file still holds what the caller
-			// read: provisioning the pad above is a full round trip to
-			// another host, and `File::putContent()` writes to the path its
-			// object remembers. The file can be moved and its name taken in
-			// that time, and this document names a file id — writing it into
-			// somebody else's file mislabels theirs and loses their content.
+			// Re-resolve after provisioning: the original File still writes to its remembered path.
 			$this->writeInitialDocument($uid, $fileId, $existingContent, $doc);
 		} catch (\Throwable $e) {
 			if ($createdNewPad) {
@@ -142,8 +137,7 @@ class PadBootstrapService {
 	}
 
 	/**
-	 * @throws PadFileChangedException when the file is no longer the one the
-	 *                                 caller read
+	 * @throws PadFileChangedException when the content differs from what the caller read
 	 */
 	private function writeInitialDocument(string $uid, int $fileId, string $expectedBefore, string $doc): void {
 		$node = $this->userNodeResolver->resolveUserFileNodeById($uid, $fileId);

--- a/lib/Service/PadCreateRollbackService.php
+++ b/lib/Service/PadCreateRollbackService.php
@@ -18,12 +18,9 @@ use Psr\Log\LoggerInterface;
  * Cleanup steps are isolated and best-effort so cleanup errors do not mask
  * the original create failure.
  *
- * Cleanup is addressed by the file id the create read once, at the moment it
- * created the file — never by a `File` object and never by asking one for
- * its id again. `File::delete()` unlinks its remembered path and
- * `Node::getId()` re-reads through that same path, so a node held across pad
- * provisioning answers for whatever occupies the path by then. An id that
- * was never read stays unknown, and an unknown id deletes nothing.
+ * Resolve the captured file id before deletion: a retained File deletes
+ * its remembered path, and getId() may read a replacement at that path.
+ * Without a claim, leave the file in place.
  */
 class PadCreateRollbackService {
 	public function __construct(
@@ -62,19 +59,13 @@ class PadCreateRollbackService {
 	 */
 	public function rollbackCreatedFileOnly(string $uid, string $path, ?CreatedFileClaim $claim): void {
 		if ($claim === null) {
-			// The create never got an id it could trust, so there is nothing
-			// here that identifies a file. Leaving a stray empty `.pad`
-			// behind is a mess; deleting the wrong file is a loss.
 			return;
 		}
 
 		try {
 			$node = $this->userNodeResolver->resolveUserFileNodeById($claim->uid, $claim->fileId);
 		} catch (NotFoundException) {
-			// Usually the file is simply gone. But the same exception covers
-			// an id that now resolves to a folder or outside the user's
-			// files, and in those a file this request created is still
-			// there — so this is worth a line, unlike a silent success.
+			// An unresolved id may still exist outside the user's files; log the skipped cleanup.
 			$this->logger->info('Nothing to clean up: the created .pad file did not resolve', [
 				'app' => 'etherpad_nextcloud',
 				'uid' => $uid,
@@ -116,16 +107,11 @@ class PadCreateRollbackService {
 	}
 
 	/**
-	 * The id is not proof of authorship, and neither is a valid pad
-	 * document.
+	 * Allow deletion only if empty with no recorded write, or matching the
+	 * recorded SHA-256. A matching file_id alone does not prove authorship.
 	 *
-	 * `newFile()` can hand back a file another writer created a moment
-	 * earlier, empty, which every check at create time accepts. That writer
-	 * may then have finished its own create into the same file: its
-	 * document carries the same `file_id` — the id is the file's, not the
-	 * attempt's — and only its `pad_id` differs. So the test is against
-	 * what *this* attempt wrote: the file is removed while it is still
-	 * untouched, or while it still holds exactly those bytes.
+	 * A competing create's empty file is indistinguishable from ours.
+	 * This check and the subsequent delete are not atomic.
 	 */
 	private function isStillOurs(File $node, string $path, ?string $writtenHash): bool {
 		try {

--- a/lib/Service/PadCreateRollbackService.php
+++ b/lib/Service/PadCreateRollbackService.php
@@ -33,14 +33,8 @@ class PadCreateRollbackService {
 	) {
 	}
 
-	public function rollbackFailedCreate(
-		string $uid,
-		string $path,
-		string $padId,
-		?int $createdFileId,
-		?string $writtenHash = null
-	): void {
-		$this->rollbackCreatedFileOnly($uid, $path, $createdFileId, $writtenHash);
+	public function rollbackFailedCreate(string $uid, string $path, string $padId, ?CreatedFileClaim $claim): void {
+		$this->rollbackCreatedFileOnly($uid, $path, $claim);
 
 		if ($padId !== '') {
 			try {
@@ -66,13 +60,8 @@ class PadCreateRollbackService {
 	 * would delete it a second time, costing a round trip and logging a
 	 * warning about a pad that is already gone.
 	 */
-	public function rollbackCreatedFileOnly(
-		string $uid,
-		string $path,
-		?int $createdFileId,
-		?string $writtenHash = null
-	): void {
-		if ($createdFileId === null || $createdFileId <= 0) {
+	public function rollbackCreatedFileOnly(string $uid, string $path, ?CreatedFileClaim $claim): void {
+		if ($claim === null) {
 			// The create never got an id it could trust, so there is nothing
 			// here that identifies a file. Leaving a stray empty `.pad`
 			// behind is a mess; deleting the wrong file is a loss.
@@ -80,7 +69,7 @@ class PadCreateRollbackService {
 		}
 
 		try {
-			$node = $this->userNodeResolver->resolveUserFileNodeById($uid, $createdFileId);
+			$node = $this->userNodeResolver->resolveUserFileNodeById($claim->uid, $claim->fileId);
 		} catch (NotFoundException) {
 			// Usually the file is simply gone. But the same exception covers
 			// an id that now resolves to a folder or outside the user's
@@ -90,7 +79,7 @@ class PadCreateRollbackService {
 				'app' => 'etherpad_nextcloud',
 				'uid' => $uid,
 				'file' => $path,
-				'fileId' => $createdFileId,
+				'fileId' => $claim->fileId,
 			]);
 			return;
 		} catch (\Throwable $lookupError) {
@@ -98,13 +87,13 @@ class PadCreateRollbackService {
 				'app' => 'etherpad_nextcloud',
 				'uid' => $uid,
 				'file' => $path,
-				'fileId' => $createdFileId,
+				'fileId' => $claim->fileId,
 				'exception' => $lookupError,
 			]);
 			return;
 		}
 
-		if (!$this->isStillOurs($node, $path, $writtenHash)) {
+		if (!$this->isStillOurs($node, $path, $claim->writtenHash)) {
 			return;
 		}
 
@@ -120,15 +109,10 @@ class PadCreateRollbackService {
 		}
 	}
 
-	public function rollbackExternalCreate(
-		string $uid,
-		string $path,
-		?int $createdFileId,
-		?string $writtenHash = null
-	): void {
+	public function rollbackExternalCreate(string $uid, string $path, ?CreatedFileClaim $claim): void {
 		// An external create links a pad that already exists elsewhere, so
 		// there is nothing of ours on the Etherpad side to remove.
-		$this->rollbackCreatedFileOnly($uid, $path, $createdFileId, $writtenHash);
+		$this->rollbackCreatedFileOnly($uid, $path, $claim);
 	}
 
 	/**

--- a/lib/Service/PadCreateRollbackService.php
+++ b/lib/Service/PadCreateRollbackService.php
@@ -27,15 +27,20 @@ use Psr\Log\LoggerInterface;
  */
 class PadCreateRollbackService {
 	public function __construct(
-		private PadFileService $padFileService,
 		private ManagedPadLifecycle $padLifecycle,
 		private UserNodeResolver $userNodeResolver,
 		private LoggerInterface $logger,
 	) {
 	}
 
-	public function rollbackFailedCreate(string $uid, string $path, string $padId, ?int $createdFileId): void {
-		$this->rollbackCreatedFileOnly($uid, $path, $createdFileId);
+	public function rollbackFailedCreate(
+		string $uid,
+		string $path,
+		string $padId,
+		?int $createdFileId,
+		?string $writtenHash = null
+	): void {
+		$this->rollbackCreatedFileOnly($uid, $path, $createdFileId, $writtenHash);
 
 		if ($padId !== '') {
 			try {
@@ -61,7 +66,12 @@ class PadCreateRollbackService {
 	 * would delete it a second time, costing a round trip and logging a
 	 * warning about a pad that is already gone.
 	 */
-	public function rollbackCreatedFileOnly(string $uid, string $path, ?int $createdFileId): void {
+	public function rollbackCreatedFileOnly(
+		string $uid,
+		string $path,
+		?int $createdFileId,
+		?string $writtenHash = null
+	): void {
 		if ($createdFileId === null || $createdFileId <= 0) {
 			// The create never got an id it could trust, so there is nothing
 			// here that identifies a file. Leaving a stray empty `.pad`
@@ -72,8 +82,16 @@ class PadCreateRollbackService {
 		try {
 			$node = $this->userNodeResolver->resolveUserFileNodeById($uid, $createdFileId);
 		} catch (NotFoundException) {
-			// Already gone, or no longer this user's. Nothing of ours to
-			// remove, and nothing to report.
+			// Usually the file is simply gone. But the same exception covers
+			// an id that now resolves to a folder or outside the user's
+			// files, and in those a file this request created is still
+			// there — so this is worth a line, unlike a silent success.
+			$this->logger->info('Nothing to clean up: the created .pad file did not resolve', [
+				'app' => 'etherpad_nextcloud',
+				'uid' => $uid,
+				'file' => $path,
+				'fileId' => $createdFileId,
+			]);
 			return;
 		} catch (\Throwable $lookupError) {
 			$this->logger->warning('Could not look up the .pad file to clean up', [
@@ -86,7 +104,7 @@ class PadCreateRollbackService {
 			return;
 		}
 
-		if (!$this->isStillOurs($node, $createdFileId, $path)) {
+		if (!$this->isStillOurs($node, $path, $writtenHash)) {
 			return;
 		}
 
@@ -102,50 +120,58 @@ class PadCreateRollbackService {
 		}
 	}
 
-	public function rollbackExternalCreate(string $uid, string $path, ?int $createdFileId): void {
+	public function rollbackExternalCreate(
+		string $uid,
+		string $path,
+		?int $createdFileId,
+		?string $writtenHash = null
+	): void {
 		// An external create links a pad that already exists elsewhere, so
 		// there is nothing of ours on the Etherpad side to remove.
-		$this->rollbackCreatedFileOnly($uid, $path, $createdFileId);
+		$this->rollbackCreatedFileOnly($uid, $path, $createdFileId, $writtenHash);
 	}
 
 	/**
-	 * The id is not proof of authorship.
+	 * The id is not proof of authorship, and neither is a valid pad
+	 * document.
 	 *
 	 * `newFile()` can hand back a file another writer created a moment
-	 * earlier, empty, which every check at create time accepts — and that
-	 * writer may have filled it while this request was away at Etherpad.
-	 * So the file is only removed while it is still empty, or while it
-	 * carries the document this create wrote into it, which names the id.
+	 * earlier, empty, which every check at create time accepts. That writer
+	 * may then have finished its own create into the same file: its
+	 * document carries the same `file_id` — the id is the file's, not the
+	 * attempt's — and only its `pad_id` differs. So the test is against
+	 * what *this* attempt wrote: the file is removed while it is still
+	 * untouched, or while it still holds exactly those bytes.
 	 */
-	private function isStillOurs(File $node, int $fileId, string $path): bool {
+	private function isStillOurs(File $node, string $path, ?string $writtenHash): bool {
 		try {
 			if ((int)$node->getSize() === 0) {
-				return true;
+				return $writtenHash === null;
 			}
-			$content = (string)$node->getContent();
+			if ($writtenHash === null) {
+				$this->logger->warning('Left a .pad file in place: it has content this create never wrote', [
+					'app' => 'etherpad_nextcloud',
+					'file' => $path,
+				]);
+				return false;
+			}
+			$current = hash('sha256', (string)$node->getContent());
 		} catch (\Throwable $readError) {
 			$this->logger->warning('Left a .pad file in place because its content could not be read', [
 				'app' => 'etherpad_nextcloud',
-				'uid' => $path,
-				'fileId' => $fileId,
+				'file' => $path,
 				'exception' => $readError,
 			]);
 			return false;
 		}
 
-		try {
-			$writtenFileId = (int)($this->padFileService->readPad($content)->frontmatter['file_id'] ?? 0);
-		} catch (\Throwable) {
-			$writtenFileId = 0;
-		}
-		if ($writtenFileId === $fileId) {
+		if (hash_equals($writtenHash, $current)) {
 			return true;
 		}
 
-		$this->logger->warning('Left a .pad file in place: it has content this create did not write', [
+		$this->logger->warning('Left a .pad file in place: its content is not what this create wrote', [
 			'app' => 'etherpad_nextcloud',
 			'file' => $path,
-			'fileId' => $fileId,
 		]);
 
 		return false;

--- a/lib/Service/PadCreateRollbackService.php
+++ b/lib/Service/PadCreateRollbackService.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace OCA\EtherpadNextcloud\Service;
 
 use OCP\Files\File;
+use OCP\Files\NotFoundException;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -17,16 +18,19 @@ use Psr\Log\LoggerInterface;
  * Cleanup steps are isolated and best-effort so cleanup errors do not mask
  * the original create failure.
  *
- * Cleanup is handed the node the create made, not its path and not its id.
- * A path is not an identity — the file can be renamed while Etherpad is
- * being provisioned, and something else can take the old name — and looking
- * an id up again reopens the same question of whether the thing found is
- * still the thing created. The node is the answer to both: it is the object
- * this request created, in this request.
+ * The file is deleted by id, never through the node the create returned.
+ * A `File` object is not an identity: `File::delete()` unlinks
+ * `$this->view->unlink($this->path)`, so it acts on whatever sits at the
+ * remembered path at that moment. Etherpad provisioning takes long enough
+ * for the file to be moved and the name taken by something else, and the
+ * rollback would then delete a stranger's file. Re-resolving the id gives a
+ * fresh path for the file we actually created — and when the id resolves to
+ * nothing, there is nothing of ours left to remove.
  */
 class PadCreateRollbackService {
 	public function __construct(
 		private ManagedPadLifecycle $padLifecycle,
+		private UserNodeResolver $userNodeResolver,
 		private LoggerInterface $logger,
 	) {
 	}
@@ -63,8 +67,24 @@ class PadCreateRollbackService {
 			return;
 		}
 
+		$fileId = $this->createdFileId($createdNode);
+		if ($fileId === null) {
+			// No id, no proof of which file this is. Leaving a stray empty
+			// `.pad` behind is a mess; deleting the wrong file is a loss.
+			$this->logger->warning('Skipped .pad cleanup because the created file has no usable id', [
+				'app' => 'etherpad_nextcloud',
+				'uid' => $uid,
+				'file' => $path,
+			]);
+			return;
+		}
+
 		try {
-			$createdNode->delete();
+			$this->userNodeResolver->resolveUserFileNodeById($uid, $fileId)->delete();
+		} catch (NotFoundException) {
+			// Already gone, or no longer this user's. Either way there is
+			// nothing of ours to remove, and nothing to report.
+			return;
 		} catch (\Throwable $cleanupError) {
 			$this->logger->warning('Could not cleanup failed .pad file create', [
 				'app' => 'etherpad_nextcloud',
@@ -73,6 +93,16 @@ class PadCreateRollbackService {
 				'exception' => $cleanupError,
 			]);
 		}
+	}
+
+	private function createdFileId(File $createdNode): ?int {
+		try {
+			$fileId = $createdNode->getId();
+		} catch (\Throwable) {
+			return null;
+		}
+
+		return $fileId > 0 ? $fileId : null;
 	}
 
 	public function rollbackExternalCreate(string $uid, string $path, ?File $createdNode): void {

--- a/lib/Service/PadCreateRollbackService.php
+++ b/lib/Service/PadCreateRollbackService.php
@@ -18,25 +18,24 @@ use Psr\Log\LoggerInterface;
  * Cleanup steps are isolated and best-effort so cleanup errors do not mask
  * the original create failure.
  *
- * The file is deleted by id, never through the node the create returned.
- * A `File` object is not an identity: `File::delete()` unlinks
- * `$this->view->unlink($this->path)`, so it acts on whatever sits at the
- * remembered path at that moment. Etherpad provisioning takes long enough
- * for the file to be moved and the name taken by something else, and the
- * rollback would then delete a stranger's file. Re-resolving the id gives a
- * fresh path for the file we actually created — and when the id resolves to
- * nothing, there is nothing of ours left to remove.
+ * Cleanup is addressed by the file id the create read once, at the moment it
+ * created the file — never by a `File` object and never by asking one for
+ * its id again. `File::delete()` unlinks its remembered path and
+ * `Node::getId()` re-reads through that same path, so a node held across pad
+ * provisioning answers for whatever occupies the path by then. An id that
+ * was never read stays unknown, and an unknown id deletes nothing.
  */
 class PadCreateRollbackService {
 	public function __construct(
+		private PadFileService $padFileService,
 		private ManagedPadLifecycle $padLifecycle,
 		private UserNodeResolver $userNodeResolver,
 		private LoggerInterface $logger,
 	) {
 	}
 
-	public function rollbackFailedCreate(string $uid, string $path, string $padId, ?File $createdNode): void {
-		$this->rollbackCreatedFileOnly($uid, $path, $createdNode);
+	public function rollbackFailedCreate(string $uid, string $path, string $padId, ?int $createdFileId): void {
+		$this->rollbackCreatedFileOnly($uid, $path, $createdFileId);
 
 		if ($padId !== '') {
 			try {
@@ -62,29 +61,37 @@ class PadCreateRollbackService {
 	 * would delete it a second time, costing a round trip and logging a
 	 * warning about a pad that is already gone.
 	 */
-	public function rollbackCreatedFileOnly(string $uid, string $path, ?File $createdNode): void {
-		if ($createdNode === null) {
-			return;
-		}
-
-		$fileId = $this->createdFileId($createdNode);
-		if ($fileId === null) {
-			// No id, no proof of which file this is. Leaving a stray empty
-			// `.pad` behind is a mess; deleting the wrong file is a loss.
-			$this->logger->warning('Skipped .pad cleanup because the created file has no usable id', [
-				'app' => 'etherpad_nextcloud',
-				'uid' => $uid,
-				'file' => $path,
-			]);
+	public function rollbackCreatedFileOnly(string $uid, string $path, ?int $createdFileId): void {
+		if ($createdFileId === null || $createdFileId <= 0) {
+			// The create never got an id it could trust, so there is nothing
+			// here that identifies a file. Leaving a stray empty `.pad`
+			// behind is a mess; deleting the wrong file is a loss.
 			return;
 		}
 
 		try {
-			$this->userNodeResolver->resolveUserFileNodeById($uid, $fileId)->delete();
+			$node = $this->userNodeResolver->resolveUserFileNodeById($uid, $createdFileId);
 		} catch (NotFoundException) {
-			// Already gone, or no longer this user's. Either way there is
-			// nothing of ours to remove, and nothing to report.
+			// Already gone, or no longer this user's. Nothing of ours to
+			// remove, and nothing to report.
 			return;
+		} catch (\Throwable $lookupError) {
+			$this->logger->warning('Could not look up the .pad file to clean up', [
+				'app' => 'etherpad_nextcloud',
+				'uid' => $uid,
+				'file' => $path,
+				'fileId' => $createdFileId,
+				'exception' => $lookupError,
+			]);
+			return;
+		}
+
+		if (!$this->isStillOurs($node, $createdFileId, $path)) {
+			return;
+		}
+
+		try {
+			$node->delete();
 		} catch (\Throwable $cleanupError) {
 			$this->logger->warning('Could not cleanup failed .pad file create', [
 				'app' => 'etherpad_nextcloud',
@@ -95,19 +102,52 @@ class PadCreateRollbackService {
 		}
 	}
 
-	private function createdFileId(File $createdNode): ?int {
-		try {
-			$fileId = $createdNode->getId();
-		} catch (\Throwable) {
-			return null;
-		}
-
-		return $fileId > 0 ? $fileId : null;
-	}
-
-	public function rollbackExternalCreate(string $uid, string $path, ?File $createdNode): void {
+	public function rollbackExternalCreate(string $uid, string $path, ?int $createdFileId): void {
 		// An external create links a pad that already exists elsewhere, so
 		// there is nothing of ours on the Etherpad side to remove.
-		$this->rollbackCreatedFileOnly($uid, $path, $createdNode);
+		$this->rollbackCreatedFileOnly($uid, $path, $createdFileId);
+	}
+
+	/**
+	 * The id is not proof of authorship.
+	 *
+	 * `newFile()` can hand back a file another writer created a moment
+	 * earlier, empty, which every check at create time accepts — and that
+	 * writer may have filled it while this request was away at Etherpad.
+	 * So the file is only removed while it is still empty, or while it
+	 * carries the document this create wrote into it, which names the id.
+	 */
+	private function isStillOurs(File $node, int $fileId, string $path): bool {
+		try {
+			if ((int)$node->getSize() === 0) {
+				return true;
+			}
+			$content = (string)$node->getContent();
+		} catch (\Throwable $readError) {
+			$this->logger->warning('Left a .pad file in place because its content could not be read', [
+				'app' => 'etherpad_nextcloud',
+				'uid' => $path,
+				'fileId' => $fileId,
+				'exception' => $readError,
+			]);
+			return false;
+		}
+
+		try {
+			$writtenFileId = (int)($this->padFileService->readPad($content)->frontmatter['file_id'] ?? 0);
+		} catch (\Throwable) {
+			$writtenFileId = 0;
+		}
+		if ($writtenFileId === $fileId) {
+			return true;
+		}
+
+		$this->logger->warning('Left a .pad file in place: it has content this create did not write', [
+			'app' => 'etherpad_nextcloud',
+			'file' => $path,
+			'fileId' => $fileId,
+		]);
+
+		return false;
 	}
 }

--- a/lib/Service/PadCreationService.php
+++ b/lib/Service/PadCreationService.php
@@ -14,6 +14,7 @@ use OCA\EtherpadNextcloud\Exception\EtherpadClientException;
 use OCA\EtherpadNextcloud\Exception\NotAPadFileException;
 use OCA\EtherpadNextcloud\Exception\InvalidPadNameException;
 use OCA\EtherpadNextcloud\Exception\PadFileAlreadyExistsException;
+use OCA\EtherpadNextcloud\Exception\PadFileChangedException;
 use OCA\EtherpadNextcloud\Exception\PadParentFolderNotWritableException;
 use OCA\EtherpadNextcloud\Util\PathNormalizer;
 use OCP\Files\File;
@@ -45,21 +46,20 @@ class PadCreationService {
 		$this->padTypePolicy->requireEnabled($accessMode);
 		$path = $this->padPaths->normalizeCreatePath($file);
 		$padId = '';
-		$createdFileId = null;
-		$writtenHash = null;
+		$claim = null;
 
 		return $this->withCreateRollback(
-			function () use ($uid, $path, $accessMode, &$padId, &$createdFileId, &$writtenHash): array {
+			function () use ($uid, $path, $accessMode, &$padId, &$claim): array {
 				$fileNode = $this->padFileCreator->createUserFile($uid, $path);
 				// Read once, here, and carried as a number. Asking the node
 				// again later would answer for whatever holds the path by
 				// then; an id that was never read stays unknown, and an
 				// unknown id cleans up nothing.
 				$fileId = $this->requireFileId($fileNode, $path);
-				$createdFileId = $fileId;
+				$claim = new CreatedFileClaim($uid, $fileId);
 				if ($this->isNotOurs($fileNode, $fileId, $path)) {
 					// Not ours after all, so it is not ours to clean up either.
-					$createdFileId = null;
+					$claim = null;
 					throw new PadFileAlreadyExistsException('Target .pad file already exists.');
 				}
 				$padId = $this->padBootstrapService->provisionPadId($accessMode);
@@ -72,7 +72,7 @@ class PadCreationService {
 					'',
 					$padUrl
 				);
-				$writtenHash = $this->writeCreatedFile($uid, $fileId, $content);
+				$this->writeCreatedFile($claim, $content);
 
 				$this->bindingService->createBinding($fileId, $padId, $accessMode);
 
@@ -84,8 +84,8 @@ class PadCreationService {
 					'pad_url' => $padUrl,
 				];
 			},
-			function () use ($uid, $path, &$padId, &$createdFileId, &$writtenHash): void {
-				$this->rollbackService->rollbackFailedCreate($uid, $path, $padId, $createdFileId, $writtenHash);
+			function () use ($uid, $path, &$padId, &$claim): void {
+				$this->rollbackService->rollbackFailedCreate($uid, $path, $padId, $claim);
 			},
 			function (\Throwable $e) use ($path, $accessMode, &$padId): ?array {
 				if ($e instanceof BindingException) {
@@ -126,21 +126,20 @@ class PadCreationService {
 		}
 
 		$padId = '';
-		$createdFileId = null;
-		$writtenHash = null;
+		$claim = null;
 		$path = '';
 
 		return $this->withCreateRollback(
-			function () use ($uid, $parentFolder, $parentFolderId, $fileName, $accessMode, &$path, &$padId, &$createdFileId, &$writtenHash): array {
+			function () use ($uid, $parentFolder, $parentFolderId, $fileName, $accessMode, &$path, &$padId, &$claim): array {
 				$fileNode = $this->padFileCreator->createUserFileInFolder($parentFolder, $fileName);
 				// The id is recorded as soon as it can be read. If reading it
 				// throws, nothing below identifies the file, and the empty
 				// one `newFile()` already made is left where it is.
 				$fileId = $this->requireFileId($fileNode, $path);
-				$createdFileId = $fileId;
+				$claim = new CreatedFileClaim($uid, $fileId);
 				if ($this->isNotOurs($fileNode, $fileId, $path)) {
 					// Not ours after all, so it is not ours to clean up either.
-					$createdFileId = null;
+					$claim = null;
 					throw new PadFileAlreadyExistsException('Target .pad file already exists.');
 				}
 				$path = $this->userNodeResolver->toUserAbsolutePath($uid, $fileNode);
@@ -154,7 +153,7 @@ class PadCreationService {
 					'',
 					$padUrl
 				);
-				$this->writeCreatedFile($uid, $fileId, $content);
+				$this->writeCreatedFile($claim, $content);
 				$this->bindingService->createBinding($fileId, $padId, $accessMode);
 
 				return [
@@ -166,8 +165,8 @@ class PadCreationService {
 					'pad_url' => $padUrl,
 				];
 			},
-			function () use ($uid, &$path, &$padId, &$createdFileId, &$writtenHash): void {
-				$this->rollbackService->rollbackFailedCreate($uid, $path, $padId, $createdFileId, $writtenHash);
+			function () use ($uid, &$path, &$padId, &$claim): void {
+				$this->rollbackService->rollbackFailedCreate($uid, $path, $padId, $claim);
 			},
 			function (\Throwable $e) use ($parentFolderId, $name, $accessMode, &$path, &$padId): ?array {
 				if ($e instanceof BindingException) {
@@ -205,17 +204,16 @@ class PadCreationService {
 	 */
 	public function createFromUrl(string $uid, string $file, string $padUrl): array {
 		$path = $this->padPaths->normalizeCreatePath($file);
-		$createdFileId = null;
-		$writtenHash = null;
+		$claim = null;
 
 		return $this->withCreateRollback(
-			function () use ($uid, $path, $padUrl, &$createdFileId, &$writtenHash) {
+			function () use ($uid, $path, $padUrl, &$claim) {
 				$fileNode = $this->padFileCreator->createUserFile($uid, $path);
 				$fileId = $this->requireFileId($fileNode, $path);
-				$createdFileId = $fileId;
+				$claim = new CreatedFileClaim($uid, $fileId);
 				if ($this->isNotOurs($fileNode, $fileId, $path)) {
 					// Not ours after all, so it is not ours to clean up either.
-					$createdFileId = null;
+					$claim = null;
 					throw new PadFileAlreadyExistsException('Target .pad file already exists.');
 				}
 
@@ -223,7 +221,7 @@ class PadCreationService {
 				// export first, and that wait is long enough for the file to
 				// be moved and its name taken.
 				$prepared = $this->externalPadSeeder->prepare($fileId, $padUrl);
-				$writtenHash = $this->writeCreatedFile($uid, $fileId, $prepared['content']);
+				$this->writeCreatedFile($claim, $prepared['content']);
 				$seeded = $prepared['result'];
 				// Preserve the historical key ordering for the external-create
 				// response: `file` is the first key so tests asserting via
@@ -231,8 +229,8 @@ class PadCreationService {
 				$result = ['file' => $path] + $seeded;
 				return $result;
 			},
-			function () use ($uid, $path, &$createdFileId, &$writtenHash): void {
-				$this->rollbackService->rollbackExternalCreate($uid, $path, $createdFileId, $writtenHash);
+			function () use ($uid, $path, &$claim): void {
+				$this->rollbackService->rollbackExternalCreate($uid, $path, $claim);
 			},
 			function (\Throwable $e) use ($path, $padUrl): ?array {
 				if ($e instanceof EtherpadClientException) {
@@ -276,28 +274,28 @@ class PadCreationService {
 		$templateNode = $this->userNodeResolver->resolveUserFileNodeById($uid, $templateFileId);
 
 		$padId = '';
-		$createdFileId = null;
-		$writtenHash = null;
+		$claim = null;
 
 		return $this->withCreateRollback(
-			function () use ($uid, $path, $templateNode, $user, &$padId, &$createdFileId, &$writtenHash): array {
+			function () use ($uid, $path, $templateNode, $user, &$padId, &$claim): array {
 				$fileNode = $this->padFileCreator->createUserFile($uid, $path);
 				// The id is recorded as soon as it can be read; if reading it
 				// throws, the empty file stays where it is because nothing
 				// below can prove it is ours.
 				$fileId = $this->requireFileId($fileNode, $path);
-				$createdFileId = $fileId;
+				// Empty, because this flow made the file itself — not what
+				// the helper would find after reading the template.
+				$claim = new CreatedFileClaim($uid, $fileId);
 				if ($this->isNotOurs($fileNode, $fileId, $path)) {
 					// Not ours after all, so it is not ours to clean up either.
-					$createdFileId = null;
+					$claim = null;
 					throw new PadFileAlreadyExistsException('Target .pad file already exists.');
 				}
 
 				// This flow creates its own target, so the write goes by id
 				// like the others; the template-hook caller below has no uid
 				// and keeps writing through the node it was handed.
-				$result = $this->materializeTemplateInto($fileNode, $templateNode, $user, $uid);
-				$writtenHash = $result['written_hash'];
+				$result = $this->materializeTemplateInto($fileNode, $templateNode, $user, $claim);
 				$padId = $result['pad_id'];
 
 				return [
@@ -308,10 +306,10 @@ class PadCreationService {
 					'pad_url' => $result['pad_url'],
 				];
 			},
-			function () use ($uid, $path, &$padId, &$createdFileId, &$writtenHash): void {
+			function () use ($uid, $path, &$padId, &$claim): void {
 				// File only: materializeTemplateInto() has already deleted the
 				// pad it provisioned before rethrowing.
-				$this->rollbackService->rollbackCreatedFileOnly($uid, $path, $createdFileId, $writtenHash);
+				$this->rollbackService->rollbackCreatedFileOnly($uid, $path, $claim);
 			},
 			function (\Throwable $e) use ($path, &$padId): ?array {
 				if ($e instanceof BindingException) {
@@ -402,15 +400,21 @@ class PadCreationService {
 		}
 	}
 
-	public function materializeTemplateInto(File $target, File $template, ?IUser $user, ?string $uid = null): array {
-		// The template hook has a user too — it returns early without one —
-		// so this path is not the exception it looked like, and it gets the
-		// same id-addressed write as the four API creates.
-		$uid ??= $user?->getUID();
-		// What the target held before this call. Nextcloud's template hook
-		// hands over a file that already carries the template's bytes, so
-		// "unchanged" is the check that fits both callers, not "empty".
-		$before = (string)$target->getContent();
+	public function materializeTemplateInto(
+		File $target,
+		File $template,
+		?IUser $user,
+		?CreatedFileClaim $claim = null
+	): array {
+		// The caller states what it claimed. Reading identity or prior
+		// content again here would answer for whatever the file has become
+		// since — which for the API create means accepting a rival's
+		// content as the expected starting state.
+		//
+		// Nextcloud's template hook brings no claim: it has a user, so it
+		// gets one made here, and its file already carries the template's
+		// bytes, so "unchanged" rather than "empty" is what fits it.
+		$claim ??= $this->claimForTemplateHook($target, $user);
 		if (!str_ends_with(strtolower($template->getName()), '.pad')) {
 			throw new NotAPadFileException('Template is not a .pad file.');
 		}
@@ -436,10 +440,7 @@ class PadCreationService {
 		$resolvedText = $this->placeholderResolver->applyForContent($snapshot['text'], $user);
 		$resolvedHtml = $this->placeholderResolver->applyForContent($snapshot['html'], $user);
 
-		$fileId = (int)$target->getId();
-		if ($fileId <= 0) {
-			throw new \RuntimeException('Could not resolve target file ID.');
-		}
+		$fileId = $claim->fileId;
 
 		$padId = $this->padBootstrapService->provisionPadId($accessMode);
 		try {
@@ -460,15 +461,10 @@ class PadCreationService {
 				0,
 				true,
 			);
-			// By id, and only onto the file as it was when this call started:
+			// By id, and only onto the file as the claim describes it:
 			// provisioning the pad and pushing the snapshot take long enough
 			// for the target to be moved and its name reused.
-			if ($uid !== null && $uid !== '') {
-				$writtenHash = $this->writeCreatedFile($uid, $fileId, $content, $before);
-			} else {
-				$target->putContent($content);
-				$writtenHash = hash('sha256', $content);
-			}
+			$this->writeCreatedFile($claim, $content);
 			$this->bindingService->createBinding($fileId, $padId, $accessMode);
 		} catch (\Throwable $e) {
 			$this->unwindMaterializedPad($fileId, $padId);
@@ -480,8 +476,23 @@ class PadCreationService {
 			'pad_id' => $padId,
 			'access_mode' => $accessMode,
 			'pad_url' => $padUrl,
-			'written_hash' => $writtenHash,
 		];
+	}
+
+	/**
+	 * A claim for the one caller that does not create the file: Nextcloud's
+	 * template hook, which hands over a file it made from the template.
+	 *
+	 * Read once, here, so the rest of the call works from a fixed
+	 * expectation rather than from whatever the file has become.
+	 */
+	private function claimForTemplateHook(File $target, ?IUser $user): CreatedFileClaim {
+		$uid = $user?->getUID();
+		if ($uid === null || $uid === '') {
+			throw new \RuntimeException('Cannot materialize a template without a user to resolve the file by.');
+		}
+
+		return new CreatedFileClaim($uid, $this->requireFileId($target, $target->getName()), (string)$target->getContent());
 	}
 
 	/**
@@ -496,19 +507,21 @@ class PadCreationService {
 	 *
 	 * @throws \OCP\Files\NotFoundException
 	 */
-	private function writeCreatedFile(string $uid, int $fileId, string $content, string $expectedBefore = ''): string {
-		$node = $this->userNodeResolver->resolveUserFileNodeById($uid, $fileId);
+	private function writeCreatedFile(CreatedFileClaim $claim, string $content): void {
+		$node = $this->userNodeResolver->resolveUserFileNodeById($claim->uid, $claim->fileId);
 		// The file was empty when this create claimed it, and a claim is not
 		// a lock: another writer can have finished its own create into the
 		// same file while this request was away at Etherpad. Overwriting
 		// that is the loss this whole change exists to prevent, so a file
 		// that is no longer what it was is not written to.
-		if ((string)$node->getContent() !== $expectedBefore) {
-			throw new PadFileAlreadyExistsException('The target .pad file changed while the pad was being provisioned.');
+		if ((string)$node->getContent() !== $claim->expectedBefore) {
+			throw new PadFileChangedException('The target .pad file changed while the pad was being provisioned.');
 		}
 		$node->putContent($content);
-
-		return hash('sha256', $content);
+		// On the claim, not returned: a caller that fails at the next step
+		// never receives a return value, and its rollback would then have no
+		// proof of what this attempt wrote.
+		$claim->writtenHash = hash('sha256', $content);
 	}
 
 	/**

--- a/lib/Service/PadCreationService.php
+++ b/lib/Service/PadCreationService.php
@@ -51,10 +51,7 @@ class PadCreationService {
 		return $this->withCreateRollback(
 			function () use ($uid, $path, $accessMode, &$padId, &$claim): array {
 				$fileNode = $this->padFileCreator->createUserFile($uid, $path);
-				// Read once, here, and carried as a number. Asking the node
-				// again later would answer for whatever holds the path by
-				// then; an id that was never read stays unknown, and an
-				// unknown id cleans up nothing.
+				// Capture the id before provisioning; getId() on this node is path-based.
 				$fileId = $this->requireFileId($fileNode, $path);
 				$claim = new CreatedFileClaim($uid, $fileId);
 				if ($this->isNotOurs($fileNode, $fileId, $path)) {
@@ -132,9 +129,6 @@ class PadCreationService {
 		return $this->withCreateRollback(
 			function () use ($uid, $parentFolder, $parentFolderId, $fileName, $accessMode, &$path, &$padId, &$claim): array {
 				$fileNode = $this->padFileCreator->createUserFileInFolder($parentFolder, $fileName);
-				// The id is recorded as soon as it can be read. If reading it
-				// throws, nothing below identifies the file, and the empty
-				// one `newFile()` already made is left where it is.
 				$fileId = $this->requireFileId($fileNode, $path);
 				$claim = new CreatedFileClaim($uid, $fileId);
 				if ($this->isNotOurs($fileNode, $fileId, $path)) {
@@ -217,9 +211,6 @@ class PadCreationService {
 					throw new PadFileAlreadyExistsException('Target .pad file already exists.');
 				}
 
-				// Prepared, then written by id: seeding fetches the foreign
-				// export first, and that wait is long enough for the file to
-				// be moved and its name taken.
 				$prepared = $this->externalPadSeeder->prepare($fileId, $padUrl);
 				$this->writeCreatedFile($claim, $prepared['content']);
 				$seeded = $prepared['result'];
@@ -279,12 +270,8 @@ class PadCreationService {
 		return $this->withCreateRollback(
 			function () use ($uid, $path, $templateNode, $user, &$padId, &$claim): array {
 				$fileNode = $this->padFileCreator->createUserFile($uid, $path);
-				// The id is recorded as soon as it can be read; if reading it
-				// throws, the empty file stays where it is because nothing
-				// below can prove it is ours.
 				$fileId = $this->requireFileId($fileNode, $path);
-				// Empty, because this flow made the file itself — not what
-				// the helper would find after reading the template.
+				// API creates start empty; do not replace this baseline with a later read.
 				$claim = new CreatedFileClaim($uid, $fileId);
 				if ($this->isNotOurs($fileNode, $fileId, $path)) {
 					// Not ours after all, so it is not ours to clean up either.
@@ -292,9 +279,6 @@ class PadCreationService {
 					throw new PadFileAlreadyExistsException('Target .pad file already exists.');
 				}
 
-				// This flow creates its own target, so the write goes by id
-				// like the others; the template-hook caller below has no uid
-				// and keeps writing through the node it was handed.
 				$result = $this->materializeTemplateInto($fileNode, $templateNode, $user, $claim);
 				$padId = $result['pad_id'];
 
@@ -406,14 +390,7 @@ class PadCreationService {
 		?IUser $user,
 		?CreatedFileClaim $claim = null
 	): array {
-		// The caller states what it claimed. Reading identity or prior
-		// content again here would answer for whatever the file has become
-		// since — which for the API create means accepting a rival's
-		// content as the expected starting state.
-		//
-		// Nextcloud's template hook brings no claim: it has a user, so it
-		// gets one made here, and its file already carries the template's
-		// bytes, so "unchanged" rather than "empty" is what fits it.
+		// Keep the caller's baseline; only claim the current content if none was supplied.
 		$claim ??= $this->claimTemplateTarget($target, $user);
 		if (!str_ends_with(strtolower($template->getName()), '.pad')) {
 			throw new NotAPadFileException('Template is not a .pad file.');
@@ -461,9 +438,6 @@ class PadCreationService {
 				0,
 				true,
 			);
-			// By id, and only onto the file as the claim describes it:
-			// provisioning the pad and pushing the snapshot take long enough
-			// for the target to be moved and its name reused.
 			$this->writeCreatedFile($claim, $content);
 			$this->bindingService->createBinding($fileId, $padId, $accessMode);
 		} catch (\Throwable $e) {
@@ -480,12 +454,8 @@ class PadCreationService {
 	}
 
 	/**
-	 * A claim for the one caller that does not create the file: Nextcloud's
-	 * template hook, which hands over a file it made from the template.
-	 *
-	 * Read once, so the rest of the work — including whatever the caller
-	 * does after a failure — measures against a fixed expectation rather
-	 * than against whatever the file has become.
+	 * Capture identity and copied template content before materialization.
+	 * The listener shares this claim with materialization and recovery.
 	 */
 	public function claimTemplateTarget(File $target, ?IUser $user): CreatedFileClaim {
 		$uid = $user?->getUID();
@@ -497,50 +467,32 @@ class PadCreationService {
 	}
 
 	/**
-	 * Write to the file this create made, addressed by id.
+	 * Re-resolve by id and require the claimed content before writing.
 	 *
-	 * Not through the node the create returned: `File::putContent()` writes
-	 * to its remembered path, and by this point the request has been away
-	 * at Etherpad long enough for the file to be moved and the name taken
-	 * by something else. Resolving the id gives a fresh path for the file
-	 * we actually created; if it resolves to nothing, the create fails and
-	 * rolls back rather than writing over a stranger.
+	 * File::putContent() uses its remembered path, which may have been reused
+	 * during provisioning. The content check and write are not atomic.
 	 *
 	 * @throws \OCP\Files\NotFoundException
+	 * @throws PadFileChangedException
 	 */
 	private function writeCreatedFile(CreatedFileClaim $claim, string $content): void {
 		$node = $this->userNodeResolver->resolveUserFileNodeById($claim->uid, $claim->fileId);
-		// The file was empty when this create claimed it, and a claim is not
-		// a lock: another writer can have finished its own create into the
-		// same file while this request was away at Etherpad. Overwriting
-		// that is the loss this whole change exists to prevent, so a file
-		// that is no longer what it was is not written to.
 		if ((string)$node->getContent() !== $claim->expectedBefore) {
 			throw new PadFileChangedException('The target .pad file changed while the pad was being provisioned.');
 		}
 		$node->putContent($content);
-		// On the claim, not returned: a caller that fails at the next step
-		// never receives a return value, and its rollback would then have no
-		// proof of what this attempt wrote.
+		// Record on the shared claim so recovery retains proof if binding fails next.
 		$claim->writtenHash = hash('sha256', $content);
 	}
 
 	/**
-	 * The claimed file, if it is still exactly as it was claimed.
-	 *
-	 * For a caller that wants to recover from a failed create by rewriting
-	 * the target: a failure says nothing about who owns the file now. The
-	 * pad call may have failed *because* the file moved, and the name it
-	 * left behind may belong to somebody else by the time anyone looks.
+	 * Resolve for recovery only if the original content or recorded write still matches.
+	 * Return null if the file changed or cannot be resolved or read. This does not lock it.
 	 */
 	public function resolveUnchangedClaim(CreatedFileClaim $claim): ?File {
 		try {
 			$node = $this->userNodeResolver->resolveUserFileNodeById($claim->uid, $claim->fileId);
 			$current = (string)$node->getContent();
-			// Two states belong to this attempt: what it found, and what it
-			// wrote. A create that wrote its document and then failed at the
-			// binding leaves the second — refusing to recover from it would
-			// strand the file pointing at a pad that has just been deleted.
 			$isOurs = $current === $claim->expectedBefore
 				|| ($claim->writtenHash !== null && hash_equals($claim->writtenHash, hash('sha256', $current)));
 			if (!$isOurs) {

--- a/lib/Service/PadCreationService.php
+++ b/lib/Service/PadCreationService.php
@@ -536,7 +536,14 @@ class PadCreationService {
 	public function resolveUnchangedClaim(CreatedFileClaim $claim): ?File {
 		try {
 			$node = $this->userNodeResolver->resolveUserFileNodeById($claim->uid, $claim->fileId);
-			if ((string)$node->getContent() !== $claim->expectedBefore) {
+			$current = (string)$node->getContent();
+			// Two states belong to this attempt: what it found, and what it
+			// wrote. A create that wrote its document and then failed at the
+			// binding leaves the second — refusing to recover from it would
+			// strand the file pointing at a pad that has just been deleted.
+			$isOurs = $current === $claim->expectedBefore
+				|| ($claim->writtenHash !== null && hash_equals($claim->writtenHash, hash('sha256', $current)));
+			if (!$isOurs) {
 				return null;
 			}
 		} catch (\Throwable) {

--- a/lib/Service/PadCreationService.php
+++ b/lib/Service/PadCreationService.php
@@ -67,7 +67,7 @@ class PadCreationService {
 					'',
 					$padUrl
 				);
-				$fileNode->putContent($content);
+				$this->writeCreatedFile($uid, $fileId, $content);
 
 				$this->bindingService->createBinding($fileId, $padId, $accessMode);
 
@@ -147,7 +147,7 @@ class PadCreationService {
 					'',
 					$padUrl
 				);
-				$fileNode->putContent($content);
+				$this->writeCreatedFile($uid, $fileId, $content);
 				$this->bindingService->createBinding($fileId, $padId, $accessMode);
 
 				return [
@@ -434,6 +434,10 @@ class PadCreationService {
 				0,
 				true,
 			);
+			// Written through the node as given: unlike the create flows,
+			// this file is not one we made — Nextcloud's template hook hands
+			// it over — and the caller need not supply a uid to re-resolve
+			// the id with.
 			$target->putContent($content);
 			$this->bindingService->createBinding($fileId, $padId, $accessMode);
 		} catch (\Throwable $e) {
@@ -456,6 +460,22 @@ class PadCreationService {
 	 *
 	 * @throws \RuntimeException
 	 */
+	/**
+	 * Write to the file this create made, addressed by id.
+	 *
+	 * Not through the node the create returned: `File::putContent()` writes
+	 * to its remembered path, and by this point the request has been away
+	 * at Etherpad long enough for the file to be moved and the name taken
+	 * by something else. Resolving the id gives a fresh path for the file
+	 * we actually created; if it resolves to nothing, the create fails and
+	 * rolls back rather than writing over a stranger.
+	 *
+	 * @throws \OCP\Files\NotFoundException
+	 */
+	private function writeCreatedFile(string $uid, int $fileId, string $content): void {
+		$this->userNodeResolver->resolveUserFileNodeById($uid, $fileId)->putContent($content);
+	}
+
 	private function requireFileId(File $fileNode, string $path): int {
 		try {
 			$fileId = (int)$fileNode->getId();

--- a/lib/Service/PadCreationService.php
+++ b/lib/Service/PadCreationService.php
@@ -414,7 +414,7 @@ class PadCreationService {
 		// Nextcloud's template hook brings no claim: it has a user, so it
 		// gets one made here, and its file already carries the template's
 		// bytes, so "unchanged" rather than "empty" is what fits it.
-		$claim ??= $this->claimForTemplateHook($target, $user);
+		$claim ??= $this->claimTemplateTarget($target, $user);
 		if (!str_ends_with(strtolower($template->getName()), '.pad')) {
 			throw new NotAPadFileException('Template is not a .pad file.');
 		}
@@ -483,10 +483,11 @@ class PadCreationService {
 	 * A claim for the one caller that does not create the file: Nextcloud's
 	 * template hook, which hands over a file it made from the template.
 	 *
-	 * Read once, here, so the rest of the call works from a fixed
-	 * expectation rather than from whatever the file has become.
+	 * Read once, so the rest of the work — including whatever the caller
+	 * does after a failure — measures against a fixed expectation rather
+	 * than against whatever the file has become.
 	 */
-	private function claimForTemplateHook(File $target, ?IUser $user): CreatedFileClaim {
+	public function claimTemplateTarget(File $target, ?IUser $user): CreatedFileClaim {
 		$uid = $user?->getUID();
 		if ($uid === null || $uid === '') {
 			throw new \RuntimeException('Cannot materialize a template without a user to resolve the file by.');
@@ -522,6 +523,27 @@ class PadCreationService {
 		// never receives a return value, and its rollback would then have no
 		// proof of what this attempt wrote.
 		$claim->writtenHash = hash('sha256', $content);
+	}
+
+	/**
+	 * The claimed file, if it is still exactly as it was claimed.
+	 *
+	 * For a caller that wants to recover from a failed create by rewriting
+	 * the target: a failure says nothing about who owns the file now. The
+	 * pad call may have failed *because* the file moved, and the name it
+	 * left behind may belong to somebody else by the time anyone looks.
+	 */
+	public function resolveUnchangedClaim(CreatedFileClaim $claim): ?File {
+		try {
+			$node = $this->userNodeResolver->resolveUserFileNodeById($claim->uid, $claim->fileId);
+			if ((string)$node->getContent() !== $claim->expectedBefore) {
+				return null;
+			}
+		} catch (\Throwable) {
+			return null;
+		}
+
+		return $node;
 	}
 
 	/**

--- a/lib/Service/PadCreationService.php
+++ b/lib/Service/PadCreationService.php
@@ -46,9 +46,10 @@ class PadCreationService {
 		$path = $this->padPaths->normalizeCreatePath($file);
 		$padId = '';
 		$createdFileId = null;
+		$writtenHash = null;
 
 		return $this->withCreateRollback(
-			function () use ($uid, $path, $accessMode, &$padId, &$createdFileId): array {
+			function () use ($uid, $path, $accessMode, &$padId, &$createdFileId, &$writtenHash): array {
 				$fileNode = $this->padFileCreator->createUserFile($uid, $path);
 				// Read once, here, and carried as a number. Asking the node
 				// again later would answer for whatever holds the path by
@@ -71,7 +72,7 @@ class PadCreationService {
 					'',
 					$padUrl
 				);
-				$this->writeCreatedFile($uid, $fileId, $content);
+				$writtenHash = $this->writeCreatedFile($uid, $fileId, $content);
 
 				$this->bindingService->createBinding($fileId, $padId, $accessMode);
 
@@ -83,8 +84,8 @@ class PadCreationService {
 					'pad_url' => $padUrl,
 				];
 			},
-			function () use ($uid, $path, &$padId, &$createdFileId): void {
-				$this->rollbackService->rollbackFailedCreate($uid, $path, $padId, $createdFileId);
+			function () use ($uid, $path, &$padId, &$createdFileId, &$writtenHash): void {
+				$this->rollbackService->rollbackFailedCreate($uid, $path, $padId, $createdFileId, $writtenHash);
 			},
 			function (\Throwable $e) use ($path, $accessMode, &$padId): ?array {
 				if ($e instanceof BindingException) {
@@ -126,13 +127,15 @@ class PadCreationService {
 
 		$padId = '';
 		$createdFileId = null;
+		$writtenHash = null;
 		$path = '';
 
 		return $this->withCreateRollback(
-			function () use ($uid, $parentFolder, $parentFolderId, $fileName, $accessMode, &$path, &$padId, &$createdFileId): array {
+			function () use ($uid, $parentFolder, $parentFolderId, $fileName, $accessMode, &$path, &$padId, &$createdFileId, &$writtenHash): array {
 				$fileNode = $this->padFileCreator->createUserFileInFolder($parentFolder, $fileName);
-				// The node is recorded before anything that can throw, so a
-				// failure anywhere below still cleans the file up.
+				// The id is recorded as soon as it can be read. If reading it
+				// throws, nothing below identifies the file, and the empty
+				// one `newFile()` already made is left where it is.
 				$fileId = $this->requireFileId($fileNode, $path);
 				$createdFileId = $fileId;
 				if ($this->isNotOurs($fileNode, $fileId, $path)) {
@@ -163,8 +166,8 @@ class PadCreationService {
 					'pad_url' => $padUrl,
 				];
 			},
-			function () use ($uid, &$path, &$padId, &$createdFileId): void {
-				$this->rollbackService->rollbackFailedCreate($uid, $path, $padId, $createdFileId);
+			function () use ($uid, &$path, &$padId, &$createdFileId, &$writtenHash): void {
+				$this->rollbackService->rollbackFailedCreate($uid, $path, $padId, $createdFileId, $writtenHash);
 			},
 			function (\Throwable $e) use ($parentFolderId, $name, $accessMode, &$path, &$padId): ?array {
 				if ($e instanceof BindingException) {
@@ -203,9 +206,10 @@ class PadCreationService {
 	public function createFromUrl(string $uid, string $file, string $padUrl): array {
 		$path = $this->padPaths->normalizeCreatePath($file);
 		$createdFileId = null;
+		$writtenHash = null;
 
 		return $this->withCreateRollback(
-			function () use ($uid, $path, $padUrl, &$createdFileId) {
+			function () use ($uid, $path, $padUrl, &$createdFileId, &$writtenHash) {
 				$fileNode = $this->padFileCreator->createUserFile($uid, $path);
 				$fileId = $this->requireFileId($fileNode, $path);
 				$createdFileId = $fileId;
@@ -219,7 +223,7 @@ class PadCreationService {
 				// export first, and that wait is long enough for the file to
 				// be moved and its name taken.
 				$prepared = $this->externalPadSeeder->prepare($fileId, $padUrl);
-				$this->writeCreatedFile($uid, $fileId, $prepared['content']);
+				$writtenHash = $this->writeCreatedFile($uid, $fileId, $prepared['content']);
 				$seeded = $prepared['result'];
 				// Preserve the historical key ordering for the external-create
 				// response: `file` is the first key so tests asserting via
@@ -227,8 +231,8 @@ class PadCreationService {
 				$result = ['file' => $path] + $seeded;
 				return $result;
 			},
-			function () use ($uid, $path, &$createdFileId): void {
-				$this->rollbackService->rollbackExternalCreate($uid, $path, $createdFileId);
+			function () use ($uid, $path, &$createdFileId, &$writtenHash): void {
+				$this->rollbackService->rollbackExternalCreate($uid, $path, $createdFileId, $writtenHash);
 			},
 			function (\Throwable $e) use ($path, $padUrl): ?array {
 				if ($e instanceof EtherpadClientException) {
@@ -273,13 +277,14 @@ class PadCreationService {
 
 		$padId = '';
 		$createdFileId = null;
+		$writtenHash = null;
 
 		return $this->withCreateRollback(
-			function () use ($uid, $path, $templateNode, $user, &$padId, &$createdFileId): array {
+			function () use ($uid, $path, $templateNode, $user, &$padId, &$createdFileId, &$writtenHash): array {
 				$fileNode = $this->padFileCreator->createUserFile($uid, $path);
-				// Recorded before the template is materialised: everything
-				// after this can fail, and rollback needs to know which file
-				// to remove.
+				// The id is recorded as soon as it can be read; if reading it
+				// throws, the empty file stays where it is because nothing
+				// below can prove it is ours.
 				$fileId = $this->requireFileId($fileNode, $path);
 				$createdFileId = $fileId;
 				if ($this->isNotOurs($fileNode, $fileId, $path)) {
@@ -292,6 +297,7 @@ class PadCreationService {
 				// like the others; the template-hook caller below has no uid
 				// and keeps writing through the node it was handed.
 				$result = $this->materializeTemplateInto($fileNode, $templateNode, $user, $uid);
+				$writtenHash = $result['written_hash'];
 				$padId = $result['pad_id'];
 
 				return [
@@ -302,10 +308,10 @@ class PadCreationService {
 					'pad_url' => $result['pad_url'],
 				];
 			},
-			function () use ($uid, $path, &$padId, &$createdFileId): void {
+			function () use ($uid, $path, &$padId, &$createdFileId, &$writtenHash): void {
 				// File only: materializeTemplateInto() has already deleted the
 				// pad it provisioned before rethrowing.
-				$this->rollbackService->rollbackCreatedFileOnly($uid, $path, $createdFileId);
+				$this->rollbackService->rollbackCreatedFileOnly($uid, $path, $createdFileId, $writtenHash);
 			},
 			function (\Throwable $e) use ($path, &$padId): ?array {
 				if ($e instanceof BindingException) {
@@ -397,6 +403,14 @@ class PadCreationService {
 	}
 
 	public function materializeTemplateInto(File $target, File $template, ?IUser $user, ?string $uid = null): array {
+		// The template hook has a user too — it returns early without one —
+		// so this path is not the exception it looked like, and it gets the
+		// same id-addressed write as the four API creates.
+		$uid ??= $user?->getUID();
+		// What the target held before this call. Nextcloud's template hook
+		// hands over a file that already carries the template's bytes, so
+		// "unchanged" is the check that fits both callers, not "empty".
+		$before = (string)$target->getContent();
 		if (!str_ends_with(strtolower($template->getName()), '.pad')) {
 			throw new NotAPadFileException('Template is not a .pad file.');
 		}
@@ -446,13 +460,14 @@ class PadCreationService {
 				0,
 				true,
 			);
-			// By id when the caller made this file and can name its owner;
-			// through the node when it came from Nextcloud's template hook,
-			// which supplies no uid to resolve an id with.
-			if ($uid !== null) {
-				$this->writeCreatedFile($uid, $fileId, $content);
+			// By id, and only onto the file as it was when this call started:
+			// provisioning the pad and pushing the snapshot take long enough
+			// for the target to be moved and its name reused.
+			if ($uid !== null && $uid !== '') {
+				$writtenHash = $this->writeCreatedFile($uid, $fileId, $content, $before);
 			} else {
 				$target->putContent($content);
+				$writtenHash = hash('sha256', $content);
 			}
 			$this->bindingService->createBinding($fileId, $padId, $accessMode);
 		} catch (\Throwable $e) {
@@ -465,16 +480,10 @@ class PadCreationService {
 			'pad_id' => $padId,
 			'access_mode' => $accessMode,
 			'pad_url' => $padUrl,
+			'written_hash' => $writtenHash,
 		];
 	}
 
-	/**
-	 * The id of the file we just created, or an exception. getId() can throw
-	 * on a node that is not in the cache yet, which is the same failure as
-	 * returning 0 and is reported the same way.
-	 *
-	 * @throws \RuntimeException
-	 */
 	/**
 	 * Write to the file this create made, addressed by id.
 	 *
@@ -487,10 +496,28 @@ class PadCreationService {
 	 *
 	 * @throws \OCP\Files\NotFoundException
 	 */
-	private function writeCreatedFile(string $uid, int $fileId, string $content): void {
-		$this->userNodeResolver->resolveUserFileNodeById($uid, $fileId)->putContent($content);
+	private function writeCreatedFile(string $uid, int $fileId, string $content, string $expectedBefore = ''): string {
+		$node = $this->userNodeResolver->resolveUserFileNodeById($uid, $fileId);
+		// The file was empty when this create claimed it, and a claim is not
+		// a lock: another writer can have finished its own create into the
+		// same file while this request was away at Etherpad. Overwriting
+		// that is the loss this whole change exists to prevent, so a file
+		// that is no longer what it was is not written to.
+		if ((string)$node->getContent() !== $expectedBefore) {
+			throw new PadFileAlreadyExistsException('The target .pad file changed while the pad was being provisioned.');
+		}
+		$node->putContent($content);
+
+		return hash('sha256', $content);
 	}
 
+	/**
+	 * The id of the file we just created, or an exception. getId() can throw
+	 * on a node that is not in the cache yet, which is the same failure as
+	 * returning 0 and is reported the same way.
+	 *
+	 * @throws \RuntimeException
+	 */
 	private function requireFileId(File $fileNode, string $path): int {
 		try {
 			$fileId = (int)$fileNode->getId();

--- a/lib/Service/PadCreationService.php
+++ b/lib/Service/PadCreationService.php
@@ -45,16 +45,20 @@ class PadCreationService {
 		$this->padTypePolicy->requireEnabled($accessMode);
 		$path = $this->padPaths->normalizeCreatePath($file);
 		$padId = '';
-		$createdNode = null;
+		$createdFileId = null;
 
 		return $this->withCreateRollback(
-			function () use ($uid, $path, $accessMode, &$padId, &$createdNode): array {
+			function () use ($uid, $path, $accessMode, &$padId, &$createdFileId): array {
 				$fileNode = $this->padFileCreator->createUserFile($uid, $path);
-				$createdNode = $fileNode;
+				// Read once, here, and carried as a number. Asking the node
+				// again later would answer for whatever holds the path by
+				// then; an id that was never read stays unknown, and an
+				// unknown id cleans up nothing.
 				$fileId = $this->requireFileId($fileNode, $path);
+				$createdFileId = $fileId;
 				if ($this->isNotOurs($fileNode, $fileId, $path)) {
 					// Not ours after all, so it is not ours to clean up either.
-					$createdNode = null;
+					$createdFileId = null;
 					throw new PadFileAlreadyExistsException('Target .pad file already exists.');
 				}
 				$padId = $this->padBootstrapService->provisionPadId($accessMode);
@@ -79,8 +83,8 @@ class PadCreationService {
 					'pad_url' => $padUrl,
 				];
 			},
-			function () use ($uid, $path, &$padId, &$createdNode): void {
-				$this->rollbackService->rollbackFailedCreate($uid, $path, $padId, $createdNode);
+			function () use ($uid, $path, &$padId, &$createdFileId): void {
+				$this->rollbackService->rollbackFailedCreate($uid, $path, $padId, $createdFileId);
 			},
 			function (\Throwable $e) use ($path, $accessMode, &$padId): ?array {
 				if ($e instanceof BindingException) {
@@ -121,19 +125,19 @@ class PadCreationService {
 		}
 
 		$padId = '';
-		$createdNode = null;
+		$createdFileId = null;
 		$path = '';
 
 		return $this->withCreateRollback(
-			function () use ($uid, $parentFolder, $parentFolderId, $fileName, $accessMode, &$path, &$padId, &$createdNode): array {
+			function () use ($uid, $parentFolder, $parentFolderId, $fileName, $accessMode, &$path, &$padId, &$createdFileId): array {
 				$fileNode = $this->padFileCreator->createUserFileInFolder($parentFolder, $fileName);
 				// The node is recorded before anything that can throw, so a
 				// failure anywhere below still cleans the file up.
-				$createdNode = $fileNode;
 				$fileId = $this->requireFileId($fileNode, $path);
+				$createdFileId = $fileId;
 				if ($this->isNotOurs($fileNode, $fileId, $path)) {
 					// Not ours after all, so it is not ours to clean up either.
-					$createdNode = null;
+					$createdFileId = null;
 					throw new PadFileAlreadyExistsException('Target .pad file already exists.');
 				}
 				$path = $this->userNodeResolver->toUserAbsolutePath($uid, $fileNode);
@@ -159,8 +163,8 @@ class PadCreationService {
 					'pad_url' => $padUrl,
 				];
 			},
-			function () use ($uid, &$path, &$padId, &$createdNode): void {
-				$this->rollbackService->rollbackFailedCreate($uid, $path, $padId, $createdNode);
+			function () use ($uid, &$path, &$padId, &$createdFileId): void {
+				$this->rollbackService->rollbackFailedCreate($uid, $path, $padId, $createdFileId);
 			},
 			function (\Throwable $e) use ($parentFolderId, $name, $accessMode, &$path, &$padId): ?array {
 				if ($e instanceof BindingException) {
@@ -198,28 +202,33 @@ class PadCreationService {
 	 */
 	public function createFromUrl(string $uid, string $file, string $padUrl): array {
 		$path = $this->padPaths->normalizeCreatePath($file);
-		$createdNode = null;
+		$createdFileId = null;
 
 		return $this->withCreateRollback(
-			function () use ($uid, $path, $padUrl, &$createdNode) {
+			function () use ($uid, $path, $padUrl, &$createdFileId) {
 				$fileNode = $this->padFileCreator->createUserFile($uid, $path);
-				$createdNode = $fileNode;
 				$fileId = $this->requireFileId($fileNode, $path);
+				$createdFileId = $fileId;
 				if ($this->isNotOurs($fileNode, $fileId, $path)) {
 					// Not ours after all, so it is not ours to clean up either.
-					$createdNode = null;
+					$createdFileId = null;
 					throw new PadFileAlreadyExistsException('Target .pad file already exists.');
 				}
 
-				$seeded = $this->externalPadSeeder->seed($fileNode, $fileId, $padUrl);
+				// Prepared, then written by id: seeding fetches the foreign
+				// export first, and that wait is long enough for the file to
+				// be moved and its name taken.
+				$prepared = $this->externalPadSeeder->prepare($fileId, $padUrl);
+				$this->writeCreatedFile($uid, $fileId, $prepared['content']);
+				$seeded = $prepared['result'];
 				// Preserve the historical key ordering for the external-create
 				// response: `file` is the first key so tests asserting via
 				// `assertSame` keep matching after the refactor.
 				$result = ['file' => $path] + $seeded;
 				return $result;
 			},
-			function () use ($uid, $path, &$createdNode): void {
-				$this->rollbackService->rollbackExternalCreate($uid, $path, $createdNode);
+			function () use ($uid, $path, &$createdFileId): void {
+				$this->rollbackService->rollbackExternalCreate($uid, $path, $createdFileId);
 			},
 			function (\Throwable $e) use ($path, $padUrl): ?array {
 				if ($e instanceof EtherpadClientException) {
@@ -263,23 +272,26 @@ class PadCreationService {
 		$templateNode = $this->userNodeResolver->resolveUserFileNodeById($uid, $templateFileId);
 
 		$padId = '';
-		$createdNode = null;
+		$createdFileId = null;
 
 		return $this->withCreateRollback(
-			function () use ($uid, $path, $templateNode, $user, &$padId, &$createdNode): array {
+			function () use ($uid, $path, $templateNode, $user, &$padId, &$createdFileId): array {
 				$fileNode = $this->padFileCreator->createUserFile($uid, $path);
 				// Recorded before the template is materialised: everything
 				// after this can fail, and rollback needs to know which file
 				// to remove.
-				$createdNode = $fileNode;
 				$fileId = $this->requireFileId($fileNode, $path);
+				$createdFileId = $fileId;
 				if ($this->isNotOurs($fileNode, $fileId, $path)) {
 					// Not ours after all, so it is not ours to clean up either.
-					$createdNode = null;
+					$createdFileId = null;
 					throw new PadFileAlreadyExistsException('Target .pad file already exists.');
 				}
 
-				$result = $this->materializeTemplateInto($fileNode, $templateNode, $user);
+				// This flow creates its own target, so the write goes by id
+				// like the others; the template-hook caller below has no uid
+				// and keeps writing through the node it was handed.
+				$result = $this->materializeTemplateInto($fileNode, $templateNode, $user, $uid);
 				$padId = $result['pad_id'];
 
 				return [
@@ -290,10 +302,10 @@ class PadCreationService {
 					'pad_url' => $result['pad_url'],
 				];
 			},
-			function () use ($uid, $path, &$padId, &$createdNode): void {
+			function () use ($uid, $path, &$padId, &$createdFileId): void {
 				// File only: materializeTemplateInto() has already deleted the
 				// pad it provisioned before rethrowing.
-				$this->rollbackService->rollbackCreatedFileOnly($uid, $path, $createdNode);
+				$this->rollbackService->rollbackCreatedFileOnly($uid, $path, $createdFileId);
 			},
 			function (\Throwable $e) use ($path, &$padId): ?array {
 				if ($e instanceof BindingException) {
@@ -384,7 +396,7 @@ class PadCreationService {
 		}
 	}
 
-	public function materializeTemplateInto(File $target, File $template, ?IUser $user): array {
+	public function materializeTemplateInto(File $target, File $template, ?IUser $user, ?string $uid = null): array {
 		if (!str_ends_with(strtolower($template->getName()), '.pad')) {
 			throw new NotAPadFileException('Template is not a .pad file.');
 		}
@@ -434,11 +446,14 @@ class PadCreationService {
 				0,
 				true,
 			);
-			// Written through the node as given: unlike the create flows,
-			// this file is not one we made — Nextcloud's template hook hands
-			// it over — and the caller need not supply a uid to re-resolve
-			// the id with.
-			$target->putContent($content);
+			// By id when the caller made this file and can name its owner;
+			// through the node when it came from Nextcloud's template hook,
+			// which supplies no uid to resolve an id with.
+			if ($uid !== null) {
+				$this->writeCreatedFile($uid, $fileId, $content);
+			} else {
+				$target->putContent($content);
+			}
 			$this->bindingService->createBinding($fileId, $padId, $accessMode);
 		} catch (\Throwable $e) {
 			$this->unwindMaterializedPad($fileId, $padId);

--- a/lib/Service/UserNodeResolver.php
+++ b/lib/Service/UserNodeResolver.php
@@ -115,12 +115,8 @@ class UserNodeResolver {
 			if ($path !== $root && !str_starts_with($path, $root . '/')) {
 				continue;
 			}
-			// One folder can be reached by several shares, and only some of
-			// them may allow creating. Taking the first hit made the answer
-			// depend on the order `getById()` happened to return, so a user
-			// with both a read-only and a writable path to the same folder
-			// could be refused on the strength of the wrong one. Same rule
-			// the file lookup above already follows.
+			// Overlapping shares can expose the same folder with different permissions.
+			// Prefer a mount that allows creation, regardless of getById() order.
 			if ($node->isCreatable()) {
 				return $node;
 			}

--- a/lib/Service/UserNodeResolver.php
+++ b/lib/Service/UserNodeResolver.php
@@ -100,6 +100,7 @@ class UserNodeResolver {
 		}
 		$nodes = $userFolder->getById($folderId);
 		$root = '/' . $uid . '/files';
+		$fallback = null;
 		foreach ($nodes as $node) {
 			if (!$node instanceof Folder) {
 				continue;
@@ -111,9 +112,22 @@ class UserNodeResolver {
 			// id above, and getById() is not expected to return the folder it
 			// searches — but "not expected to" is an implementation detail,
 			// and this is the path create-by-parent takes into "All files".
-			if ($path === $root || str_starts_with($path, $root . '/')) {
+			if ($path !== $root && !str_starts_with($path, $root . '/')) {
+				continue;
+			}
+			// One folder can be reached by several shares, and only some of
+			// them may allow creating. Taking the first hit made the answer
+			// depend on the order `getById()` happened to return, so a user
+			// with both a read-only and a writable path to the same folder
+			// could be refused on the strength of the wrong one. Same rule
+			// the file lookup above already follows.
+			if ($node->isCreatable()) {
 				return $node;
 			}
+			$fallback ??= $node;
+		}
+		if ($fallback !== null) {
+			return $fallback;
 		}
 
 		throw new NotFoundException('Folder not found by ID.');

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -188,11 +188,6 @@
       <code><![CDATA[__construct]]></code>
     </PossiblyUnusedMethod>
   </file>
-  <file src="lib/Service/ParsedPadFile.php">
-    <PossiblyUnusedProperty>
-      <code><![CDATA[$frontmatter]]></code>
-    </PossiblyUnusedProperty>
-  </file>
   <file src="lib/Service/PendingDeleteRetryService.php">
     <PossiblyUnusedMethod>
       <code><![CDATA[__construct]]></code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -188,6 +188,11 @@
       <code><![CDATA[__construct]]></code>
     </PossiblyUnusedMethod>
   </file>
+  <file src="lib/Service/ParsedPadFile.php">
+    <PossiblyUnusedProperty>
+      <code><![CDATA[$frontmatter]]></code>
+    </PossiblyUnusedProperty>
+  </file>
   <file src="lib/Service/PendingDeleteRetryService.php">
     <PossiblyUnusedMethod>
       <code><![CDATA[__construct]]></code>

--- a/tests/phpunit/unit/FileCreatedFromTemplateListenerTest.php
+++ b/tests/phpunit/unit/FileCreatedFromTemplateListenerTest.php
@@ -9,6 +9,7 @@ use OCA\EtherpadNextcloud\Exception\PadFileChangedException;
 use OCA\EtherpadNextcloud\Exception\PadTypeDisabledException;
 use OCA\EtherpadNextcloud\Service\PadBootstrapService;
 use OCA\EtherpadNextcloud\Service\ExternalPadSeeder;
+use OCA\EtherpadNextcloud\Service\CreatedFileClaim;
 use OCA\EtherpadNextcloud\Service\PadCreationService;
 use OCA\EtherpadNextcloud\Service\PadTemplateStorage;
 use OCP\EventDispatcher\Event;
@@ -99,6 +100,7 @@ class FileCreatedFromTemplateListenerTest extends TestCase {
 		$target->expects($this->once())->method('putContent')->with('');
 
 		$creation = $this->createMock(PadCreationService::class);
+		$this->expectClaimFor($creation, $target);
 		$creation->method('materializeTemplateInto')
 			->willThrowException(new \RuntimeException('boom'));
 
@@ -333,6 +335,7 @@ class FileCreatedFromTemplateListenerTest extends TestCase {
 		$target->expects($this->once())->method('delete');
 
 		$creation = $this->createMock(PadCreationService::class);
+		$this->expectClaimFor($creation, $target);
 		$creation->method('materializeTemplateInto')->willThrowException(new PadTypeDisabledException());
 		$bootstrap = $this->createMock(PadBootstrapService::class);
 		$bootstrap->expects($this->never())->method('initializeMissingFrontmatter');
@@ -340,6 +343,60 @@ class FileCreatedFromTemplateListenerTest extends TestCase {
 		$this->expectException(PadTypeDisabledException::class);
 		$this->buildListener($creation, $bootstrap)
 			->handle(new FileCreatedFromTemplateEvent($template, $target, []));
+	}
+
+	/**
+	 * The general failure branch is not exempt. A pad call can fail
+	 * *because* the file moved, and the name it left behind may belong to
+	 * somebody else — so the blank recovery only runs on a file that is
+	 * still the one this listener was handed.
+	 */
+	public function testDoesNotBlankAFileThatIsNoLongerTheClaimedOne(): void {
+		$target = $this->file('Notes.pad');
+		$target->expects($this->never())->method('putContent');
+		$target->expects($this->never())->method('delete');
+
+		$creation = $this->createMock(PadCreationService::class);
+		$creation->method('claimTemplateTarget')->willReturn(new CreatedFileClaim('alice', 4242));
+		// Moved away, or replaced at that path: nothing matches the claim.
+		$creation->method('resolveUnchangedClaim')->willReturn(null);
+		$creation->method('materializeTemplateInto')
+			->willThrowException(new \RuntimeException('etherpad unreachable'));
+
+		$bootstrap = $this->createMock(PadBootstrapService::class);
+		$bootstrap->expects($this->never())->method('initializeMissingFrontmatter');
+
+		$this->buildListener($creation, $bootstrap)
+			->handle(new FileCreatedFromTemplateEvent($this->file('Template.pad'), $target, []));
+	}
+
+	/** Same rule for the refusal that deletes rather than blanks. */
+	public function testDoesNotDeleteAFileThatIsNoLongerTheClaimedOne(): void {
+		$target = $this->file('Notes.pad');
+		$target->expects($this->never())->method('delete');
+
+		$creation = $this->createMock(PadCreationService::class);
+		$creation->method('claimTemplateTarget')->willReturn(new CreatedFileClaim('alice', 4242));
+		$creation->method('resolveUnchangedClaim')->willReturn(null);
+		$creation->method('materializeTemplateInto')->willThrowException(new PadTypeDisabledException());
+
+		$this->expectException(PadTypeDisabledException::class);
+
+		$this->buildListener($creation, $this->createMock(PadBootstrapService::class))
+			->handle(new FileCreatedFromTemplateEvent($this->file('Template.pad'), $target, []));
+	}
+
+	/**
+	 * The listener claims its target before materialising and measures every
+	 * recovery against that claim, so a double that answers neither call
+	 * leaves it with nothing to act on.
+	 */
+	private function expectClaimFor(PadCreationService $creation, File $target, int $fileId = 4242): CreatedFileClaim {
+		$claim = new CreatedFileClaim('alice', $fileId);
+		$creation->method('claimTemplateTarget')->willReturn($claim);
+		$creation->method('resolveUnchangedClaim')->willReturn($target);
+
+		return $claim;
 	}
 
 	private function buildListener(

--- a/tests/phpunit/unit/FileCreatedFromTemplateListenerTest.php
+++ b/tests/phpunit/unit/FileCreatedFromTemplateListenerTest.php
@@ -345,12 +345,7 @@ class FileCreatedFromTemplateListenerTest extends TestCase {
 			->handle(new FileCreatedFromTemplateEvent($template, $target, []));
 	}
 
-	/**
-	 * The general failure branch is not exempt. A pad call can fail
-	 * *because* the file moved, and the name it left behind may belong to
-	 * somebody else — so the blank recovery only runs on a file that is
-	 * still the one this listener was handed.
-	 */
+	/** A remote error must not bypass the content check before blank recovery. */
 	public function testDoesNotBlankAFileThatIsNoLongerTheClaimedOne(): void {
 		$target = $this->file('Notes.pad');
 		$target->expects($this->never())->method('putContent');
@@ -358,7 +353,7 @@ class FileCreatedFromTemplateListenerTest extends TestCase {
 
 		$creation = $this->createMock(PadCreationService::class);
 		$creation->method('claimTemplateTarget')->willReturn(new CreatedFileClaim('alice', 4242));
-		// Moved away, or replaced at that path: nothing matches the claim.
+		// The claimed file is no longer accessible or its content changed.
 		$creation->method('resolveUnchangedClaim')->willReturn(null);
 		$creation->method('materializeTemplateInto')
 			->willThrowException(new \RuntimeException('etherpad unreachable'));
@@ -370,7 +365,6 @@ class FileCreatedFromTemplateListenerTest extends TestCase {
 			->handle(new FileCreatedFromTemplateEvent($this->file('Template.pad'), $target, []));
 	}
 
-	/** Same rule for the refusal that deletes rather than blanks. */
 	public function testDoesNotDeleteAFileThatIsNoLongerTheClaimedOne(): void {
 		$target = $this->file('Notes.pad');
 		$target->expects($this->never())->method('delete');
@@ -386,11 +380,7 @@ class FileCreatedFromTemplateListenerTest extends TestCase {
 			->handle(new FileCreatedFromTemplateEvent($this->file('Template.pad'), $target, []));
 	}
 
-	/**
-	 * The listener claims its target before materialising and measures every
-	 * recovery against that claim, so a double that answers neither call
-	 * leaves it with nothing to act on.
-	 */
+	/** Stub a claimed target that remains eligible for recovery. */
 	private function expectClaimFor(PadCreationService $creation, File $target, int $fileId = 4242): CreatedFileClaim {
 		$claim = new CreatedFileClaim('alice', $fileId);
 		$creation->method('claimTemplateTarget')->willReturn($claim);
@@ -436,17 +426,17 @@ class FileCreatedFromTemplateListenerTest extends TestCase {
 		return $file;
 	}
 
-	/**
-	 * The write refuses because somebody else filled the file while the pad
-	 * was being provisioned. The blank fallback would empty exactly that
-	 * content, so this failure has to end without touching the file.
-	 */
 	public function testAChangedTargetIsLeftAloneInsteadOfBlanked(): void {
 		$target = $this->file('Notes.pad');
 		$target->expects($this->never())->method('putContent');
 		$target->expects($this->never())->method('delete');
+		// The handler must not ask the stale node anything, id included: it
+		// answers for whatever holds the path by then, and it can throw
+		// while an error is already being handled.
+		$target->expects($this->never())->method('getId');
 
 		$creation = $this->createMock(PadCreationService::class);
+		$this->expectClaimFor($creation, $target);
 		$creation->method('materializeTemplateInto')
 			->willThrowException(new PadFileChangedException('changed'));
 

--- a/tests/phpunit/unit/FileCreatedFromTemplateListenerTest.php
+++ b/tests/phpunit/unit/FileCreatedFromTemplateListenerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OCA\EtherpadNextcloud\Tests\Unit;
 
 use OCA\EtherpadNextcloud\Listeners\FileCreatedFromTemplateListener;
+use OCA\EtherpadNextcloud\Exception\PadFileChangedException;
 use OCA\EtherpadNextcloud\Exception\PadTypeDisabledException;
 use OCA\EtherpadNextcloud\Service\PadBootstrapService;
 use OCA\EtherpadNextcloud\Service\ExternalPadSeeder;
@@ -376,5 +377,29 @@ class FileCreatedFromTemplateListenerTest extends TestCase {
 		$file->method('getName')->willReturn($name);
 		$file->method('getId')->willReturn(42);
 		return $file;
+	}
+
+	/**
+	 * The write refuses because somebody else filled the file while the pad
+	 * was being provisioned. The blank fallback would empty exactly that
+	 * content, so this failure has to end without touching the file.
+	 */
+	public function testAChangedTargetIsLeftAloneInsteadOfBlanked(): void {
+		$target = $this->file('Notes.pad');
+		$target->expects($this->never())->method('putContent');
+		$target->expects($this->never())->method('delete');
+
+		$creation = $this->createMock(PadCreationService::class);
+		$creation->method('materializeTemplateInto')
+			->willThrowException(new PadFileChangedException('changed'));
+
+		$bootstrap = $this->createMock(PadBootstrapService::class);
+		$bootstrap->expects($this->never())->method('initializeMissingFrontmatter');
+
+		$this->buildListener($creation, $bootstrap)->handle(new FileCreatedFromTemplateEvent(
+			$this->file('Template.pad'),
+			$target,
+			[],
+		));
 	}
 }

--- a/tests/phpunit/unit/PadBootstrapServiceTest.php
+++ b/tests/phpunit/unit/PadBootstrapServiceTest.php
@@ -627,11 +627,7 @@ class PadBootstrapServiceTest extends TestCase {
 		return new \OCA\EtherpadNextcloud\Service\PadTypePolicy($config);
 	}
 
-	/**
-	 * The node the id resolves to at write time. The service writes there
-	 * rather than through the node it was handed, so a double that answers
-	 * with nothing would let a passing test write nowhere.
-	 */
+	/** Stub the node resolved at write time, which may differ from the input node. */
 	private function resolverReturning(?File $file): UserNodeResolver {
 		$file ??= $this->createMock(File::class);
 		$resolver = $this->createMock(UserNodeResolver::class);
@@ -640,13 +636,6 @@ class PadBootstrapServiceTest extends TestCase {
 		return $resolver;
 	}
 
-	/**
-	 * Provisioning the pad is a full round trip to another host, and the
-	 * document written afterwards names a file id. If the file moved and
-	 * something else took its name in the meantime, writing through the
-	 * node handed in would mislabel the stranger's file and lose its
-	 * content — so the write goes by id and only onto what the caller read.
-	 */
 	public function testRefusesToWriteWhenTheFileChangedWhileThePadWasProvisioned(): void {
 		$bindingService = $this->createMock(BindingService::class);
 		$bindingService->method('findByFileId')->willReturn(null);
@@ -664,7 +653,7 @@ class PadBootstrapServiceTest extends TestCase {
 		$claimed->method('getId')->willReturn(4242);
 		$claimed->expects($this->never())->method('putContent');
 
-		// What the id resolves to now: a different file at that path.
+		// A fresh node for the claimed id, now containing another writer's content.
 		$stranger = $this->createMock(File::class);
 		$stranger->method('getContent')->willReturn('somebody else\'s notes');
 		$stranger->expects($this->never())->method('putContent');

--- a/tests/phpunit/unit/PadBootstrapServiceTest.php
+++ b/tests/phpunit/unit/PadBootstrapServiceTest.php
@@ -9,6 +9,7 @@ use OCA\EtherpadNextcloud\Service\BindingService;
 use OCA\EtherpadNextcloud\Service\EtherpadClient;
 use OCA\EtherpadNextcloud\Service\ManagedPadLifecycle;
 use OCA\EtherpadNextcloud\Service\PadBootstrapService;
+use OCA\EtherpadNextcloud\Service\UserNodeResolver;
 use OCA\EtherpadNextcloud\Service\PadFileService;
 use OCP\Files\File;
 use OCP\Security\ISecureRandom;
@@ -67,7 +68,7 @@ class PadBootstrapServiceTest extends TestCase {
 		$file->expects($this->once())->method('putContent')->with('doc-content');
 
 		$migration = $this->createMock(\OCA\EtherpadNextcloud\Service\PadLegacyMigrationService::class);
-		$service = new PadBootstrapService($bindingService, $padFileService, $etherpadClient, new ManagedPadLifecycle($etherpadClient, $this->createMock(LoggerInterface::class)), $secureRandom, $logger, $migration, $this->buildPadTypePolicy(true));
+		$service = new PadBootstrapService($bindingService, $padFileService, $etherpadClient, new ManagedPadLifecycle($etherpadClient, $this->createMock(LoggerInterface::class)), $secureRandom, $logger, $migration, $this->buildPadTypePolicy(true), $this->resolverReturning($file));
 		$service->initializeMissingFrontmatter('alice', $file, '');
 	}
 
@@ -97,7 +98,7 @@ class PadBootstrapServiceTest extends TestCase {
 			->method('migrate')
 			->with('alice', $file, $legacy);
 
-		$service = new PadBootstrapService($bindingService, $padFileService, $etherpadClient, new ManagedPadLifecycle($etherpadClient, $this->createMock(LoggerInterface::class)), $secureRandom, $logger, $migration, $this->buildPadTypePolicy(true));
+		$service = new PadBootstrapService($bindingService, $padFileService, $etherpadClient, new ManagedPadLifecycle($etherpadClient, $this->createMock(LoggerInterface::class)), $secureRandom, $logger, $migration, $this->buildPadTypePolicy(true), $this->resolverReturning($file));
 
 		$this->assertTrue(
 			$service->initializeMissingFrontmatter('alice', $file, "[InternetShortcut]\nURL=https://pad.example.test/p/public-pad\n")
@@ -150,6 +151,7 @@ class PadBootstrapServiceTest extends TestCase {
 			$this->createMock(LoggerInterface::class),
 			$this->createMock(\OCA\EtherpadNextcloud\Service\PadLegacyMigrationService::class),
 			$this->buildPadTypePolicy(true),
+			$this->resolverReturning($file),
 		);
 
 		$this->expectException(\RuntimeException::class);
@@ -182,6 +184,7 @@ class PadBootstrapServiceTest extends TestCase {
 			$this->createMock(LoggerInterface::class),
 			$this->createMock(\OCA\EtherpadNextcloud\Service\PadLegacyMigrationService::class),
 			$this->buildPadTypePolicy(true),
+			$this->resolverReturning(null),
 		);
 
 		$this->expectException(\RuntimeException::class);
@@ -228,6 +231,7 @@ class PadBootstrapServiceTest extends TestCase {
 			$this->createMock(LoggerInterface::class),
 			$this->createMock(\OCA\EtherpadNextcloud\Service\PadLegacyMigrationService::class),
 			$this->buildPadTypePolicy(true),
+			$this->resolverReturning($file),
 		);
 
 		$this->expectException(\RuntimeException::class);
@@ -279,6 +283,7 @@ class PadBootstrapServiceTest extends TestCase {
 			$this->createMock(LoggerInterface::class),
 			$this->createMock(\OCA\EtherpadNextcloud\Service\PadLegacyMigrationService::class),
 			$this->buildPadTypePolicy(true),
+			$this->resolverReturning($file),
 		);
 
 		$this->expectException(\RuntimeException::class);
@@ -328,6 +333,7 @@ class PadBootstrapServiceTest extends TestCase {
 			$this->createMock(LoggerInterface::class),
 			$this->createMock(\OCA\EtherpadNextcloud\Service\PadLegacyMigrationService::class),
 			$this->buildPadTypePolicy(true),
+			$this->resolverReturning($file),
 		);
 
 		$this->expectException(\RuntimeException::class);
@@ -395,7 +401,7 @@ class PadBootstrapServiceTest extends TestCase {
 			->willThrowException(new \RuntimeException('write failed'));
 
 		$migration = $this->createMock(\OCA\EtherpadNextcloud\Service\PadLegacyMigrationService::class);
-		$service = new PadBootstrapService($bindingService, $padFileService, $etherpadClient, new ManagedPadLifecycle($etherpadClient, $this->createMock(LoggerInterface::class)), $secureRandom, $logger, $migration, $this->buildPadTypePolicy(true));
+		$service = new PadBootstrapService($bindingService, $padFileService, $etherpadClient, new ManagedPadLifecycle($etherpadClient, $this->createMock(LoggerInterface::class)), $secureRandom, $logger, $migration, $this->buildPadTypePolicy(true), $this->resolverReturning($file));
 
 		$this->expectException(\RuntimeException::class);
 		$this->expectExceptionMessage('write failed');
@@ -464,6 +470,7 @@ class PadBootstrapServiceTest extends TestCase {
 			$this->createMock(LoggerInterface::class),
 			$this->createMock(\OCA\EtherpadNextcloud\Service\PadLegacyMigrationService::class),
 			$this->buildPadTypePolicy(false, true),
+			$this->resolverReturning($file),
 		);
 
 		$service->initializeMissingFrontmatter('alice', $file, '');
@@ -474,6 +481,7 @@ class PadBootstrapServiceTest extends TestCase {
 		PadFileService $padFileService,
 		EtherpadClient $etherpadClient,
 		\OCA\EtherpadNextcloud\Service\PadTypePolicy $policy,
+		?File $file = null,
 	): PadBootstrapService {
 		return new PadBootstrapService(
 			$bindingService,
@@ -484,6 +492,7 @@ class PadBootstrapServiceTest extends TestCase {
 			$this->createMock(LoggerInterface::class),
 			$this->createMock(\OCA\EtherpadNextcloud\Service\PadLegacyMigrationService::class),
 			$policy,
+			$this->resolverReturning($file ?? $this->createMock(File::class)),
 		);
 	}
 
@@ -521,6 +530,7 @@ class PadBootstrapServiceTest extends TestCase {
 			$this->createMock(LoggerInterface::class),
 			$this->createMock(\OCA\EtherpadNextcloud\Service\PadLegacyMigrationService::class),
 			$this->buildPadTypePolicy(false),
+			$this->resolverReturning($file),
 		);
 
 		$service->initializeMissingFrontmatter('alice', $file, '');
@@ -548,6 +558,7 @@ class PadBootstrapServiceTest extends TestCase {
 			$this->createMock(LoggerInterface::class),
 			$migration,
 			$this->buildPadTypePolicy(false),
+			$this->resolverReturning($file),
 		);
 
 		self::assertTrue($service->initializeMissingFrontmatter(
@@ -597,6 +608,7 @@ class PadBootstrapServiceTest extends TestCase {
 			$this->createMock(LoggerInterface::class),
 			$this->createMock(\OCA\EtherpadNextcloud\Service\PadLegacyMigrationService::class),
 			$this->buildPadTypePolicy(false),
+			$this->resolverReturning($file),
 		);
 
 		$this->expectException(\RuntimeException::class);
@@ -613,5 +625,63 @@ class PadBootstrapServiceTest extends TestCase {
 			}
 		);
 		return new \OCA\EtherpadNextcloud\Service\PadTypePolicy($config);
+	}
+
+	/**
+	 * The node the id resolves to at write time. The service writes there
+	 * rather than through the node it was handed, so a double that answers
+	 * with nothing would let a passing test write nowhere.
+	 */
+	private function resolverReturning(?File $file): UserNodeResolver {
+		$file ??= $this->createMock(File::class);
+		$resolver = $this->createMock(UserNodeResolver::class);
+		$resolver->method('resolveUserFileNodeById')->willReturn($file);
+
+		return $resolver;
+	}
+
+	/**
+	 * Provisioning the pad is a full round trip to another host, and the
+	 * document written afterwards names a file id. If the file moved and
+	 * something else took its name in the meantime, writing through the
+	 * node handed in would mislabel the stranger's file and lose its
+	 * content — so the write goes by id and only onto what the caller read.
+	 */
+	public function testRefusesToWriteWhenTheFileChangedWhileThePadWasProvisioned(): void {
+		$bindingService = $this->createMock(BindingService::class);
+		$bindingService->method('findByFileId')->willReturn(null);
+
+		$padFileService = $this->createMock(PadFileService::class);
+		$padFileService->method('buildInitialDocument')->willReturn('doc-content');
+
+		$etherpadClient = $this->createMock(EtherpadClient::class);
+		$etherpadClient->method('buildPadUrl')->willReturn('https://pad.example.test/p/nc-x');
+
+		$secureRandom = $this->createMock(ISecureRandom::class);
+		$secureRandom->method('generate')->willReturn('abcdefghijklmnopqrstuvwx');
+
+		$claimed = $this->createMock(File::class);
+		$claimed->method('getId')->willReturn(4242);
+		$claimed->expects($this->never())->method('putContent');
+
+		// What the id resolves to now: a different file at that path.
+		$stranger = $this->createMock(File::class);
+		$stranger->method('getContent')->willReturn('somebody else\'s notes');
+		$stranger->expects($this->never())->method('putContent');
+
+		$service = new PadBootstrapService(
+			$bindingService,
+			$padFileService,
+			$etherpadClient,
+			new ManagedPadLifecycle($etherpadClient, $this->createMock(LoggerInterface::class)),
+			$secureRandom,
+			$this->createMock(LoggerInterface::class),
+			$this->createMock(\OCA\EtherpadNextcloud\Service\PadLegacyMigrationService::class),
+			$this->buildPadTypePolicy(true),
+			$this->resolverReturning($stranger),
+		);
+
+		$this->expectException(\OCA\EtherpadNextcloud\Exception\PadFileChangedException::class);
+		$service->initializeMissingFrontmatter('alice', $claimed, '');
 	}
 }

--- a/tests/phpunit/unit/PadCreateRollbackServiceTest.php
+++ b/tests/phpunit/unit/PadCreateRollbackServiceTest.php
@@ -6,6 +6,8 @@ namespace OCA\EtherpadNextcloud\Tests\Unit;
 
 use OCA\EtherpadNextcloud\Service\EtherpadClient;
 use OCA\EtherpadNextcloud\Service\ManagedPadLifecycle;
+use OCA\EtherpadNextcloud\Service\PadFileService;
+use OCA\EtherpadNextcloud\Service\ParsedPadFile;
 use OCA\EtherpadNextcloud\Service\PadCreateRollbackService;
 use OCA\EtherpadNextcloud\Service\UserNodeResolver;
 use OCP\Files\File;
@@ -29,11 +31,11 @@ class PadCreateRollbackServiceTest extends TestCase {
 	 * rollback runs.
 	 */
 	public function testDeletesTheFileTheIdResolvesToNow(): void {
-		$stillOurs = $this->createMock(File::class);
+		$stillOurs = $this->untouchedFile();
 		$stillOurs->expects($this->once())->method('delete');
 
 		$this->buildService(userNodeResolver: $this->resolverFinding($stillOurs))
-			->rollbackFailedCreate('alice', '/Created.pad', '', $this->createdNode());
+			->rollbackFailedCreate('alice', '/Created.pad', '', 4711);
 	}
 
 	/**
@@ -49,27 +51,63 @@ class PadCreateRollbackServiceTest extends TestCase {
 		$logger->expects($this->never())->method('warning');
 
 		$this->buildService(logger: $logger, userNodeResolver: $resolver)
-			->rollbackFailedCreate('alice', '/Created.pad', '', $this->createdNode());
+			->rollbackFailedCreate('alice', '/Created.pad', '', 4711);
 	}
 
 	/**
-	 * No id, no proof of which file this is. A stray empty `.pad` is a
-	 * mess; deleting the wrong file is a loss.
+	 * The create never read an id it could trust, so nothing here names a
+	 * file. Asking the old node for one now would answer for whatever holds
+	 * that path by now — which is the substitution this exists to prevent.
 	 */
-	public function testLeavesTheFileAloneWhenItsIdCannotBeRead(): void {
-		$node = $this->createMock(File::class);
-		$node->method('getId')->willThrowException(new \RuntimeException('no cache entry'));
-		$node->expects($this->never())->method('delete');
-
+	public function testLooksUpNothingWhenTheCreateNeverGotAnId(): void {
 		$resolver = $this->createMock(UserNodeResolver::class);
 		$resolver->expects($this->never())->method('resolveUserFileNodeById');
 
+		$this->buildService(userNodeResolver: $resolver)
+			->rollbackFailedCreate('alice', '/Created.pad', '', null);
+	}
+
+	/**
+	 * The id is not proof of authorship: `newFile()` can hand back a file
+	 * another writer created a moment earlier, and that writer may have
+	 * filled it while this request was away at Etherpad.
+	 */
+	public function testLeavesAFileSomebodyElseWroteInto(): void {
+		$foreign = $this->createMock(File::class);
+		$foreign->method('getSize')->willReturn(42);
+		$foreign->method('getContent')->willReturn('someone else\'s notes');
+		$foreign->expects($this->never())->method('delete');
+
+		$padFiles = $this->createMock(PadFileService::class);
+		$padFiles->method('readPad')->willThrowException(new \RuntimeException('not a pad file'));
+
 		$logger = $this->createMock(LoggerInterface::class);
 		$logger->expects($this->once())->method('warning')
-			->with($this->stringContains('no usable id'), $this->anything());
+			->with($this->stringContains('content this create did not write'), $this->anything());
 
-		$this->buildService(logger: $logger, userNodeResolver: $resolver)
-			->rollbackFailedCreate('alice', '/Created.pad', '', $node);
+		$this->buildService(logger: $logger, userNodeResolver: $this->resolverFinding($foreign), padFileService: $padFiles)
+			->rollbackFailedCreate('alice', '/Created.pad', '', 4711);
+	}
+
+	/** Its own frontmatter names the id, so this one is ours to remove. */
+	public function testDeletesAFileCarryingTheDocumentThisCreateWrote(): void {
+		$ours = $this->createMock(File::class);
+		$ours->method('getSize')->willReturn(120);
+		$ours->method('getContent')->willReturn('frontmatter');
+		$ours->expects($this->once())->method('delete');
+
+		$padFiles = $this->createMock(PadFileService::class);
+		$padFiles->method('readPad')->with('frontmatter')->willReturn(new ParsedPadFile(
+			frontmatter: ['file_id' => 4711, 'pad_id' => 'p-1', 'access_mode' => 'public'],
+			body: '',
+			padId: 'p-1',
+			accessMode: 'public',
+			padUrl: '',
+			isExternal: false,
+		));
+
+		$this->buildService(userNodeResolver: $this->resolverFinding($ours), padFileService: $padFiles)
+			->rollbackFailedCreate('alice', '/Created.pad', '', 4711);
 	}
 
 	/**
@@ -83,7 +121,7 @@ class PadCreateRollbackServiceTest extends TestCase {
 		$empty->expects($this->once())->method('delete');
 
 		$this->buildService(userNodeResolver: $this->resolverFinding($empty))
-			->rollbackFailedCreate('alice', '/Created.pad', '', $this->createdNode());
+			->rollbackFailedCreate('alice', '/Created.pad', '', 4711);
 	}
 
 	public function testDeletesTheProvisionedPad(): void {
@@ -121,7 +159,7 @@ class PadCreateRollbackServiceTest extends TestCase {
 
 	/** A cleanup failure must not replace the error that caused the rollback. */
 	public function testReportsButSwallowsADeleteFailure(): void {
-		$resolved = $this->createMock(File::class);
+		$resolved = $this->untouchedFile();
 		$resolved->method('delete')->willThrowException(new \RuntimeException('nope'));
 
 		$logger = $this->createMock(LoggerInterface::class);
@@ -133,7 +171,7 @@ class PadCreateRollbackServiceTest extends TestCase {
 			);
 
 		$this->buildService(logger: $logger, userNodeResolver: $this->resolverFinding($resolved))
-			->rollbackFailedCreate('alice', '/Created.pad', '', $this->createdNode());
+			->rollbackFailedCreate('alice', '/Created.pad', '', 4711);
 	}
 
 	public function testReportsButSwallowsAPadDeleteFailure(): void {
@@ -155,14 +193,14 @@ class PadCreateRollbackServiceTest extends TestCase {
 	 * pad step, so a future pad-side step cannot leak into it.
 	 */
 	public function testFileOnlyRollbackLeavesThePadAlone(): void {
-		$resolved = $this->createMock(File::class);
+		$resolved = $this->untouchedFile();
 		$resolved->expects($this->once())->method('delete');
 
 		$etherpad = $this->createMock(EtherpadClient::class);
 		$etherpad->expects($this->never())->method('deletePad');
 
 		$this->buildService(etherpad: $etherpad, userNodeResolver: $this->resolverFinding($resolved))
-			->rollbackCreatedFileOnly('alice', '/Created.pad', $this->createdNode());
+			->rollbackCreatedFileOnly('alice', '/Created.pad', 4711);
 	}
 
 	/**
@@ -170,22 +208,24 @@ class PadCreateRollbackServiceTest extends TestCase {
 	 * file goes and nothing is deleted on the Etherpad side.
 	 */
 	public function testExternalRollbackDeletesTheFileButNoPad(): void {
-		$resolved = $this->createMock(File::class);
+		$resolved = $this->untouchedFile();
 		$resolved->expects($this->once())->method('delete');
 
 		$etherpad = $this->createMock(EtherpadClient::class);
 		$etherpad->expects($this->never())->method('deletePad');
 
 		$this->buildService(etherpad: $etherpad, userNodeResolver: $this->resolverFinding($resolved))
-			->rollbackExternalCreate('alice', '/Created.pad', $this->createdNode());
+			->rollbackExternalCreate('alice', '/Created.pad', 4711);
 	}
 
 	private function buildService(
 		?EtherpadClient $etherpad = null,
 		?LoggerInterface $logger = null,
 		?UserNodeResolver $userNodeResolver = null,
+		?PadFileService $padFileService = null,
 	): PadCreateRollbackService {
 		return new PadCreateRollbackService(
+			$padFileService ?? $this->createMock(PadFileService::class),
 			new ManagedPadLifecycle($etherpad ?? $this->createMock(EtherpadClient::class), $this->createMock(LoggerInterface::class)),
 			$userNodeResolver ?? $this->createMock(UserNodeResolver::class),
 			$logger ?? $this->createMock(LoggerInterface::class),
@@ -203,11 +243,10 @@ class PadCreateRollbackServiceTest extends TestCase {
 		return $resolver;
 	}
 
-	/** A node the create returned, carrying an id but nothing else. */
-	private function createdNode(int $fileId = 4711): File {
+	/** An untouched file: still empty, so still ours to remove. */
+	private function untouchedFile(): File {
 		$node = $this->createMock(File::class);
-		$node->method('getId')->willReturn($fileId);
-		$node->expects($this->never())->method('delete');
+		$node->method('getSize')->willReturn(0);
 
 		return $node;
 	}

--- a/tests/phpunit/unit/PadCreateRollbackServiceTest.php
+++ b/tests/phpunit/unit/PadCreateRollbackServiceTest.php
@@ -7,7 +7,9 @@ namespace OCA\EtherpadNextcloud\Tests\Unit;
 use OCA\EtherpadNextcloud\Service\EtherpadClient;
 use OCA\EtherpadNextcloud\Service\ManagedPadLifecycle;
 use OCA\EtherpadNextcloud\Service\PadCreateRollbackService;
+use OCA\EtherpadNextcloud\Service\UserNodeResolver;
 use OCP\Files\File;
+use OCP\Files\NotFoundException;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
@@ -21,14 +23,53 @@ class PadCreateRollbackServiceTest extends TestCase {
 	}
 
 	/**
-	 * The node itself, not its path and not a fresh lookup by id: this is
-	 * the object the create made, in the request that made it.
+	 * By id, never through the node the create returned. `File::delete()`
+	 * unlinks its remembered path, and Etherpad provisioning lasts long
+	 * enough for that path to hold somebody else's file by the time the
+	 * rollback runs.
 	 */
-	public function testDeletesTheNodeTheCreateMade(): void {
-		$created = $this->createMock(File::class);
-		$created->expects($this->once())->method('delete');
+	public function testDeletesTheFileTheIdResolvesToNow(): void {
+		$stillOurs = $this->createMock(File::class);
+		$stillOurs->expects($this->once())->method('delete');
 
-		$this->buildService()->rollbackFailedCreate('alice', '/Created.pad', '', $created);
+		$this->buildService(userNodeResolver: $this->resolverFinding($stillOurs))
+			->rollbackFailedCreate('alice', '/Created.pad', '', $this->createdNode());
+	}
+
+	/**
+	 * The substitution this exists to prevent: our file was moved away and
+	 * another one took the name. The id finds nothing, so nothing is
+	 * deleted — and the stranger's file survives.
+	 */
+	public function testDeletesNothingWhenTheCreatedFileIsNoLongerThere(): void {
+		$resolver = $this->createMock(UserNodeResolver::class);
+		$resolver->method('resolveUserFileNodeById')->willThrowException(new NotFoundException('gone'));
+
+		$logger = $this->createMock(LoggerInterface::class);
+		$logger->expects($this->never())->method('warning');
+
+		$this->buildService(logger: $logger, userNodeResolver: $resolver)
+			->rollbackFailedCreate('alice', '/Created.pad', '', $this->createdNode());
+	}
+
+	/**
+	 * No id, no proof of which file this is. A stray empty `.pad` is a
+	 * mess; deleting the wrong file is a loss.
+	 */
+	public function testLeavesTheFileAloneWhenItsIdCannotBeRead(): void {
+		$node = $this->createMock(File::class);
+		$node->method('getId')->willThrowException(new \RuntimeException('no cache entry'));
+		$node->expects($this->never())->method('delete');
+
+		$resolver = $this->createMock(UserNodeResolver::class);
+		$resolver->expects($this->never())->method('resolveUserFileNodeById');
+
+		$logger = $this->createMock(LoggerInterface::class);
+		$logger->expects($this->once())->method('warning')
+			->with($this->stringContains('no usable id'), $this->anything());
+
+		$this->buildService(logger: $logger, userNodeResolver: $resolver)
+			->rollbackFailedCreate('alice', '/Created.pad', '', $node);
 	}
 
 	/**
@@ -41,7 +82,8 @@ class PadCreateRollbackServiceTest extends TestCase {
 		$empty->method('getSize')->willReturn(0);
 		$empty->expects($this->once())->method('delete');
 
-		$this->buildService()->rollbackFailedCreate('alice', '/Created.pad', '', $empty);
+		$this->buildService(userNodeResolver: $this->resolverFinding($empty))
+			->rollbackFailedCreate('alice', '/Created.pad', '', $this->createdNode());
 	}
 
 	public function testDeletesTheProvisionedPad(): void {
@@ -79,8 +121,8 @@ class PadCreateRollbackServiceTest extends TestCase {
 
 	/** A cleanup failure must not replace the error that caused the rollback. */
 	public function testReportsButSwallowsADeleteFailure(): void {
-		$created = $this->createMock(File::class);
-		$created->method('delete')->willThrowException(new \RuntimeException('nope'));
+		$resolved = $this->createMock(File::class);
+		$resolved->method('delete')->willThrowException(new \RuntimeException('nope'));
 
 		$logger = $this->createMock(LoggerInterface::class);
 		$logger->expects($this->once())
@@ -90,8 +132,8 @@ class PadCreateRollbackServiceTest extends TestCase {
 				$this->callback(static fn (array $c): bool => $c['file'] === '/Created.pad' && $c['uid'] === 'alice'),
 			);
 
-		$this->buildService(logger: $logger)
-			->rollbackFailedCreate('alice', '/Created.pad', '', $created);
+		$this->buildService(logger: $logger, userNodeResolver: $this->resolverFinding($resolved))
+			->rollbackFailedCreate('alice', '/Created.pad', '', $this->createdNode());
 	}
 
 	public function testReportsButSwallowsAPadDeleteFailure(): void {
@@ -113,14 +155,14 @@ class PadCreateRollbackServiceTest extends TestCase {
 	 * pad step, so a future pad-side step cannot leak into it.
 	 */
 	public function testFileOnlyRollbackLeavesThePadAlone(): void {
-		$created = $this->createMock(File::class);
-		$created->expects($this->once())->method('delete');
+		$resolved = $this->createMock(File::class);
+		$resolved->expects($this->once())->method('delete');
 
 		$etherpad = $this->createMock(EtherpadClient::class);
 		$etherpad->expects($this->never())->method('deletePad');
 
-		$this->buildService(etherpad: $etherpad)
-			->rollbackCreatedFileOnly('alice', '/Created.pad', $created);
+		$this->buildService(etherpad: $etherpad, userNodeResolver: $this->resolverFinding($resolved))
+			->rollbackCreatedFileOnly('alice', '/Created.pad', $this->createdNode());
 	}
 
 	/**
@@ -128,23 +170,45 @@ class PadCreateRollbackServiceTest extends TestCase {
 	 * file goes and nothing is deleted on the Etherpad side.
 	 */
 	public function testExternalRollbackDeletesTheFileButNoPad(): void {
-		$created = $this->createMock(File::class);
-		$created->expects($this->once())->method('delete');
+		$resolved = $this->createMock(File::class);
+		$resolved->expects($this->once())->method('delete');
 
 		$etherpad = $this->createMock(EtherpadClient::class);
 		$etherpad->expects($this->never())->method('deletePad');
 
-		$this->buildService(etherpad: $etherpad)
-			->rollbackExternalCreate('alice', '/Created.pad', $created);
+		$this->buildService(etherpad: $etherpad, userNodeResolver: $this->resolverFinding($resolved))
+			->rollbackExternalCreate('alice', '/Created.pad', $this->createdNode());
 	}
 
 	private function buildService(
 		?EtherpadClient $etherpad = null,
 		?LoggerInterface $logger = null,
+		?UserNodeResolver $userNodeResolver = null,
 	): PadCreateRollbackService {
 		return new PadCreateRollbackService(
 			new ManagedPadLifecycle($etherpad ?? $this->createMock(EtherpadClient::class), $this->createMock(LoggerInterface::class)),
+			$userNodeResolver ?? $this->createMock(UserNodeResolver::class),
 			$logger ?? $this->createMock(LoggerInterface::class),
 		);
+	}
+
+	/**
+	 * The file the id resolves to now — which is what the service deletes,
+	 * so a test that stubs only the create's own node proves nothing.
+	 */
+	private function resolverFinding(File $node, int $fileId = 4711): UserNodeResolver {
+		$resolver = $this->createMock(UserNodeResolver::class);
+		$resolver->method('resolveUserFileNodeById')->with('alice', $fileId)->willReturn($node);
+
+		return $resolver;
+	}
+
+	/** A node the create returned, carrying an id but nothing else. */
+	private function createdNode(int $fileId = 4711): File {
+		$node = $this->createMock(File::class);
+		$node->method('getId')->willReturn($fileId);
+		$node->expects($this->never())->method('delete');
+
+		return $node;
 	}
 }

--- a/tests/phpunit/unit/PadCreateRollbackServiceTest.php
+++ b/tests/phpunit/unit/PadCreateRollbackServiceTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OCA\EtherpadNextcloud\Tests\Unit;
 
 use OCA\EtherpadNextcloud\Service\EtherpadClient;
+use OCA\EtherpadNextcloud\Service\CreatedFileClaim;
 use OCA\EtherpadNextcloud\Service\ManagedPadLifecycle;
 use OCA\EtherpadNextcloud\Service\PadCreateRollbackService;
 use OCA\EtherpadNextcloud\Service\UserNodeResolver;
@@ -33,7 +34,7 @@ class PadCreateRollbackServiceTest extends TestCase {
 		$stillOurs->expects($this->once())->method('delete');
 
 		$this->buildService(userNodeResolver: $this->resolverFinding($stillOurs))
-			->rollbackFailedCreate('alice', '/Created.pad', '', 4711);
+			->rollbackFailedCreate('alice', '/Created.pad', '', new CreatedFileClaim('alice', 4711));
 	}
 
 	/**
@@ -49,7 +50,7 @@ class PadCreateRollbackServiceTest extends TestCase {
 		$logger->expects($this->never())->method('warning');
 
 		$this->buildService(logger: $logger, userNodeResolver: $resolver)
-			->rollbackFailedCreate('alice', '/Created.pad', '', 4711);
+			->rollbackFailedCreate('alice', '/Created.pad', '', new CreatedFileClaim('alice', 4711));
 	}
 
 	/**
@@ -79,7 +80,7 @@ class PadCreateRollbackServiceTest extends TestCase {
 			->with($this->stringContains('not what this create wrote'), $this->anything());
 
 		$this->buildService(logger: $logger, userNodeResolver: $this->resolverFinding($foreign))
-			->rollbackFailedCreate('alice', '/Created.pad', '', 4711, hash('sha256', 'our document'));
+			->rollbackFailedCreate('alice', '/Created.pad', '', $this->claimThatWrote('our document'));
 	}
 
 	/**
@@ -92,7 +93,7 @@ class PadCreateRollbackServiceTest extends TestCase {
 		$rivals->expects($this->never())->method('delete');
 
 		$this->buildService(userNodeResolver: $this->resolverFinding($rivals))
-			->rollbackFailedCreate('alice', '/Created.pad', 'nc-own', 4711, hash('sha256', "---\nfile_id: 4711\npad_id: nc-own\n---\n"));
+			->rollbackFailedCreate('alice', '/Created.pad', 'nc-own', $this->claimThatWrote("---\nfile_id: 4711\npad_id: nc-own\n---\n"));
 	}
 
 	/** Exactly the bytes this create wrote, so this one is ours to remove. */
@@ -101,7 +102,7 @@ class PadCreateRollbackServiceTest extends TestCase {
 		$ours->expects($this->once())->method('delete');
 
 		$this->buildService(userNodeResolver: $this->resolverFinding($ours))
-			->rollbackFailedCreate('alice', '/Created.pad', '', 4711, hash('sha256', 'our document'));
+			->rollbackFailedCreate('alice', '/Created.pad', '', $this->claimThatWrote('our document'));
 	}
 
 	/**
@@ -120,7 +121,7 @@ class PadCreateRollbackServiceTest extends TestCase {
 			->with($this->stringContains('could not be read'), $this->anything());
 
 		$this->buildService(logger: $logger, userNodeResolver: $this->resolverFinding($locked))
-			->rollbackFailedCreate('alice', '/Created.pad', '', 4711, hash('sha256', 'our document'));
+			->rollbackFailedCreate('alice', '/Created.pad', '', $this->claimThatWrote('our document'));
 	}
 
 	public function testSwallowsAFailedLookup(): void {
@@ -132,7 +133,15 @@ class PadCreateRollbackServiceTest extends TestCase {
 			->with($this->stringContains('Could not look up'), $this->anything());
 
 		$this->buildService(logger: $logger, userNodeResolver: $resolver)
-			->rollbackFailedCreate('alice', '/Created.pad', '', 4711, null);
+			->rollbackFailedCreate('alice', '/Created.pad', '', new CreatedFileClaim('alice', 4711));
+	}
+
+	/** A claim whose write succeeded, carrying proof of those exact bytes. */
+	private function claimThatWrote(string $content): CreatedFileClaim {
+		$claim = new CreatedFileClaim('alice', 4711);
+		$claim->writtenHash = hash('sha256', $content);
+
+		return $claim;
 	}
 
 	private function fileHolding(string $content): File {
@@ -154,7 +163,7 @@ class PadCreateRollbackServiceTest extends TestCase {
 		$empty->expects($this->once())->method('delete');
 
 		$this->buildService(userNodeResolver: $this->resolverFinding($empty))
-			->rollbackFailedCreate('alice', '/Created.pad', '', 4711);
+			->rollbackFailedCreate('alice', '/Created.pad', '', new CreatedFileClaim('alice', 4711));
 	}
 
 	public function testDeletesTheProvisionedPad(): void {
@@ -204,7 +213,7 @@ class PadCreateRollbackServiceTest extends TestCase {
 			);
 
 		$this->buildService(logger: $logger, userNodeResolver: $this->resolverFinding($resolved))
-			->rollbackFailedCreate('alice', '/Created.pad', '', 4711);
+			->rollbackFailedCreate('alice', '/Created.pad', '', new CreatedFileClaim('alice', 4711));
 	}
 
 	public function testReportsButSwallowsAPadDeleteFailure(): void {
@@ -233,7 +242,7 @@ class PadCreateRollbackServiceTest extends TestCase {
 		$etherpad->expects($this->never())->method('deletePad');
 
 		$this->buildService(etherpad: $etherpad, userNodeResolver: $this->resolverFinding($resolved))
-			->rollbackCreatedFileOnly('alice', '/Created.pad', 4711);
+			->rollbackCreatedFileOnly('alice', '/Created.pad', new CreatedFileClaim('alice', 4711));
 	}
 
 	/**
@@ -248,7 +257,7 @@ class PadCreateRollbackServiceTest extends TestCase {
 		$etherpad->expects($this->never())->method('deletePad');
 
 		$this->buildService(etherpad: $etherpad, userNodeResolver: $this->resolverFinding($resolved))
-			->rollbackExternalCreate('alice', '/Created.pad', 4711);
+			->rollbackExternalCreate('alice', '/Created.pad', new CreatedFileClaim('alice', 4711));
 	}
 
 	private function buildService(

--- a/tests/phpunit/unit/PadCreateRollbackServiceTest.php
+++ b/tests/phpunit/unit/PadCreateRollbackServiceTest.php
@@ -6,8 +6,6 @@ namespace OCA\EtherpadNextcloud\Tests\Unit;
 
 use OCA\EtherpadNextcloud\Service\EtherpadClient;
 use OCA\EtherpadNextcloud\Service\ManagedPadLifecycle;
-use OCA\EtherpadNextcloud\Service\PadFileService;
-use OCA\EtherpadNextcloud\Service\ParsedPadFile;
 use OCA\EtherpadNextcloud\Service\PadCreateRollbackService;
 use OCA\EtherpadNextcloud\Service\UserNodeResolver;
 use OCP\Files\File;
@@ -73,41 +71,76 @@ class PadCreateRollbackServiceTest extends TestCase {
 	 * filled it while this request was away at Etherpad.
 	 */
 	public function testLeavesAFileSomebodyElseWroteInto(): void {
-		$foreign = $this->createMock(File::class);
-		$foreign->method('getSize')->willReturn(42);
-		$foreign->method('getContent')->willReturn('someone else\'s notes');
+		$foreign = $this->fileHolding('someone else\'s notes');
 		$foreign->expects($this->never())->method('delete');
-
-		$padFiles = $this->createMock(PadFileService::class);
-		$padFiles->method('readPad')->willThrowException(new \RuntimeException('not a pad file'));
 
 		$logger = $this->createMock(LoggerInterface::class);
 		$logger->expects($this->once())->method('warning')
-			->with($this->stringContains('content this create did not write'), $this->anything());
+			->with($this->stringContains('not what this create wrote'), $this->anything());
 
-		$this->buildService(logger: $logger, userNodeResolver: $this->resolverFinding($foreign), padFileService: $padFiles)
-			->rollbackFailedCreate('alice', '/Created.pad', '', 4711);
+		$this->buildService(logger: $logger, userNodeResolver: $this->resolverFinding($foreign))
+			->rollbackFailedCreate('alice', '/Created.pad', '', 4711, hash('sha256', 'our document'));
 	}
 
-	/** Its own frontmatter names the id, so this one is ours to remove. */
-	public function testDeletesAFileCarryingTheDocumentThisCreateWrote(): void {
-		$ours = $this->createMock(File::class);
-		$ours->method('getSize')->willReturn(120);
-		$ours->method('getContent')->willReturn('frontmatter');
+	/**
+	 * A rival create can finish into the same file. Its document carries the
+	 * same `file_id` — the id belongs to the file, not to the attempt — so
+	 * only the bytes this attempt wrote settle it.
+	 */
+	public function testLeavesADocumentAnotherCreateWroteIntoTheSameFile(): void {
+		$rivals = $this->fileHolding("---\nfile_id: 4711\npad_id: nc-rival\n---\n");
+		$rivals->expects($this->never())->method('delete');
+
+		$this->buildService(userNodeResolver: $this->resolverFinding($rivals))
+			->rollbackFailedCreate('alice', '/Created.pad', 'nc-own', 4711, hash('sha256', "---\nfile_id: 4711\npad_id: nc-own\n---\n"));
+	}
+
+	/** Exactly the bytes this create wrote, so this one is ours to remove. */
+	public function testDeletesAFileHoldingWhatThisCreateWrote(): void {
+		$ours = $this->fileHolding('our document');
 		$ours->expects($this->once())->method('delete');
 
-		$padFiles = $this->createMock(PadFileService::class);
-		$padFiles->method('readPad')->with('frontmatter')->willReturn(new ParsedPadFile(
-			frontmatter: ['file_id' => 4711, 'pad_id' => 'p-1', 'access_mode' => 'public'],
-			body: '',
-			padId: 'p-1',
-			accessMode: 'public',
-			padUrl: '',
-			isExternal: false,
-		));
+		$this->buildService(userNodeResolver: $this->resolverFinding($ours))
+			->rollbackFailedCreate('alice', '/Created.pad', '', 4711, hash('sha256', 'our document'));
+	}
 
-		$this->buildService(userNodeResolver: $this->resolverFinding($ours), padFileService: $padFiles)
-			->rollbackFailedCreate('alice', '/Created.pad', '', 4711);
+	/**
+	 * Both give up rather than delete. They are the conservative half of the
+	 * rule, and an exception escaping either would turn a best-effort
+	 * cleanup into a failure that hides the original create error.
+	 */
+	public function testLeavesTheFileAloneWhenItsContentCannotBeRead(): void {
+		$locked = $this->createMock(File::class);
+		$locked->method('getSize')->willReturn(120);
+		$locked->method('getContent')->willThrowException(new \OCP\Lock\LockedException('/Created.pad'));
+		$locked->expects($this->never())->method('delete');
+
+		$logger = $this->createMock(LoggerInterface::class);
+		$logger->expects($this->once())->method('warning')
+			->with($this->stringContains('could not be read'), $this->anything());
+
+		$this->buildService(logger: $logger, userNodeResolver: $this->resolverFinding($locked))
+			->rollbackFailedCreate('alice', '/Created.pad', '', 4711, hash('sha256', 'our document'));
+	}
+
+	public function testSwallowsAFailedLookup(): void {
+		$resolver = $this->createMock(UserNodeResolver::class);
+		$resolver->method('resolveUserFileNodeById')->willThrowException(new \RuntimeException('storage down'));
+
+		$logger = $this->createMock(LoggerInterface::class);
+		$logger->expects($this->once())->method('warning')
+			->with($this->stringContains('Could not look up'), $this->anything());
+
+		$this->buildService(logger: $logger, userNodeResolver: $resolver)
+			->rollbackFailedCreate('alice', '/Created.pad', '', 4711, null);
+	}
+
+	private function fileHolding(string $content): File {
+		$node = $this->createMock(File::class);
+		$node->method('getSize')->willReturn(strlen($content));
+		$node->method('getContent')->willReturn($content);
+
+		return $node;
 	}
 
 	/**
@@ -222,10 +255,8 @@ class PadCreateRollbackServiceTest extends TestCase {
 		?EtherpadClient $etherpad = null,
 		?LoggerInterface $logger = null,
 		?UserNodeResolver $userNodeResolver = null,
-		?PadFileService $padFileService = null,
 	): PadCreateRollbackService {
 		return new PadCreateRollbackService(
-			$padFileService ?? $this->createMock(PadFileService::class),
 			new ManagedPadLifecycle($etherpad ?? $this->createMock(EtherpadClient::class), $this->createMock(LoggerInterface::class)),
 			$userNodeResolver ?? $this->createMock(UserNodeResolver::class),
 			$logger ?? $this->createMock(LoggerInterface::class),

--- a/tests/phpunit/unit/PadCreateRollbackServiceTest.php
+++ b/tests/phpunit/unit/PadCreateRollbackServiceTest.php
@@ -23,12 +23,6 @@ class PadCreateRollbackServiceTest extends TestCase {
 			->rollbackFailedCreate('alice', '/Existing.pad', '', null);
 	}
 
-	/**
-	 * By id, never through the node the create returned. `File::delete()`
-	 * unlinks its remembered path, and Etherpad provisioning lasts long
-	 * enough for that path to hold somebody else's file by the time the
-	 * rollback runs.
-	 */
 	public function testDeletesTheFileTheIdResolvesToNow(): void {
 		$stillOurs = $this->untouchedFile();
 		$stillOurs->expects($this->once())->method('delete');
@@ -37,11 +31,6 @@ class PadCreateRollbackServiceTest extends TestCase {
 			->rollbackFailedCreate('alice', '/Created.pad', '', new CreatedFileClaim('alice', 4711));
 	}
 
-	/**
-	 * The substitution this exists to prevent: our file was moved away and
-	 * another one took the name. The id finds nothing, so nothing is
-	 * deleted — and the stranger's file survives.
-	 */
 	public function testDeletesNothingWhenTheCreatedFileIsNoLongerThere(): void {
 		$resolver = $this->createMock(UserNodeResolver::class);
 		$resolver->method('resolveUserFileNodeById')->willThrowException(new NotFoundException('gone'));
@@ -53,11 +42,6 @@ class PadCreateRollbackServiceTest extends TestCase {
 			->rollbackFailedCreate('alice', '/Created.pad', '', new CreatedFileClaim('alice', 4711));
 	}
 
-	/**
-	 * The create never read an id it could trust, so nothing here names a
-	 * file. Asking the old node for one now would answer for whatever holds
-	 * that path by now — which is the substitution this exists to prevent.
-	 */
 	public function testLooksUpNothingWhenTheCreateNeverGotAnId(): void {
 		$resolver = $this->createMock(UserNodeResolver::class);
 		$resolver->expects($this->never())->method('resolveUserFileNodeById');
@@ -66,11 +50,6 @@ class PadCreateRollbackServiceTest extends TestCase {
 			->rollbackFailedCreate('alice', '/Created.pad', '', null);
 	}
 
-	/**
-	 * The id is not proof of authorship: `newFile()` can hand back a file
-	 * another writer created a moment earlier, and that writer may have
-	 * filled it while this request was away at Etherpad.
-	 */
 	public function testLeavesAFileSomebodyElseWroteInto(): void {
 		$foreign = $this->fileHolding('someone else\'s notes');
 		$foreign->expects($this->never())->method('delete');
@@ -83,11 +62,7 @@ class PadCreateRollbackServiceTest extends TestCase {
 			->rollbackFailedCreate('alice', '/Created.pad', '', $this->claimThatWrote('our document'));
 	}
 
-	/**
-	 * A rival create can finish into the same file. Its document carries the
-	 * same `file_id` — the id belongs to the file, not to the attempt — so
-	 * only the bytes this attempt wrote settle it.
-	 */
+	/** Matching file_id values do not prove that this attempt wrote the document. */
 	public function testLeavesADocumentAnotherCreateWroteIntoTheSameFile(): void {
 		$rivals = $this->fileHolding("---\nfile_id: 4711\npad_id: nc-rival\n---\n");
 		$rivals->expects($this->never())->method('delete');
@@ -96,7 +71,6 @@ class PadCreateRollbackServiceTest extends TestCase {
 			->rollbackFailedCreate('alice', '/Created.pad', 'nc-own', $this->claimThatWrote("---\nfile_id: 4711\npad_id: nc-own\n---\n"));
 	}
 
-	/** Exactly the bytes this create wrote, so this one is ours to remove. */
 	public function testDeletesAFileHoldingWhatThisCreateWrote(): void {
 		$ours = $this->fileHolding('our document');
 		$ours->expects($this->once())->method('delete');
@@ -105,11 +79,7 @@ class PadCreateRollbackServiceTest extends TestCase {
 			->rollbackFailedCreate('alice', '/Created.pad', '', $this->claimThatWrote('our document'));
 	}
 
-	/**
-	 * Both give up rather than delete. They are the conservative half of the
-	 * rule, and an exception escaping either would turn a best-effort
-	 * cleanup into a failure that hides the original create error.
-	 */
+	/** A read failure must not delete the file or mask the original create error. */
 	public function testLeavesTheFileAloneWhenItsContentCannotBeRead(): void {
 		$locked = $this->createMock(File::class);
 		$locked->method('getSize')->willReturn(120);
@@ -136,7 +106,6 @@ class PadCreateRollbackServiceTest extends TestCase {
 			->rollbackFailedCreate('alice', '/Created.pad', '', new CreatedFileClaim('alice', 4711));
 	}
 
-	/** A claim whose write succeeded, carrying proof of those exact bytes. */
 	private function claimThatWrote(string $content): CreatedFileClaim {
 		$claim = new CreatedFileClaim('alice', 4711);
 		$claim->writtenHash = hash('sha256', $content);
@@ -272,10 +241,7 @@ class PadCreateRollbackServiceTest extends TestCase {
 		);
 	}
 
-	/**
-	 * The file the id resolves to now — which is what the service deletes,
-	 * so a test that stubs only the create's own node proves nothing.
-	 */
+	/** Pin the lookup identity and return the node used for cleanup. */
 	private function resolverFinding(File $node, int $fileId = 4711): UserNodeResolver {
 		$resolver = $this->createMock(UserNodeResolver::class);
 		$resolver->method('resolveUserFileNodeById')->with('alice', $fileId)->willReturn($node);
@@ -283,7 +249,6 @@ class PadCreateRollbackServiceTest extends TestCase {
 		return $resolver;
 	}
 
-	/** An untouched file: still empty, so still ours to remove. */
 	private function untouchedFile(): File {
 		$node = $this->createMock(File::class);
 		$node->method('getSize')->willReturn(0);

--- a/tests/phpunit/unit/PadCreationServiceTest.php
+++ b/tests/phpunit/unit/PadCreationServiceTest.php
@@ -76,7 +76,7 @@ class PadCreationServiceTest extends TestCase {
 		$rollbackService = $this->createMock(PadCreateRollbackService::class);
 		$rollbackService->expects($this->once())
 			->method('rollbackFailedCreate')
-			->with('alice', '/Test.pad', 'g.ABC$pad', $this->isInstanceOf(\OCP\Files\File::class));
+			->with('alice', '/Test.pad', 'g.ABC$pad', $this->isType('int'));
 
 		$bootstrap = $this->createMock(PadBootstrapService::class);
 		$bootstrap->method('provisionPadId')->willReturn('g.ABC$pad');
@@ -274,7 +274,8 @@ class PadCreationServiceTest extends TestCase {
 		$bindingService = $this->createMock(BindingService::class);
 		$bindingService->expects($this->never())->method('createBinding');
 
-		$result = $this->buildService($padFileService, $padPaths, $fileCreator, null, $rollbackService, $bindingService, externalPadExportFetcher: $fetcher)
+		$result = $this->buildService(
+			$padFileService, $padPaths, $fileCreator, $this->resolverFor($fileNode), $rollbackService, $bindingService, externalPadExportFetcher: $fetcher)
 			->createFromUrl('alice', '/External', 'https://pad.remote.test/p/RemotePad');
 
 		$this->assertSame([
@@ -317,7 +318,8 @@ class PadCreationServiceTest extends TestCase {
 		$bindingService = $this->createMock(BindingService::class);
 		$bindingService->expects($this->never())->method('createBinding');
 
-		$result = $this->buildService($padFileService, $padPaths, $fileCreator, null, $rollbackService, $bindingService, externalPadExportFetcher: $fetcher)
+		$result = $this->buildService(
+			$padFileService, $padPaths, $fileCreator, $this->resolverFor($fileNode), $rollbackService, $bindingService, externalPadExportFetcher: $fetcher)
 			->createFromUrl('alice', '/External', 'https://pad.remote.test/p/RemotePad');
 
 		$this->assertSame([
@@ -381,7 +383,7 @@ class PadCreationServiceTest extends TestCase {
 		$rollbackService = $this->createMock(PadCreateRollbackService::class);
 		$rollbackService->expects($this->once())
 			->method('rollbackExternalCreate')
-			->with('alice', '/External.pad', $this->isInstanceOf(\OCP\Files\File::class));
+			->with('alice', '/External.pad', $this->isType('int'));
 
 		$fetcher = $this->createMock(ExternalPadExportFetcher::class);
 		$fetcher->method('normalizeAndFetchExternalPublicPadTextOrEmpty')
@@ -402,17 +404,26 @@ class PadCreationServiceTest extends TestCase {
 		$templateNode->method('getName')->willReturn('Protokoll-Tpl.pad');
 		$templateNode->method('getContent')->willReturn('tpl-content');
 
-		$userNodeResolver = $this->createMock(UserNodeResolver::class);
-		$userNodeResolver->method('resolveUserFileNodeById')
-			->with('alice', 7)
-			->willReturn($templateNode);
-
 		$padPaths = $this->createMock(PathNormalizer::class);
 		$padPaths->method('normalizeCreatePath')->with('/Meetings/Protokoll 18.05.2026.pad')->willReturn('/Meetings/Protokoll 18.05.2026.pad');
 
 		$newFile = $this->createMock(\OCP\Files\File::class);
 		$newFile->method('getId')->willReturn(99);
-		$newFile->expects($this->once())->method('putContent');
+		// The template is read by its id, and the pad is written to the file
+		// this create made — by its id too, not through the node.
+		$newFile->expects($this->never())->method('putContent');
+
+		$written = $this->createMock(\OCP\Files\File::class);
+		$written->expects($this->once())->method('putContent');
+
+		$userNodeResolver = $this->createMock(UserNodeResolver::class);
+		$userNodeResolver->method('resolveUserFileNodeById')->willReturnCallback(
+			fn (string $uid, int $fileId): \OCP\Files\File => match ([$uid, $fileId]) {
+				['alice', 7] => $templateNode,
+				['alice', 99] => $written,
+				default => throw new \OCP\Files\NotFoundException('unexpected lookup'),
+			}
+		);
 		$fileCreator = $this->createMock(PadFileCreator::class);
 		$fileCreator->method('createUserFile')->with('alice', '/Meetings/Protokoll 18.05.2026.pad')->willReturn($newFile);
 
@@ -456,7 +467,8 @@ class PadCreationServiceTest extends TestCase {
 		$user->method('getDisplayName')->willReturn('Alice');
 		$user->method('getUID')->willReturn('alice');
 
-		$result = $this->buildService($padFileService, $padPaths, $fileCreator, $userNodeResolver, null, $bindingService, $etherpadClient, $bootstrap)
+		$result = $this->buildService(
+			$padFileService, $padPaths, $fileCreator, $userNodeResolver, null, $bindingService, $etherpadClient, $bootstrap)
 			->createFromTemplate('alice', '/Meetings/Protokoll {{date:next monday|d.m.Y}}.pad', 7, $user);
 
 		$this->assertSame('/Meetings/Protokoll 18.05.2026.pad', $result['file']);
@@ -494,7 +506,7 @@ class PadCreationServiceTest extends TestCase {
 		$rollbackService = $this->createMock(PadCreateRollbackService::class);
 		$rollbackService->expects($this->once())
 			->method('rollbackCreatedFileOnly')
-			->with('alice', '/FromTpl.pad', $this->isInstanceOf(\OCP\Files\File::class));
+			->with('alice', '/FromTpl.pad', $this->isType('int'));
 
 		$this->expectException(\RuntimeException::class);
 
@@ -547,7 +559,7 @@ class PadCreationServiceTest extends TestCase {
 		$rollbackService = $this->createMock(PadCreateRollbackService::class);
 		$rollbackService->expects($this->once())
 			->method('rollbackCreatedFileOnly')
-			->with('alice', '/FromTpl.pad', $this->isInstanceOf(\OCP\Files\File::class));
+			->with('alice', '/FromTpl.pad', $this->isType('int'));
 		$rollbackService->expects($this->never())->method('rollbackFailedCreate');
 
 		$this->expectException(\RuntimeException::class);
@@ -603,6 +615,7 @@ class PadCreationServiceTest extends TestCase {
 		$etherpadClient->expects($this->once())->method('deletePad')->with('p-fresh');
 
 		$rollbackService = new PadCreateRollbackService(
+			$this->createMock(PadFileService::class),
 			new ManagedPadLifecycle($etherpadClient, $this->createMock(LoggerInterface::class)),
 			$this->createMock(UserNodeResolver::class),
 			$this->createMock(\Psr\Log\LoggerInterface::class),
@@ -660,6 +673,7 @@ class PadCreationServiceTest extends TestCase {
 			bindingService: $bindingService,
 			bootstrap: $bootstrap,
 			rollbackService: new PadCreateRollbackService(
+				$this->createMock(PadFileService::class),
 				new ManagedPadLifecycle($this->createMock(EtherpadClient::class), $this->createMock(LoggerInterface::class)),
 				$this->createMock(UserNodeResolver::class),
 				$this->createMock(\Psr\Log\LoggerInterface::class),
@@ -795,6 +809,7 @@ class PadCreationServiceTest extends TestCase {
 			fileCreator: $fileCreator,
 			bootstrap: $bootstrap,
 			rollbackService: new PadCreateRollbackService(
+				$this->createMock(PadFileService::class),
 				new ManagedPadLifecycle($this->createMock(EtherpadClient::class), $this->createMock(LoggerInterface::class)),
 				$this->createMock(UserNodeResolver::class),
 				$this->createMock(\Psr\Log\LoggerInterface::class),
@@ -874,7 +889,7 @@ class PadCreationServiceTest extends TestCase {
 			padFileService: $padFileService,
 			padPaths: $padPaths,
 			fileCreator: $fileCreator,
-			userNodeResolver: $this->resolverFor($stillOurs),
+			userNodeResolver: $this->resolverFor($stillOurs, 'alice', 4242),
 			bootstrap: $bootstrap,
 		)->create('alice', '/Notes.pad', BindingService::ACCESS_PUBLIC);
 	}
@@ -884,9 +899,15 @@ class PadCreationServiceTest extends TestCase {
 	 * writes through, so a test stubbing only the creator's node would pass
 	 * while nothing was written.
 	 */
-	private function resolverFor(\OCP\Files\File $node): UserNodeResolver {
+	private function resolverFor(\OCP\Files\File $node, ?string $uid = null, ?int $fileId = null): UserNodeResolver {
 		$resolver = $this->createMock(UserNodeResolver::class);
-		$resolver->method('resolveUserFileNodeById')->willReturn($node);
+		$expectation = $resolver->method('resolveUserFileNodeById');
+		// Pinned where the test knows them: "some node came back" would pass
+		// just as well if the create looked up the wrong user or file.
+		if ($uid !== null && $fileId !== null) {
+			$expectation->with($uid, $fileId);
+		}
+		$expectation->willReturn($node);
 
 		return $resolver;
 	}

--- a/tests/phpunit/unit/PadCreationServiceTest.php
+++ b/tests/phpunit/unit/PadCreationServiceTest.php
@@ -53,7 +53,7 @@ class PadCreationServiceTest extends TestCase {
 			->method('createBinding')
 			->with(123, 'g.ABC$pad', BindingService::ACCESS_PROTECTED);
 
-		$result = $this->buildService($padFileService, $padPaths, $fileCreator, null, null, $bindingService, $etherpadClient, $bootstrap)
+		$result = $this->buildService($padFileService, $padPaths, $fileCreator, $this->resolverFor($fileNode), null, $bindingService, $etherpadClient, $bootstrap)
 			->create('alice', '/Test', BindingService::ACCESS_PROTECTED);
 
 		$this->assertSame([
@@ -604,6 +604,7 @@ class PadCreationServiceTest extends TestCase {
 
 		$rollbackService = new PadCreateRollbackService(
 			new ManagedPadLifecycle($etherpadClient, $this->createMock(LoggerInterface::class)),
+			$this->createMock(UserNodeResolver::class),
 			$this->createMock(\Psr\Log\LoggerInterface::class),
 		);
 
@@ -660,6 +661,7 @@ class PadCreationServiceTest extends TestCase {
 			bootstrap: $bootstrap,
 			rollbackService: new PadCreateRollbackService(
 				new ManagedPadLifecycle($this->createMock(EtherpadClient::class), $this->createMock(LoggerInterface::class)),
+				$this->createMock(UserNodeResolver::class),
 				$this->createMock(\Psr\Log\LoggerInterface::class),
 			),
 		)->create('alice', '/Notes.pad', BindingService::ACCESS_PUBLIC);
@@ -794,6 +796,7 @@ class PadCreationServiceTest extends TestCase {
 			bootstrap: $bootstrap,
 			rollbackService: new PadCreateRollbackService(
 				new ManagedPadLifecycle($this->createMock(EtherpadClient::class), $this->createMock(LoggerInterface::class)),
+				$this->createMock(UserNodeResolver::class),
 				$this->createMock(\Psr\Log\LoggerInterface::class),
 			),
 		);
@@ -838,6 +841,54 @@ class PadCreationServiceTest extends TestCase {
 
 		$this->buildService($padFileService, $padPaths, $this->fileCreatorReturningId(11), $userNodeResolver)
 			->createFromTemplate('alice', '/Out.pad', 7, null);
+	}
+
+	/**
+	 * The write goes to the file the id resolves to, not through the node
+	 * the create returned. `File::putContent()` writes to its remembered
+	 * path, and provisioning the pad takes long enough for that path to
+	 * hold somebody else's file by the time the content is written.
+	 */
+	public function testWritesToTheFileTheIdResolvesToNotTheCreatedNode(): void {
+		$createdNode = $this->createMock(\OCP\Files\File::class);
+		$createdNode->method('getId')->willReturn(4242);
+		$createdNode->method('getSize')->willReturn(0);
+		$createdNode->expects($this->never())->method('putContent');
+
+		$stillOurs = $this->createMock(\OCP\Files\File::class);
+		$stillOurs->expects($this->once())->method('putContent')->with('frontmatter');
+
+		$fileCreator = $this->createMock(PadFileCreator::class);
+		$fileCreator->method('createUserFile')->willReturn($createdNode);
+
+		$padPaths = $this->createMock(PathNormalizer::class);
+		$padPaths->method('normalizeCreatePath')->willReturn('/Notes.pad');
+
+		$padFileService = $this->createMock(PadFileService::class);
+		$padFileService->method('buildInitialDocument')->willReturn('frontmatter');
+
+		$bootstrap = $this->createMock(PadBootstrapService::class);
+		$bootstrap->method('provisionPadId')->willReturn('p-fresh');
+
+		$this->buildService(
+			padFileService: $padFileService,
+			padPaths: $padPaths,
+			fileCreator: $fileCreator,
+			userNodeResolver: $this->resolverFor($stillOurs),
+			bootstrap: $bootstrap,
+		)->create('alice', '/Notes.pad', BindingService::ACCESS_PUBLIC);
+	}
+
+	/**
+	 * The file the id resolves to at write time — which is what the create
+	 * writes through, so a test stubbing only the creator's node would pass
+	 * while nothing was written.
+	 */
+	private function resolverFor(\OCP\Files\File $node): UserNodeResolver {
+		$resolver = $this->createMock(UserNodeResolver::class);
+		$resolver->method('resolveUserFileNodeById')->willReturn($node);
+
+		return $resolver;
 	}
 
 	private function buildService(

--- a/tests/phpunit/unit/PadCreationServiceTest.php
+++ b/tests/phpunit/unit/PadCreationServiceTest.php
@@ -913,6 +913,37 @@ class PadCreationServiceTest extends TestCase {
 	}
 
 	/**
+	 * A create that wrote its document and then failed at the binding leaves
+	 * that document, not the state it started from. Recovery has to accept
+	 * it — refusing would strand the file pointing at a pad the failure has
+	 * just deleted.
+	 */
+	public function testRecognisesOurOwnWrittenDocumentAsStillOurs(): void {
+		$claim = new CreatedFileClaim('alice', 4242);
+		$claim->writtenHash = hash('sha256', 'our document');
+
+		$node = $this->createMock(\OCP\Files\File::class);
+		$node->method('getContent')->willReturn('our document');
+
+		$service = $this->buildService(userNodeResolver: $this->resolverFor($node, 'alice', 4242));
+
+		$this->assertSame($node, $service->resolveUnchangedClaim($claim));
+	}
+
+	/** Somebody else's content is neither the prior state nor our write. */
+	public function testDoesNotRecogniseAStrangersContent(): void {
+		$claim = new CreatedFileClaim('alice', 4242);
+		$claim->writtenHash = hash('sha256', 'our document');
+
+		$node = $this->createMock(\OCP\Files\File::class);
+		$node->method('getContent')->willReturn('somebody else\'s notes');
+
+		$service = $this->buildService(userNodeResolver: $this->resolverFor($node, 'alice', 4242));
+
+		$this->assertNull($service->resolveUnchangedClaim($claim));
+	}
+
+	/**
 	 * The whole way through: `getId()` throws on the freshly created node,
 	 * so the create never holds an id — and the rollback must not go
 	 * looking for one, because a second read would answer for whatever

--- a/tests/phpunit/unit/PadCreationServiceTest.php
+++ b/tests/phpunit/unit/PadCreationServiceTest.php
@@ -78,8 +78,7 @@ class PadCreationServiceTest extends TestCase {
 		$rollbackService->expects($this->once())
 			->method('rollbackFailedCreate')
 			->with('alice', '/Test.pad', 'g.ABC$pad', $this->callback(
-				// Not just "a claim": the rollback needs this attempt's id
-				// and the proof of what it wrote, or it deletes nothing.
+				// Check identity, baseline and write evidence, not just the claim's type.
 				static fn (CreatedFileClaim $claim): bool => $claim->uid === 'alice'
 					&& $claim->fileId === 123
 					&& $claim->expectedBefore === ''
@@ -417,8 +416,7 @@ class PadCreationServiceTest extends TestCase {
 
 		$newFile = $this->createMock(\OCP\Files\File::class);
 		$newFile->method('getId')->willReturn(99);
-		// The template is read by its id, and the pad is written to the file
-		// this create made — by its id too, not through the node.
+		// Writing must use the re-resolved target, not the node returned by create.
 		$newFile->expects($this->never())->method('putContent');
 
 		$written = $this->createMock(\OCP\Files\File::class);
@@ -764,11 +762,6 @@ class PadCreationServiceTest extends TestCase {
 		return $template;
 	}
 
-	/**
-	 * The hook always has one — it returns early without a user — and the
-	 * file is now resolved by id under that user rather than written
-	 * through the node, so there is no userless path left to test.
-	 */
 	private function materializeUser(): \OCP\IUser {
 		$user = $this->createMock(\OCP\IUser::class);
 		$user->method('getUID')->willReturn('alice');
@@ -876,12 +869,6 @@ class PadCreationServiceTest extends TestCase {
 			->createFromTemplate('alice', '/Out.pad', 7, null);
 	}
 
-	/**
-	 * The write goes to the file the id resolves to, not through the node
-	 * the create returned. `File::putContent()` writes to its remembered
-	 * path, and provisioning the pad takes long enough for that path to
-	 * hold somebody else's file by the time the content is written.
-	 */
 	public function testWritesToTheFileTheIdResolvesToNotTheCreatedNode(): void {
 		$createdNode = $this->createMock(\OCP\Files\File::class);
 		$createdNode->method('getId')->willReturn(4242);
@@ -912,12 +899,7 @@ class PadCreationServiceTest extends TestCase {
 		)->create('alice', '/Notes.pad', BindingService::ACCESS_PUBLIC);
 	}
 
-	/**
-	 * A create that wrote its document and then failed at the binding leaves
-	 * that document, not the state it started from. Recovery has to accept
-	 * it — refusing would strand the file pointing at a pad the failure has
-	 * just deleted.
-	 */
+	/** A binding failure after writing must still allow recovery from that write. */
 	public function testRecognisesOurOwnWrittenDocumentAsStillOurs(): void {
 		$claim = new CreatedFileClaim('alice', 4242);
 		$claim->writtenHash = hash('sha256', 'our document');
@@ -930,7 +912,6 @@ class PadCreationServiceTest extends TestCase {
 		$this->assertSame($node, $service->resolveUnchangedClaim($claim));
 	}
 
-	/** Somebody else's content is neither the prior state nor our write. */
 	public function testDoesNotRecogniseAStrangersContent(): void {
 		$claim = new CreatedFileClaim('alice', 4242);
 		$claim->writtenHash = hash('sha256', 'our document');
@@ -943,12 +924,7 @@ class PadCreationServiceTest extends TestCase {
 		$this->assertNull($service->resolveUnchangedClaim($claim));
 	}
 
-	/**
-	 * The whole way through: `getId()` throws on the freshly created node,
-	 * so the create never holds an id — and the rollback must not go
-	 * looking for one, because a second read would answer for whatever
-	 * holds that path by then.
-	 */
+	/** Exercise create and rollback together when the initial getId() fails. */
 	public function testACreateThatNeverGotAnIdCleansUpNothing(): void {
 		$node = $this->createMock(\OCP\Files\File::class);
 		$node->method('getId')->willThrowException(new \RuntimeException('no cache entry'));
@@ -978,16 +954,10 @@ class PadCreationServiceTest extends TestCase {
 		)->create('alice', '/Notes.pad', BindingService::ACCESS_PUBLIC);
 	}
 
-	/**
-	 * The file the id resolves to at write time — which is what the create
-	 * writes through, so a test stubbing only the creator's node would pass
-	 * while nothing was written.
-	 */
+	/** Stub the write target and optionally constrain the lookup identity. */
 	private function resolverFor(\OCP\Files\File $node, ?string $uid = null, ?int $fileId = null): UserNodeResolver {
 		$resolver = $this->createMock(UserNodeResolver::class);
 		$expectation = $resolver->method('resolveUserFileNodeById');
-		// Pinned where the test knows them: "some node came back" would pass
-		// just as well if the create looked up the wrong user or file.
 		if ($uid !== null && $fileId !== null) {
 			$expectation->with($uid, $fileId);
 		}

--- a/tests/phpunit/unit/PadCreationServiceTest.php
+++ b/tests/phpunit/unit/PadCreationServiceTest.php
@@ -13,6 +13,7 @@ use OCA\EtherpadNextcloud\Service\EtherpadClient;
 use OCA\EtherpadNextcloud\Service\ManagedPadLifecycle;
 use OCA\EtherpadNextcloud\Service\ExternalPadExportFetcher;
 use OCA\EtherpadNextcloud\Service\PadBootstrapService;
+use OCA\EtherpadNextcloud\Service\CreatedFileClaim;
 use OCA\EtherpadNextcloud\Service\PadCreateRollbackService;
 use OCA\EtherpadNextcloud\Service\PadCreationService;
 use OCA\EtherpadNextcloud\Service\PadFileCreator;
@@ -76,7 +77,7 @@ class PadCreationServiceTest extends TestCase {
 		$rollbackService = $this->createMock(PadCreateRollbackService::class);
 		$rollbackService->expects($this->once())
 			->method('rollbackFailedCreate')
-			->with('alice', '/Test.pad', 'g.ABC$pad', $this->isType('int'));
+			->with('alice', '/Test.pad', 'g.ABC$pad', $this->isInstanceOf(CreatedFileClaim::class));
 
 		$bootstrap = $this->createMock(PadBootstrapService::class);
 		$bootstrap->method('provisionPadId')->willReturn('g.ABC$pad');
@@ -225,7 +226,7 @@ class PadCreationServiceTest extends TestCase {
 			etherpadClient: $etherpadClient,
 			bootstrap: $bootstrap,
 			padTypePolicy: $this->buildPadTypePolicy(true, false),
-		)->materializeTemplateInto($target, $template, null);
+		)->materializeTemplateInto($target, $template, $this->materializeUser());
 
 		self::assertSame(BindingService::ACCESS_PROTECTED, $result['access_mode']);
 	}
@@ -383,7 +384,7 @@ class PadCreationServiceTest extends TestCase {
 		$rollbackService = $this->createMock(PadCreateRollbackService::class);
 		$rollbackService->expects($this->once())
 			->method('rollbackExternalCreate')
-			->with('alice', '/External.pad', $this->isType('int'));
+			->with('alice', '/External.pad', $this->isInstanceOf(CreatedFileClaim::class));
 
 		$fetcher = $this->createMock(ExternalPadExportFetcher::class);
 		$fetcher->method('normalizeAndFetchExternalPublicPadTextOrEmpty')
@@ -506,7 +507,7 @@ class PadCreationServiceTest extends TestCase {
 		$rollbackService = $this->createMock(PadCreateRollbackService::class);
 		$rollbackService->expects($this->once())
 			->method('rollbackCreatedFileOnly')
-			->with('alice', '/FromTpl.pad', $this->isType('int'));
+			->with('alice', '/FromTpl.pad', $this->isInstanceOf(CreatedFileClaim::class));
 
 		$this->expectException(\RuntimeException::class);
 
@@ -559,7 +560,7 @@ class PadCreationServiceTest extends TestCase {
 		$rollbackService = $this->createMock(PadCreateRollbackService::class);
 		$rollbackService->expects($this->once())
 			->method('rollbackCreatedFileOnly')
-			->with('alice', '/FromTpl.pad', $this->isType('int'));
+			->with('alice', '/FromTpl.pad', $this->isInstanceOf(CreatedFileClaim::class));
 		$rollbackService->expects($this->never())->method('rollbackFailedCreate');
 
 		$this->expectException(\RuntimeException::class);
@@ -728,7 +729,7 @@ class PadCreationServiceTest extends TestCase {
 
 		$this->expectException(\RuntimeException::class);
 		$this->buildMaterializeService($bindingService, $etherpadClient, $padId)
-			->materializeTemplateInto($this->buildMaterializeTarget(), $this->buildMaterializeTemplate(), null);
+			->materializeTemplateInto($this->buildMaterializeTarget(), $this->buildMaterializeTemplate(), $this->materializeUser());
 	}
 
 	/** A row naming a different pad belongs to the request that won the file. */
@@ -746,7 +747,7 @@ class PadCreationServiceTest extends TestCase {
 
 		$this->expectException(\RuntimeException::class);
 		$this->buildMaterializeService($bindingService, $etherpadClient, $padId)
-			->materializeTemplateInto($this->buildMaterializeTarget(), $this->buildMaterializeTemplate(), null);
+			->materializeTemplateInto($this->buildMaterializeTarget(), $this->buildMaterializeTemplate(), $this->materializeUser());
 	}
 
 	private function buildMaterializeTemplate(): \OCP\Files\File {
@@ -754,6 +755,19 @@ class PadCreationServiceTest extends TestCase {
 		$template->method('getName')->willReturn('Template.pad');
 		$template->method('getContent')->willReturn('tpl');
 		return $template;
+	}
+
+	/**
+	 * The hook always has one — it returns early without a user — and the
+	 * file is now resolved by id under that user rather than written
+	 * through the node, so there is no userless path left to test.
+	 */
+	private function materializeUser(): \OCP\IUser {
+		$user = $this->createMock(\OCP\IUser::class);
+		$user->method('getUID')->willReturn('alice');
+		$user->method('getDisplayName')->willReturn('Alice');
+
+		return $user;
 	}
 
 	private function buildMaterializeTarget(): \OCP\Files\File {

--- a/tests/phpunit/unit/PadCreationServiceTest.php
+++ b/tests/phpunit/unit/PadCreationServiceTest.php
@@ -615,7 +615,6 @@ class PadCreationServiceTest extends TestCase {
 		$etherpadClient->expects($this->once())->method('deletePad')->with('p-fresh');
 
 		$rollbackService = new PadCreateRollbackService(
-			$this->createMock(PadFileService::class),
 			new ManagedPadLifecycle($etherpadClient, $this->createMock(LoggerInterface::class)),
 			$this->createMock(UserNodeResolver::class),
 			$this->createMock(\Psr\Log\LoggerInterface::class),
@@ -673,7 +672,6 @@ class PadCreationServiceTest extends TestCase {
 			bindingService: $bindingService,
 			bootstrap: $bootstrap,
 			rollbackService: new PadCreateRollbackService(
-				$this->createMock(PadFileService::class),
 				new ManagedPadLifecycle($this->createMock(EtherpadClient::class), $this->createMock(LoggerInterface::class)),
 				$this->createMock(UserNodeResolver::class),
 				$this->createMock(\Psr\Log\LoggerInterface::class),
@@ -809,7 +807,6 @@ class PadCreationServiceTest extends TestCase {
 			fileCreator: $fileCreator,
 			bootstrap: $bootstrap,
 			rollbackService: new PadCreateRollbackService(
-				$this->createMock(PadFileService::class),
 				new ManagedPadLifecycle($this->createMock(EtherpadClient::class), $this->createMock(LoggerInterface::class)),
 				$this->createMock(UserNodeResolver::class),
 				$this->createMock(\Psr\Log\LoggerInterface::class),
@@ -891,6 +888,41 @@ class PadCreationServiceTest extends TestCase {
 			fileCreator: $fileCreator,
 			userNodeResolver: $this->resolverFor($stillOurs, 'alice', 4242),
 			bootstrap: $bootstrap,
+		)->create('alice', '/Notes.pad', BindingService::ACCESS_PUBLIC);
+	}
+
+	/**
+	 * The whole way through: `getId()` throws on the freshly created node,
+	 * so the create never holds an id — and the rollback must not go
+	 * looking for one, because a second read would answer for whatever
+	 * holds that path by then.
+	 */
+	public function testACreateThatNeverGotAnIdCleansUpNothing(): void {
+		$node = $this->createMock(\OCP\Files\File::class);
+		$node->method('getId')->willThrowException(new \RuntimeException('no cache entry'));
+
+		$fileCreator = $this->createMock(PadFileCreator::class);
+		$fileCreator->method('createUserFile')->willReturn($node);
+
+		$padPaths = $this->createMock(PathNormalizer::class);
+		$padPaths->method('normalizeCreatePath')->willReturn('/Notes.pad');
+
+		$resolver = $this->createMock(UserNodeResolver::class);
+		$resolver->expects($this->never())->method('resolveUserFileNodeById');
+
+		$rollbackService = new PadCreateRollbackService(
+			new ManagedPadLifecycle($this->createMock(EtherpadClient::class), $this->createMock(LoggerInterface::class)),
+			$resolver,
+			$this->createMock(\Psr\Log\LoggerInterface::class),
+		);
+
+		$this->expectException(\RuntimeException::class);
+
+		$this->buildService(
+			padPaths: $padPaths,
+			fileCreator: $fileCreator,
+			userNodeResolver: $resolver,
+			rollbackService: $rollbackService,
 		)->create('alice', '/Notes.pad', BindingService::ACCESS_PUBLIC);
 	}
 

--- a/tests/phpunit/unit/PadCreationServiceTest.php
+++ b/tests/phpunit/unit/PadCreationServiceTest.php
@@ -77,7 +77,14 @@ class PadCreationServiceTest extends TestCase {
 		$rollbackService = $this->createMock(PadCreateRollbackService::class);
 		$rollbackService->expects($this->once())
 			->method('rollbackFailedCreate')
-			->with('alice', '/Test.pad', 'g.ABC$pad', $this->isInstanceOf(CreatedFileClaim::class));
+			->with('alice', '/Test.pad', 'g.ABC$pad', $this->callback(
+				// Not just "a claim": the rollback needs this attempt's id
+				// and the proof of what it wrote, or it deletes nothing.
+				static fn (CreatedFileClaim $claim): bool => $claim->uid === 'alice'
+					&& $claim->fileId === 123
+					&& $claim->expectedBefore === ''
+					&& $claim->writtenHash !== null
+			));
 
 		$bootstrap = $this->createMock(PadBootstrapService::class);
 		$bootstrap->method('provisionPadId')->willReturn('g.ABC$pad');

--- a/tests/phpunit/unit/UserNodeResolverTest.php
+++ b/tests/phpunit/unit/UserNodeResolverTest.php
@@ -213,4 +213,39 @@ class UserNodeResolverTest extends TestCase {
 		$this->expectException(NotFoundException::class);
 		$resolver->resolveUserFileNodeById('alice', 42);
 	}
+
+	/**
+	 * One folder, two shares: read-only and writable. Taking the first hit
+	 * made the answer depend on the order `getById()` happened to return,
+	 * so create-by-parent could be refused on the strength of the share
+	 * that grants less.
+	 *
+	 * @param bool $writableFirst
+	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('shareOrders')]
+	public function testPrefersAFolderThisUserMayCreateIn(bool $writableFirst): void {
+		$readOnly = $this->createMock(Folder::class);
+		$readOnly->method('getPath')->willReturn('/alice/files/Shared/Team');
+		$readOnly->method('isCreatable')->willReturn(false);
+
+		$writable = $this->createMock(Folder::class);
+		$writable->method('getPath')->willReturn('/alice/files/Team');
+		$writable->method('isCreatable')->willReturn(true);
+
+		$userFolder = $this->createMock(Folder::class);
+		$userFolder->method('getId')->willReturn(1);
+		$userFolder->method('getById')->willReturn($writableFirst ? [$writable, $readOnly] : [$readOnly, $writable]);
+
+		$rootFolder = $this->createMock(IRootFolder::class);
+		$rootFolder->method('getUserFolder')->with('alice')->willReturn($userFolder);
+
+		$resolver = new UserNodeResolver($rootFolder, $this->createMock(LoggerInterface::class));
+
+		$this->assertSame($writable, $resolver->resolveUserFolderNodeById('alice', 42));
+	}
+
+	/** @return array<string,array{0:bool}> */
+	public static function shareOrders(): array {
+		return ['writable first' => [true], 'read-only first' => [false]];
+	}
 }

--- a/tests/phpunit/unit/UserNodeResolverTest.php
+++ b/tests/phpunit/unit/UserNodeResolverTest.php
@@ -214,14 +214,7 @@ class UserNodeResolverTest extends TestCase {
 		$resolver->resolveUserFileNodeById('alice', 42);
 	}
 
-	/**
-	 * One folder, two shares: read-only and writable. Taking the first hit
-	 * made the answer depend on the order `getById()` happened to return,
-	 * so create-by-parent could be refused on the strength of the share
-	 * that grants less.
-	 *
-	 * @param bool $writableFirst
-	 */
+	/** Prefer the creatable share regardless of lookup order. */
 	#[\PHPUnit\Framework\Attributes\DataProvider('shareOrders')]
 	public function testPrefersAFolderThisUserMayCreateIn(bool $writableFirst): void {
 		$readOnly = $this->createMock(Folder::class);


### PR DESCRIPTION
A `File` object in Nextcloud is not an identity. Checked against the source in a running container:

```php
public function delete()          { … $this->view->unlink($this->path); … }
public function putContent($data) { … $this->view->file_put_contents($this->path, $data) … }
public function getId()           { return $this->getFileInfo(false)->getId() ?? -1; }
```

All three act through the path the object remembers, `getId()` included. A pad create holds such an object across provisioning on another host — seconds, sometimes more — which is long enough for the file to be moved and its name to be taken by something else. Every operation that then used that object acted on whatever had arrived at the path.

## What could happen

- A rollback deleted a stranger's file that had taken the name.
- A create wrote its frontmatter into a stranger's file, mislabelling it with a file id that is not its own.
- The template listener, recovering from a failed create, emptied a stranger's file and initialised a pad in it.
- The blank re-initialisation did the same after its own second provisioning round.
- A create that wrote its document and then failed at the binding left the file pointing at a pad that the failure had already deleted.

None of these needed an unlucky microsecond. They needed a create that was slow, which is what a create over a network is.

## What changed

**`CreatedFileClaim`** holds what one attempt knows about the file it claimed: the user, the file id read once at creation, the content the file held at that moment, and — set by the write — a sha256 of the bytes written. It is passed by reference, so a write that succeeds is visible to the rollback of a step that fails afterwards.

Everything that touches the file now works from that claim rather than re-deriving it:

- **Writes** resolve the id and refuse unless the file still holds what the attempt found. All five write paths — the four API creates and Nextcloud's template hook — go through it.
- **Deletes** resolve the id and remove the file only while it is still untouched, or while it still holds exactly the bytes this attempt wrote. Anything else is left alone with a warning: a stray empty `.pad` is a mess, a deleted document is a loss.
- **Recovery** in the template listener measures against the same claim before emptying or deleting anything, and recognises both states the attempt can own — what it found, and what it can prove it wrote.
- **An unreadable id stays unknown.** It is read once, at creation; asking the node again later would answer for whatever holds the path by then. Without an id, nothing is cleaned up.

A refusal is now its own type, `PadFileChangedException`, answered as `409` with `code: pad_file_changed`. It was reaching the API as a `500`, and — more importantly — the template listener was catching it as a generic failure and then emptying the very file the write had just refused to overwrite.

Two smaller things came out of the same review rounds. `Folder::getById()` can return several paths to one folder, and only some may allow creating; the folder lookup took the first hit, so create-by-parent could be refused on the strength of a read-only share while a writable one existed. It prefers a creatable hit now, as the file lookup already did. And `writeCreatedFile()` had been inserted between `requireFileId()`'s docblock and its method, orphaning the documentation of the throw this branch depends on.

## What this does not fix

**Check and act are not atomic.** A node resolved by id still works through a path, so a gap remains between comparing and writing or deleting. It is far narrower than a full provisioning round trip, but it is there. An earlier claim in review that this cannot be closed with Nextcloud's API was too strong and is withdrawn: `Node` offers locks, but an exclusive lock blocks our own operations too, so "lock, write, unlock" is not a drop-in. Neither a safe cross-backend approach nor its impossibility has been shown.

**A foreign file that is still empty** cannot be told apart from ours at rollback time and will be removed. What is lost is an empty file.

**Exclusive creation against all writers** still does not exist. The lock in `PadFileCreator` serialises this app's requests on a name; Files, WebDAV and other apps do not know it, and `Folder::newFile()` gives no proof that this call created what it returned. The change here is that a lost race can no longer destroy content — only claim an empty file.

## Follow-ups, deliberately not here

The same gap surfaced four times in four different places, each time where an operation did not receive the attempt's state. That is the concrete argument for the shared create core in #199: `CreatedFileClaim` holds the state together, but the four flows still each run their own write/bind/recover sequence. Streaming the comparison (`File::hash()` instead of reading the content into a string, a one-byte check where the expected state is empty) is worth doing and is independent of this.

## Verification

921 PHP tests / 3067 assertions, 261 JS tests, Psalm clean, Playwright 35 passed / 1 skipped.

The tests bind against the old behaviour rather than describing the new one: the node a create returns carries `expects($this->never())` on both `delete()` and `putContent()`, the rollback assertion checks the attempt's id and its recorded proof rather than that some claim arrived, and the bootstrap tests drive the real service with the id resolving to a *different* node than the one passed in — the arrangement under which the last two defects were found.
