### PR TITLE
Give the create flows one attempt object instead of by-reference locals

### DIFF
--- a/lib/Service/PadCreateAttempt.php
+++ b/lib/Service/PadCreateAttempt.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Copyright (c) 2026 Jacob Bühler
+ */
+
+namespace OCA\EtherpadNextcloud\Service;
+
+/**
+ * What one create has made so far, and therefore what a rollback owns.
+ *
+ * The flows used to answer that with local variables threaded through
+ * three closures by reference, which made "is this file mine to delete?"
+ * a question about *when* an assignment ran rather than about a fact. Two
+ * defects came out of that: a flow that never recorded its file, and a
+ * flow that recorded one and then discovered it belonged to somebody else
+ * — correct only because a variable was un-set a few lines before the
+ * throw.
+ *
+ * `disownFile()` is now a statement rather than a variable that has to be
+ * un-set in the right place. The template flow's pad stays out of the
+ * rollback for a different reason: `materializeTemplateInto()` removes its
+ * own pad, so that flow records it only to log it.
+ */
+class PadCreateAttempt {
+	private ?CreatedFileClaim $claim = null;
+	private string $padId = '';
+	private string $path = '';
+
+	/** The file this attempt created, from now until it is disowned. */
+	public function claimFile(string $uid, int $fileId, string $expectedBefore = ''): CreatedFileClaim {
+		$this->claim = new CreatedFileClaim($uid, $fileId, $expectedBefore);
+
+		return $this->claim;
+	}
+
+	/** Found to be somebody else's pad: not ours to write to, nor to remove. */
+	public function disownFile(): void {
+		$this->claim = null;
+	}
+
+	public function recordPad(string $padId): void {
+		$this->padId = $padId;
+	}
+
+	public function claim(): ?CreatedFileClaim {
+		return $this->claim;
+	}
+
+	public function padId(): string {
+		return $this->padId;
+	}
+
+	/**
+	 * Where the file ended up, for the rollback's log lines.
+	 *
+	 * Create-by-parent only learns this after the file exists, and it used
+	 * to reach the rollback through a by-reference capture — so a rollback
+	 * that ran before the assignment logged an empty path.
+	 */
+	public function recordPath(string $path): void {
+		$this->path = $path;
+	}
+
+	public function path(): string {
+		return $this->path;
+	}
+}

--- a/lib/Service/PadCreationService.php
+++ b/lib/Service/PadCreationService.php
@@ -45,21 +45,19 @@ class PadCreationService {
 	public function create(string $uid, string $file, string $accessMode): array {
 		$this->padTypePolicy->requireEnabled($accessMode);
 		$path = $this->padPaths->normalizeCreatePath($file);
-		$padId = '';
-		$claim = null;
 
 		return $this->withCreateRollback(
-			function () use ($uid, $path, $accessMode, &$padId, &$claim): array {
+			function (PadCreateAttempt $attempt) use ($uid, $path, $accessMode): array {
 				$fileNode = $this->padFileCreator->createUserFile($uid, $path);
 				// Capture the id before provisioning; getId() on this node is path-based.
 				$fileId = $this->requireFileId($fileNode, $path);
-				$claim = new CreatedFileClaim($uid, $fileId);
+				$claim = $attempt->claimFile($uid, $fileId);
 				if ($this->isNotOurs($fileNode, $fileId, $path)) {
-					// Not ours after all, so it is not ours to clean up either.
-					$claim = null;
+					$attempt->disownFile();
 					throw new PadFileAlreadyExistsException('Target .pad file already exists.');
 				}
 				$padId = $this->padBootstrapService->provisionPadId($accessMode);
+				$attempt->recordPad($padId);
 				$padUrl = $this->etherpadClient->buildPadUrl($padId);
 
 				$content = $this->padFileService->buildInitialDocument(
@@ -81,30 +79,30 @@ class PadCreationService {
 					'pad_url' => $padUrl,
 				];
 			},
-			function () use ($uid, $path, &$padId, &$claim): void {
-				$this->rollbackService->rollbackFailedCreate($uid, $path, $padId, $claim);
+			function (PadCreateAttempt $attempt) use ($uid, $path): void {
+				$this->rollbackService->rollbackFailedCreate($uid, $path, $attempt->padId(), $attempt->claim());
 			},
-			function (\Throwable $e) use ($path, $accessMode, &$padId): ?array {
+			function (\Throwable $e, PadCreateAttempt $attempt) use ($path, $accessMode): ?array {
 				if ($e instanceof BindingException) {
 					return [
 						'message' => 'Pad create hit existing binding',
 						'context' => [
 							'file' => $path,
 							'accessMode' => $accessMode,
-							'padId' => $padId,
+							'padId' => $attempt->padId(),
 						],
 					];
 				}
 
 				return null;
 			},
-			function () use ($path, $accessMode, &$padId): array {
+			function (PadCreateAttempt $attempt) use ($path, $accessMode): array {
 				return [
 					'message' => 'Pad creation failed',
 					'context' => [
 						'file' => $path,
 						'accessMode' => $accessMode,
-						'padId' => $padId,
+						'padId' => $attempt->padId(),
 					],
 				];
 			},
@@ -122,23 +120,20 @@ class PadCreationService {
 			throw new PadParentFolderNotWritableException('Selected parent folder is not writable.');
 		}
 
-		$padId = '';
-		$claim = null;
-		$path = '';
-
 		return $this->withCreateRollback(
-			function () use ($uid, $parentFolder, $parentFolderId, $fileName, $accessMode, &$path, &$padId, &$claim): array {
+			function (PadCreateAttempt $attempt) use ($uid, $parentFolder, $parentFolderId, $fileName, $accessMode): array {
 				$fileNode = $this->padFileCreator->createUserFileInFolder($parentFolder, $fileName);
-				$fileId = $this->requireFileId($fileNode, $path);
-				$claim = new CreatedFileClaim($uid, $fileId);
-				if ($this->isNotOurs($fileNode, $fileId, $path)) {
-					// Not ours after all, so it is not ours to clean up either.
-					$claim = null;
+				$fileId = $this->requireFileId($fileNode, $attempt->path());
+				$claim = $attempt->claimFile($uid, $fileId);
+				if ($this->isNotOurs($fileNode, $fileId, $attempt->path())) {
+					$attempt->disownFile();
 					throw new PadFileAlreadyExistsException('Target .pad file already exists.');
 				}
 				$path = $this->userNodeResolver->toUserAbsolutePath($uid, $fileNode);
+				$attempt->recordPath($path);
 
 				$padId = $this->padBootstrapService->provisionPadId($accessMode);
+				$attempt->recordPad($padId);
 				$padUrl = $this->etherpadClient->buildPadUrl($padId);
 				$content = $this->padFileService->buildInitialDocument(
 					$fileId,
@@ -159,34 +154,34 @@ class PadCreationService {
 					'pad_url' => $padUrl,
 				];
 			},
-			function () use ($uid, &$path, &$padId, &$claim): void {
-				$this->rollbackService->rollbackFailedCreate($uid, $path, $padId, $claim);
+			function (PadCreateAttempt $attempt) use ($uid): void {
+				$this->rollbackService->rollbackFailedCreate($uid, $attempt->path(), $attempt->padId(), $attempt->claim());
 			},
-			function (\Throwable $e) use ($parentFolderId, $name, $accessMode, &$path, &$padId): ?array {
+			function (\Throwable $e, PadCreateAttempt $attempt) use ($parentFolderId, $name, $accessMode): ?array {
 				if ($e instanceof BindingException) {
 					return [
 						'message' => 'Pad creation by parent hit existing binding',
 						'context' => [
 							'parentFolderId' => $parentFolderId,
 							'padName' => $name,
-							'path' => $path,
+							'path' => $attempt->path(),
 							'accessMode' => $accessMode,
-							'padId' => $padId,
+							'padId' => $attempt->padId(),
 						],
 					];
 				}
 
 				return null;
 			},
-			function () use ($parentFolderId, $name, $accessMode, &$path, &$padId): array {
+			function (PadCreateAttempt $attempt) use ($parentFolderId, $name, $accessMode): array {
 				return [
 					'message' => 'Pad creation by parent failed',
 					'context' => [
 						'parentFolderId' => $parentFolderId,
 						'padName' => $name,
-						'path' => $path,
+						'path' => $attempt->path(),
 						'accessMode' => $accessMode,
-						'padId' => $padId,
+						'padId' => $attempt->padId(),
 					],
 				];
 			},
@@ -198,16 +193,15 @@ class PadCreationService {
 	 */
 	public function createFromUrl(string $uid, string $file, string $padUrl): array {
 		$path = $this->padPaths->normalizeCreatePath($file);
-		$claim = null;
 
 		return $this->withCreateRollback(
-			function () use ($uid, $path, $padUrl, &$claim) {
+			function (PadCreateAttempt $attempt) use ($uid, $path, $padUrl) {
+				$attempt->recordPath($path);
 				$fileNode = $this->padFileCreator->createUserFile($uid, $path);
 				$fileId = $this->requireFileId($fileNode, $path);
-				$claim = new CreatedFileClaim($uid, $fileId);
+				$claim = $attempt->claimFile($uid, $fileId);
 				if ($this->isNotOurs($fileNode, $fileId, $path)) {
-					// Not ours after all, so it is not ours to clean up either.
-					$claim = null;
+					$attempt->disownFile();
 					throw new PadFileAlreadyExistsException('Target .pad file already exists.');
 				}
 
@@ -220,9 +214,11 @@ class PadCreationService {
 				$result = ['file' => $path] + $seeded;
 				return $result;
 			},
-			function () use ($uid, $path, &$claim): void {
-				$this->rollbackService->rollbackExternalCreate($uid, $path, $claim);
+			function (PadCreateAttempt $attempt) use ($uid): void {
+				$this->rollbackService->rollbackExternalCreate($uid, $attempt->path(), $attempt->claim());
 			},
+			// No pad of ours here — an external create links one that already
+			// exists — so neither log closure has an attempt to read.
 			function (\Throwable $e) use ($path, $padUrl): ?array {
 				if ($e instanceof EtherpadClientException) {
 					return [
@@ -264,23 +260,23 @@ class PadCreationService {
 
 		$templateNode = $this->userNodeResolver->resolveUserFileNodeById($uid, $templateFileId);
 
-		$padId = '';
-		$claim = null;
-
 		return $this->withCreateRollback(
-			function () use ($uid, $path, $templateNode, $user, &$padId, &$claim): array {
+			function (PadCreateAttempt $attempt) use ($uid, $path, $templateNode, $user): array {
+				$attempt->recordPath($path);
 				$fileNode = $this->padFileCreator->createUserFile($uid, $path);
 				$fileId = $this->requireFileId($fileNode, $path);
 				// API creates start empty; do not replace this baseline with a later read.
-				$claim = new CreatedFileClaim($uid, $fileId);
+				$claim = $attempt->claimFile($uid, $fileId);
 				if ($this->isNotOurs($fileNode, $fileId, $path)) {
-					// Not ours after all, so it is not ours to clean up either.
-					$claim = null;
+					$attempt->disownFile();
 					throw new PadFileAlreadyExistsException('Target .pad file already exists.');
 				}
 
 				$result = $this->materializeTemplateInto($fileNode, $templateNode, $user, $claim);
-				$padId = $result['pad_id'];
+				// Recorded for the log lines only: this pad belongs to
+				// materializeTemplateInto(), which removes it itself before
+				// rethrowing, so the rollback below is file-only.
+				$attempt->recordPad($result['pad_id']);
 
 				return [
 					'file' => $path,
@@ -290,30 +286,30 @@ class PadCreationService {
 					'pad_url' => $result['pad_url'],
 				];
 			},
-			function () use ($uid, $path, &$padId, &$claim): void {
+			function (PadCreateAttempt $attempt) use ($uid): void {
 				// File only: materializeTemplateInto() has already deleted the
 				// pad it provisioned before rethrowing.
-				$this->rollbackService->rollbackCreatedFileOnly($uid, $path, $claim);
+				$this->rollbackService->rollbackCreatedFileOnly($uid, $attempt->path(), $attempt->claim());
 			},
-			function (\Throwable $e) use ($path, &$padId): ?array {
+			function (\Throwable $e, PadCreateAttempt $attempt) use ($path): ?array {
 				if ($e instanceof BindingException) {
 					return [
 						'message' => 'Pad create-from-template hit existing binding',
 						'context' => [
 							'file' => $path,
-							'padId' => $padId,
+							'padId' => $attempt->padId(),
 						],
 					];
 				}
 				return null;
 			},
-			function () use ($path, $templateFileId, &$padId): array {
+			function (PadCreateAttempt $attempt) use ($path, $templateFileId): array {
 				return [
 					'message' => 'Pad create-from-template failed',
 					'context' => [
 						'file' => $path,
 						'templateFileId' => $templateFileId,
-						'padId' => $padId,
+						'padId' => $attempt->padId(),
 					],
 				];
 			},
@@ -591,16 +587,29 @@ class PadCreationService {
 	 * @param callable():array{message:string,context:array<string,mixed>} $errorFor
 	 * @return T
 	 */
+	/**
+	 * Runs one create attempt, owning the state the rollback needs.
+	 *
+	 * The attempt is made here and handed to both closures, so nothing has
+	 * to be threaded through by reference and the two cannot disagree about
+	 * what was created.
+	 *
+	 * @param callable(PadCreateAttempt): mixed $action
+	 * @param callable(PadCreateAttempt): void $rollback
+	 * @param callable(\Throwable, PadCreateAttempt): ?array{message:string,context:array<string,mixed>} $warningFor
+	 * @param callable(PadCreateAttempt): array{message:string,context:array<string,mixed>} $errorFor
+	 */
 	private function withCreateRollback(
 		callable $action,
 		callable $rollback,
 		callable $warningFor,
 		callable $errorFor,
 	): mixed {
+		$attempt = new PadCreateAttempt();
 		try {
-			return $action();
+			return $action($attempt);
 		} catch (\Throwable $e) {
-			$warning = $warningFor($e);
+			$warning = $warningFor($e, $attempt);
 			if ($warning !== null) {
 				$this->logger->warning($warning['message'], array_merge(
 					['app' => 'etherpad_nextcloud'],
@@ -608,7 +617,7 @@ class PadCreationService {
 					['exception' => $e],
 				));
 			} elseif (!($e instanceof PadFileAlreadyExistsException) && !($e instanceof InvalidPadNameException)) {
-				$error = $errorFor();
+				$error = $errorFor($attempt);
 				$this->logger->error($error['message'], array_merge(
 					['app' => 'etherpad_nextcloud'],
 					$error['context'],
@@ -616,7 +625,7 @@ class PadCreationService {
 				));
 			}
 
-			$rollback();
+			$rollback($attempt);
 			throw $e;
 		}
 	}

--- a/lib/Service/PadCreationService.php
+++ b/lib/Service/PadCreationService.php
@@ -123,13 +123,16 @@ class PadCreationService {
 		return $this->withCreateRollback(
 			function (PadCreateAttempt $attempt) use ($uid, $parentFolder, $parentFolderId, $fileName, $accessMode): array {
 				$fileNode = $this->padFileCreator->createUserFileInFolder($parentFolder, $fileName);
-				// Before anything that can throw: this is the only flow that
-				// does not know the path up front, and a rollback running
-				// before it was recorded used to log an empty one.
+				// Ownership first, path second. The id is what the rollback
+				// needs to remove this file at all, and `toUserAbsolutePath()`
+				// throws when the node cannot be mapped into the user's tree —
+				// claiming after it would leave the new file behind. The path
+				// only makes the log lines readable, and this is the one flow
+				// that does not know it up front.
+				$fileId = $this->requireFileId($fileNode, $fileName);
+				$claim = $attempt->claimFile($uid, $fileId);
 				$path = $this->userNodeResolver->toUserAbsolutePath($uid, $fileNode);
 				$attempt->recordPath($path);
-				$fileId = $this->requireFileId($fileNode, $path);
-				$claim = $attempt->claimFile($uid, $fileId);
 				if ($this->isNotOurs($fileNode, $fileId, $path)) {
 					$attempt->disownFile();
 					throw new PadFileAlreadyExistsException('Target .pad file already exists.');

--- a/lib/Service/PadCreationService.php
+++ b/lib/Service/PadCreationService.php
@@ -123,14 +123,17 @@ class PadCreationService {
 		return $this->withCreateRollback(
 			function (PadCreateAttempt $attempt) use ($uid, $parentFolder, $parentFolderId, $fileName, $accessMode): array {
 				$fileNode = $this->padFileCreator->createUserFileInFolder($parentFolder, $fileName);
-				$fileId = $this->requireFileId($fileNode, $attempt->path());
+				// Before anything that can throw: this is the only flow that
+				// does not know the path up front, and a rollback running
+				// before it was recorded used to log an empty one.
+				$path = $this->userNodeResolver->toUserAbsolutePath($uid, $fileNode);
+				$attempt->recordPath($path);
+				$fileId = $this->requireFileId($fileNode, $path);
 				$claim = $attempt->claimFile($uid, $fileId);
-				if ($this->isNotOurs($fileNode, $fileId, $attempt->path())) {
+				if ($this->isNotOurs($fileNode, $fileId, $path)) {
 					$attempt->disownFile();
 					throw new PadFileAlreadyExistsException('Target .pad file already exists.');
 				}
-				$path = $this->userNodeResolver->toUserAbsolutePath($uid, $fileNode);
-				$attempt->recordPath($path);
 
 				$padId = $this->padBootstrapService->provisionPadId($accessMode);
 				$attempt->recordPad($padId);
@@ -580,24 +583,18 @@ class PadCreationService {
 	}
 
 	/**
-	 * @template T
-	 * @param callable():T $action
-	 * @param callable():void $rollback
-	 * @param callable(\Throwable):?array{message:string,context:array<string,mixed>} $warningFor
-	 * @param callable():array{message:string,context:array<string,mixed>} $errorFor
-	 * @return T
-	 */
-	/**
 	 * Runs one create attempt, owning the state the rollback needs.
 	 *
-	 * The attempt is made here and handed to both closures, so nothing has
+	 * The attempt is made here and handed to every closure, so nothing has
 	 * to be threaded through by reference and the two cannot disagree about
 	 * what was created.
 	 *
-	 * @param callable(PadCreateAttempt): mixed $action
-	 * @param callable(PadCreateAttempt): void $rollback
-	 * @param callable(\Throwable, PadCreateAttempt): ?array{message:string,context:array<string,mixed>} $warningFor
-	 * @param callable(PadCreateAttempt): array{message:string,context:array<string,mixed>} $errorFor
+	 * @template T
+	 * @param callable(PadCreateAttempt):T $action
+	 * @param callable(PadCreateAttempt):void $rollback
+	 * @param callable(\Throwable,PadCreateAttempt):?array{message:string,context:array<string,mixed>} $warningFor
+	 * @param callable(PadCreateAttempt):array{message:string,context:array<string,mixed>} $errorFor
+	 * @return T
 	 */
 	private function withCreateRollback(
 		callable $action,

--- a/tests/phpunit/unit/PadCreateAttemptTest.php
+++ b/tests/phpunit/unit/PadCreateAttemptTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\EtherpadNextcloud\Tests\Unit;
+
+use OCA\EtherpadNextcloud\Service\PadCreateAttempt;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The two defects that motivated this object, written as statements about
+ * it rather than as orderings of assignments in a closure.
+ */
+class PadCreateAttemptTest extends TestCase {
+	public function testAFreshAttemptOwnsNothing(): void {
+		$attempt = new PadCreateAttempt();
+
+		$this->assertNull($attempt->claim(), 'nothing created, nothing to roll back');
+		$this->assertSame('', $attempt->padId());
+		$this->assertSame('', $attempt->path());
+	}
+
+	/**
+	 * The file turned out to be somebody else's pad. It was recorded a
+	 * moment earlier, and the old code depended on un-setting that variable
+	 * before the throw a few lines below.
+	 */
+	public function testADisownedFileIsNotHandedToTheRollback(): void {
+		$attempt = new PadCreateAttempt();
+		$attempt->claimFile('alice', 4242);
+
+		$attempt->disownFile();
+
+		$this->assertNull($attempt->claim());
+	}
+
+	/**
+	 * The claim handed to the write is the one the rollback reads, so proof
+	 * of a successful write survives a later failure. Returning it by value
+	 * was how that proof used to get lost.
+	 */
+	public function testTheWrittenProofReachesTheRollback(): void {
+		$attempt = new PadCreateAttempt();
+		$claim = $attempt->claimFile('alice', 4242);
+
+		$claim->writtenHash = hash('sha256', 'our document');
+
+		$this->assertSame($claim, $attempt->claim());
+		$this->assertSame(hash('sha256', 'our document'), $attempt->claim()?->writtenHash);
+	}
+
+	public function testCarriesWhatTheFlowRecords(): void {
+		$attempt = new PadCreateAttempt();
+
+		$attempt->claimFile('alice', 4242, 'template bytes');
+		$attempt->recordPad('g.ABC$pad');
+		$attempt->recordPath('/Notes/Meeting.pad');
+
+		$this->assertSame('alice', $attempt->claim()?->uid);
+		$this->assertSame(4242, $attempt->claim()?->fileId);
+		$this->assertSame('template bytes', $attempt->claim()?->expectedBefore);
+		$this->assertSame('g.ABC$pad', $attempt->padId());
+		$this->assertSame('/Notes/Meeting.pad', $attempt->path());
+	}
+}

--- a/tests/phpunit/unit/PadCreationServiceTest.php
+++ b/tests/phpunit/unit/PadCreationServiceTest.php
@@ -118,6 +118,47 @@ class PadCreationServiceTest extends TestCase {
 			->createInParent('alice', 99, 'Test', BindingService::ACCESS_PUBLIC);
 	}
 
+	/**
+	 * `toUserAbsolutePath()` throws when the node cannot be mapped into the
+	 * user's tree, and by then `newFile()` has already made the file. The
+	 * claim has to exist before that call, or the rollback is handed
+	 * nothing and the empty `.pad` stays behind.
+	 */
+	public function testClaimsTheFileBeforeResolvingItsPath(): void {
+		$parent = $this->createMock(Folder::class);
+		$parent->method('isCreatable')->willReturn(true);
+
+		$fileNode = $this->createMock(\OCP\Files\File::class);
+		$fileNode->method('getId')->willReturn(4242);
+
+		$fileCreator = $this->createMock(PadFileCreator::class);
+		$fileCreator->method('createUserFileInFolder')->willReturn($fileNode);
+
+		$padPaths = $this->createMock(PathNormalizer::class);
+		$padPaths->method('normalizeCreateFileName')->willReturn('Test.pad');
+
+		$userNodeResolver = $this->createMock(UserNodeResolver::class);
+		$userNodeResolver->method('resolveUserFolderNodeById')->willReturn($parent);
+		$userNodeResolver->method('toUserAbsolutePath')
+			->willThrowException(new \OCP\Files\NotFoundException('outside the user tree'));
+
+		$rollbackService = $this->createMock(PadCreateRollbackService::class);
+		$rollbackService->expects($this->once())
+			->method('rollbackFailedCreate')
+			->with('alice', $this->anything(), '', $this->callback(
+				static fn (?CreatedFileClaim $claim): bool => $claim !== null && $claim->fileId === 4242
+			));
+
+		$this->expectException(\OCP\Files\NotFoundException::class);
+
+		$this->buildService(
+			padPaths: $padPaths,
+			fileCreator: $fileCreator,
+			userNodeResolver: $userNodeResolver,
+			rollbackService: $rollbackService,
+		)->createInParent('alice', 99, 'Test', BindingService::ACCESS_PUBLIC);
+	}
+
 	public function testCreateRefusesAPadTypeTheAdminSwitchedOff(): void {
 		// The guard sits before any file is touched, so a rejected create
 		// leaves nothing behind to roll back.


### PR DESCRIPTION
Closes #199.

The four create flows each declared `$padId`, the created-file record and — in one case — `$path` as locals, then threaded them through three closures by reference: the action writes them, the rollback reads them, the log formatters read some of them. Twelve capture sites that had to stay in step, with nothing enforcing it.

Two defects had already come out of that, both found in review rather than by a test: a flow that never recorded its file, so a failure after the file existed reached the rollback with nothing to clean up; and a flow that recorded one and then discovered it was somebody else's pad — correct only because a variable was un-set a few lines above the throw.

`withCreateRollback()` now makes a `PadCreateAttempt` and hands it to every closure. There is one owner of what has been created, and nothing to keep in step. "This file is not mine after all" is `disownFile()` rather than an assignment whose position decides the answer.

Two details worth naming:

- Create-by-parent is the only flow that does not know its path up front. It recorded that path after `requireFileId()` and the ownership check, so a failure in either logged an empty path. It is recorded as soon as the node exists.
- The template flow keeps its file-only rollback, and now says why in code: it records its pad in order to log it, because `materializeTemplateInto()` removes that pad itself before rethrowing. Different resource ownership, not drift.

## Behaviour is unchanged, and that is checkable

The 921 existing tests pass, and **no existing test file is modified by this PR** — the only test file it touches is the new one for `PadCreateAttempt`. For a pure state refactor that property is the strongest evidence available, so it was worth keeping intact.

The new tests state the two defects above as properties of the object rather than as orderings inside a closure.

## What this is not

This unifies the *state*, not yet the *flow*. Production code grows by about 80 lines net: the four flows remain, their variables now live in the attempt. It is groundwork for a shared create core rather than the core itself.

What remains, in the order I would do it:

1. **Claim and check the file once instead of four times.** Every flow repeats: read the id, register the claim, check existing content and binding, disown and abort. That ordering is security-relevant and is currently written correctly four times rather than centrally. It can be made behaviour-preserving, so the "existing tests untouched" check still applies.
2. **Reduce `create()` and `createInParent()` to one path.** After the target is chosen they do the same thing. The public methods stay as thin entry points; folder resolution and `parent_folder_id` are their differences. This one changes flow, so it wants its own review.
3. **Consolidate the eight logging closures.** Mostly building similar messages and context arrays, with the warning/error distinction preserved.

Templates and external pads should not be pressed into the same path: templates clean up their own Etherpad resources, and external pads must never be deleted. Shared file handling yes; differing resource ownership stays visible.

## Verification

925 PHP tests / 3078 assertions, 261 JS tests, Psalm clean, Playwright 35 passed / 1 skipped.

One regression was introduced and fixed during review: splitting the docblock left two of them, and PHP attaches only the nearest — so `@template T` / `@return T` stopped applying and each flow's result was no longer checked against its declared return shape. Counter-checked in a throwaway worktree by returning `pad_id => false`: `main` reports 3 errors, this branch reported 0 before the fix and 2 after it.
