### PR TITLE
Refuse frontmatter values that would be read back as more keys

### DIFF
--- a/lib/Service/ExternalPadExportFetcher.php
+++ b/lib/Service/ExternalPadExportFetcher.php
@@ -417,7 +417,7 @@ class ExternalPadExportFetcher {
 
 		$basePath = rtrim($matches[1], '/');
 		$padId = trim($matches[2]);
-		if ($padId === '') {
+		if ($padId === '' || preg_match('/[\x00-\x1F\x7F]/', $padId) === 1) {
 			throw new EtherpadClientException('Invalid public pad URL.');
 		}
 

--- a/lib/Service/ExternalPadExportFetcher.php
+++ b/lib/Service/ExternalPadExportFetcher.php
@@ -407,7 +407,8 @@ class ExternalPadExportFetcher {
 		// pad-id `team pad`, then re-encoded to `/p/team%20pad` at fetch
 		// time, hitting a different / non-existent remote pad.
 		$decodedPath = rawurldecode($path);
-		if ($scheme !== 'https' || $host === '' || $decodedPath === '' || $port <= 0 || $port > 65535) {
+		if ($scheme !== 'https' || $host === '' || $decodedPath === '' || $port <= 0 || $port > 65535
+			|| preg_match('/[\x00-\x1F\x7F]/', $decodedPath) === 1) {
 			throw new EtherpadClientException('Invalid public pad URL.');
 		}
 
@@ -417,7 +418,7 @@ class ExternalPadExportFetcher {
 
 		$basePath = rtrim($matches[1], '/');
 		$padId = trim($matches[2]);
-		if ($padId === '' || preg_match('/[\x00-\x1F\x7F]/', $padId) === 1) {
+		if ($padId === '') {
 			throw new EtherpadClientException('Invalid public pad URL.');
 		}
 

--- a/lib/Service/PadFileService.php
+++ b/lib/Service/PadFileService.php
@@ -367,6 +367,9 @@ class PadFileService {
 	}
 
 	private function stringScalar(string $value): string {
+		if (preg_match('/[\x00-\x1F\x7F]/', $value) === 1) {
+			throw new PadFileFormatException('Frontmatter values must not contain control characters.');
+		}
 		$escaped = str_replace(['\\', '"'], ['\\\\', '\\"'], $value);
 		return '"' . $escaped . '"';
 	}

--- a/tests/phpunit/unit/ExternalPadExportFetcherTest.php
+++ b/tests/phpunit/unit/ExternalPadExportFetcherTest.php
@@ -63,6 +63,13 @@ class ExternalPadExportFetcherTest extends TestCase {
 		);
 	}
 
+	public function testNormalizeAndValidateExternalPublicPadUrlRejectsAControlCharacterBeforeThePadId(): void {
+		$fetcher = new ExternalPadExportFetcher($this->buildExternalEnabledConfig());
+
+		$this->expectException(EtherpadClientException::class);
+		$fetcher->normalizeAndValidateExternalPublicPadUrl('https://1.1.1.1/base%01/p/demo');
+	}
+
 	public function testNormalizeAndValidateExternalPublicPadUrlRejectsProtectedPadIds(): void {
 		$fetcher = new ExternalPadExportFetcher($this->buildExternalEnabledConfig());
 

--- a/tests/phpunit/unit/ExternalPadExportFetcherTest.php
+++ b/tests/phpunit/unit/ExternalPadExportFetcherTest.php
@@ -54,6 +54,15 @@ class ExternalPadExportFetcherTest extends TestCase {
 		$fetcher->normalizeAndValidateExternalPublicPadUrl('https://1.1.1.1:9443/p/public-pad');
 	}
 
+	public function testNormalizeAndValidateExternalPublicPadUrlRejectsAPadIdWithANewline(): void {
+		$fetcher = new ExternalPadExportFetcher($this->buildExternalEnabledConfig());
+
+		$this->expectException(EtherpadClientException::class);
+		$fetcher->normalizeAndValidateExternalPublicPadUrl(
+			'https://1.1.1.1/p/a%0Apad_id:%20g.victim$secret',
+		);
+	}
+
 	public function testNormalizeAndValidateExternalPublicPadUrlRejectsProtectedPadIds(): void {
 		$fetcher = new ExternalPadExportFetcher($this->buildExternalEnabledConfig());
 

--- a/tests/phpunit/unit/PadFileServiceTest.php
+++ b/tests/phpunit/unit/PadFileServiceTest.php
@@ -223,6 +223,20 @@ class PadFileServiceTest extends TestCase {
 		$this->assertSame('', $service->getHtmlSnapshotForRestore($textOnly));
 	}
 
+	public function testFrontmatterValuesWithControlCharactersAreRefused(): void {
+		$service = new PadFileService();
+
+		$this->expectException(PadFileFormatException::class);
+		$service->buildInitialDocument(
+			321,
+			'ext.RemotePad',
+			BindingService::ACCESS_PUBLIC,
+			'body',
+			'https://pad.remote.test/p/x',
+			['remote_pad_id' => "a\npad_id: g.victim\$secret\naccess_mode: protected"],
+		);
+	}
+
 	public function testGetSnapshotPartsFromBodyHandlesBodyWithoutMarkers(): void {
 		$service = new PadFileService();
 		$parts = $service->getSnapshotPartsFromBody('raw text without sections');


### PR DESCRIPTION
A `.pad` frontmatter block is written by `serialize()` and read back line by line as `^key: value$`. `stringScalar()` escaped a backslash and a quote and nothing else, so a value carrying a newline was written as further physical lines — and the reader took them for further keys.

## Reachable from a URL a user types

`ExternalPadExportFetcher::parsePublicPadUrl()` decodes the path with `rawurldecode()`, and its `~^(.*)/p/([^/]+)$~` matches a newline: a negated character class is not `.`, and `trim()` only takes the outer whitespace. So

```
https://p.test/p/a%0Apad_id:%20g.victim$secret%0Aaccess_mode:%20protected%0A%23
```

leaves `remote_pad_id` holding two extra lines. That key is the last one `serialize()` emits, so the injected lines land after every real key and win. The file written by create-from-URL then reads:

```
remote_pad_id: "a
pad_id: g.victim$secret
access_mode: protected
#"
```

and `readPad()` of it returns `padId "g.victim$secret"`, `accessMode "protected"`, `isExternal false` — an external pad file presenting itself as a managed protected pad. `state`, `file_id` and `deleted_at` go the same way.

Reproduced against the real `PadFileService`, not argued from the code.

## Refused in two places

`stringScalar()` rejects any control character. That is the structural half: every value the app writes goes through it, so this covers writers that do not exist yet rather than the one path the problem was found on.

It refuses rather than encodes on purpose. The reader has no escape sequence for a newline — `parseFrontmatterBlock()` splits on `\n` and matches `^key: value$` — so an encoded `\n` would not survive the round trip, and nothing this app writes has a reason to hold a control character.

`parsePublicPadUrl()` rejects a decoded path holding one, so a bad URL fails where it is entered instead of later at write time.

That guard sits on the whole decoded path rather than on the pad id alone. The base path is written to `pad_origin` through the same serializer, and while it could never carry a newline — `.` does not match one without `/s`, which is exactly why the pad id was the reachable half — it could carry other control characters. Checking the path covers both halves in one place, and lets the pad-id-specific check go.

## Not a regression

`stringScalar()` and the URL parsing are unchanged from `main`; this is an existing hole rather than something a recent change introduced. It sits on the code touched by the pad-parsing refactor, which is how it came up, but it is deliberately on its own branch off `main` so it can land without waiting for that work.

The guard stops new poisoning; it does not retroactively detect a `.pad` already written with injected frontmatter. Such a file reads back with `isExternal: false`, which routes it into `assertConsistentMapping($fileId, $padId, $accessMode)`, where the claimed `pad_id` and `access_mode` will not match the binding row written at create time and the open is refused.

## Verified

- The reproduction above fails to write at all after the fix
- 936 PHPUnit tests, 3094 assertions; Psalm clean
- Each guard carries a test that fails when that guard is removed — checked by removing each one
