### PR TITLE
Claim and check a created file in one place instead of four

### DIFF
--- a/lib/Service/PadCreationService.php
+++ b/lib/Service/PadCreationService.php
@@ -48,14 +48,10 @@ class PadCreationService {
 
 		return $this->withCreateRollback(
 			function (PadCreateAttempt $attempt) use ($uid, $path, $accessMode): array {
+				$attempt->recordPath($path);
 				$fileNode = $this->padFileCreator->createUserFile($uid, $path);
-				// Capture the id before provisioning; getId() on this node is path-based.
-				$fileId = $this->requireFileId($fileNode, $path);
-				$claim = $attempt->claimFile($uid, $fileId);
-				if ($this->isNotOurs($fileNode, $fileId, $path)) {
-					$attempt->disownFile();
-					throw new PadFileAlreadyExistsException('Target .pad file already exists.');
-				}
+				$claim = $this->claimCreatedFile($attempt, $uid, $fileNode, $path);
+				$fileId = $claim->fileId;
 				$padId = $this->padBootstrapService->provisionPadId($accessMode);
 				$attempt->recordPad($padId);
 				$padUrl = $this->etherpadClient->buildPadUrl($padId);
@@ -79,8 +75,8 @@ class PadCreationService {
 					'pad_url' => $padUrl,
 				];
 			},
-			function (PadCreateAttempt $attempt) use ($uid, $path): void {
-				$this->rollbackService->rollbackFailedCreate($uid, $path, $attempt->padId(), $attempt->claim());
+			function (PadCreateAttempt $attempt) use ($uid): void {
+				$this->rollbackService->rollbackFailedCreate($uid, $attempt->path(), $attempt->padId(), $attempt->claim());
 			},
 			function (\Throwable $e, PadCreateAttempt $attempt) use ($path, $accessMode): ?array {
 				if ($e instanceof BindingException) {
@@ -123,20 +119,9 @@ class PadCreationService {
 		return $this->withCreateRollback(
 			function (PadCreateAttempt $attempt) use ($uid, $parentFolder, $parentFolderId, $fileName, $accessMode): array {
 				$fileNode = $this->padFileCreator->createUserFileInFolder($parentFolder, $fileName);
-				// Ownership first, path second. The id is what the rollback
-				// needs to remove this file at all, and `toUserAbsolutePath()`
-				// throws when the node cannot be mapped into the user's tree —
-				// claiming after it would leave the new file behind. The path
-				// only makes the log lines readable, and this is the one flow
-				// that does not know it up front.
-				$fileId = $this->requireFileId($fileNode, $fileName);
-				$claim = $attempt->claimFile($uid, $fileId);
-				$path = $this->userNodeResolver->toUserAbsolutePath($uid, $fileNode);
-				$attempt->recordPath($path);
-				if ($this->isNotOurs($fileNode, $fileId, $path)) {
-					$attempt->disownFile();
-					throw new PadFileAlreadyExistsException('Target .pad file already exists.');
-				}
+				$claim = $this->claimCreatedFile($attempt, $uid, $fileNode);
+				$fileId = $claim->fileId;
+				$path = $attempt->path();
 
 				$padId = $this->padBootstrapService->provisionPadId($accessMode);
 				$attempt->recordPad($padId);
@@ -204,12 +189,8 @@ class PadCreationService {
 			function (PadCreateAttempt $attempt) use ($uid, $path, $padUrl) {
 				$attempt->recordPath($path);
 				$fileNode = $this->padFileCreator->createUserFile($uid, $path);
-				$fileId = $this->requireFileId($fileNode, $path);
-				$claim = $attempt->claimFile($uid, $fileId);
-				if ($this->isNotOurs($fileNode, $fileId, $path)) {
-					$attempt->disownFile();
-					throw new PadFileAlreadyExistsException('Target .pad file already exists.');
-				}
+				$claim = $this->claimCreatedFile($attempt, $uid, $fileNode, $path);
+				$fileId = $claim->fileId;
 
 				$prepared = $this->externalPadSeeder->prepare($fileId, $padUrl);
 				$this->writeCreatedFile($claim, $prepared['content']);
@@ -270,13 +251,8 @@ class PadCreationService {
 			function (PadCreateAttempt $attempt) use ($uid, $path, $templateNode, $user): array {
 				$attempt->recordPath($path);
 				$fileNode = $this->padFileCreator->createUserFile($uid, $path);
-				$fileId = $this->requireFileId($fileNode, $path);
 				// API creates start empty; do not replace this baseline with a later read.
-				$claim = $attempt->claimFile($uid, $fileId);
-				if ($this->isNotOurs($fileNode, $fileId, $path)) {
-					$attempt->disownFile();
-					throw new PadFileAlreadyExistsException('Target .pad file already exists.');
-				}
+				$claim = $this->claimCreatedFile($attempt, $uid, $fileNode, $path);
 
 				$result = $this->materializeTemplateInto($fileNode, $templateNode, $user, $claim);
 				// Recorded for the log lines only: this pad belongs to
@@ -505,6 +481,33 @@ class PadCreationService {
 		}
 
 		return $node;
+	}
+
+	/**
+	 * Take ownership of the file this attempt just made — or refuse it.
+	 *
+	 * One method because the order is the point: the id before anything
+	 * that can throw, the ownership check before any write, the disown
+	 * before the throw. Written out four times it was already drifting.
+	 *
+	 * An empty `$path` means create-by-parent, which cannot know it before
+	 * the file exists; deriving it can throw, hence after the claim.
+	 */
+	private function claimCreatedFile(PadCreateAttempt $attempt, string $uid, File $fileNode, string $path = ''): CreatedFileClaim {
+		$fileId = $this->requireFileId($fileNode, $path !== '' ? $path : $fileNode->getName());
+		$claim = $attempt->claimFile($uid, $fileId);
+
+		if ($path === '') {
+			$path = $this->userNodeResolver->toUserAbsolutePath($uid, $fileNode);
+		}
+		$attempt->recordPath($path);
+
+		if ($this->isNotOurs($fileNode, $fileId, $path)) {
+			$attempt->disownFile();
+			throw new PadFileAlreadyExistsException('Target .pad file already exists.');
+		}
+
+		return $claim;
 	}
 
 	/**


### PR DESCRIPTION
Follow-up to #199 — the first of the three steps named in that PR's description.

Every create repeated the same sequence: read the file id, register the claim, derive and record the path, check whether the file is already somebody else's pad, disown it and abort if so.

The order is the whole point, and it is security relevant:

- the id has to be recorded before anything that can throw, or a failure leaves behind a file nothing can identify;
- the ownership check has to precede any write, or the create fills in somebody else's file;
- a file that turns out not to be ours has to be disowned before the throw, or the rollback deletes it.

Written out at four call sites, that order was already drifting. Three flows recorded the path at three different points, and one of them recorded it *after* a call that can throw — the same defect shape that was found in review on the previous PR, one flow further along.

`claimCreatedFile()` states the order once. The flows say what they know — the path up front, or nothing for create-by-parent, which cannot know it until the file exists — and get a claim back. All four rollbacks now read the path the same way, and the path is recorded as soon as it is known rather than at three different moments.

## Behaviour is unchanged, and that is checkable

926 tests pass and **no test file is modified by this PR**. That was the reason to take this step before merging `create()` and `createInParent()`: it is behaviour-preserving, so the property still holds and a reviewer can read it off the diff.

## What is left

2. **Reduce `create()` and `createInParent()` to one path.** After the target is chosen they do the same thing. This one changes flow, so it wants its own review and will cost the property above.
3. **Consolidate the eight logging closures**, preserving the warning/error distinction.

Templates and external pads stay out of the shared path: templates clean up their own Etherpad resources and external pads must never be deleted. Shared file handling yes; differing resource ownership stays visible.

## Verification

926 PHP tests / 3084 assertions, 261 JS tests, Psalm clean, Playwright 35 passed / 1 skipped.
