### PR TITLE
Parse a .pad once and pass what came out

### DIFF
--- a/docs/pad-format.md
+++ b/docs/pad-format.md
@@ -114,10 +114,11 @@ Implementation: `lib/Service/PadFileService.php`
 - `parsePadFile(string $content): array{frontmatter, body}`
 - `serialize(array $frontmatter, string $body): string`
 - `readPad(string $content): ParsedPadFile` parses once and hands back the frontmatter, the body and the fields derived from them
-- `withExportSnapshot(ParsedPadFile $pad, ...)` updates export metadata + snapshot body
+- `withExportSnapshot(ParsedPadFile $pad, PadSnapshot $snapshot)` updates export metadata + snapshot body
 - `withRestoredSnapshot(ParsedPadFile $pad, ...)` writes the document a restore leaves behind: active, undeleted, pointed at the replacement pad, with both snapshot halves as given
 - `getSnapshotPartsFromBody(string $body): array{text, html}` splits a stored snapshot into its two halves, from a body a caller already has
 - `buildInitialDocument(...)` takes an optional `PadSnapshot` for a document that starts out with content; without one the document is unsnapshotted (`snapshot_rev: -1`) and its body is empty
+- `PadSnapshot` is text, an HTML half and the revision the snapshot was taken at. Its `html` is nullable, and the two empty cases write different files: `null` means a text-only snapshot and omits the `[HTML-BEGIN]`/`[HTML-END]` section entirely, `''` writes the section with nothing in it. A negative revision is refused — `-1` is what an unsnapshotted document uses
 
 Snapshot write flow:
 

--- a/docs/pad-format.md
+++ b/docs/pad-format.md
@@ -115,7 +115,7 @@ Implementation: `lib/Service/PadFileService.php`
 - `serialize(array $frontmatter, string $body): string`
 - `readPad(string $content): ParsedPadFile` parses once and hands back the frontmatter, the body and the fields derived from them
 - `withExportSnapshot(ParsedPadFile $pad, ...)` updates export metadata + snapshot body
-- `withStateAndSnapshot(ParsedPadFile $pad, ...)` updates state + snapshot
+- `withRestoredSnapshot(ParsedPadFile $pad, ...)` writes the document a restore leaves behind: active, undeleted, pointed at the replacement pad, with both snapshot halves as given
 - `getSnapshotPartsFromBody(string $body): array{text, html}` splits a stored snapshot into its two halves, from a body a caller already has
 - `buildInitialDocument(...)` takes an optional `PadSnapshot` for a document that starts out with content; without one the document is unsnapshotted (`snapshot_rev: -1`) and its body is empty
 

--- a/docs/pad-format.md
+++ b/docs/pad-format.md
@@ -113,9 +113,11 @@ Implementation: `lib/Service/PadFileService.php`
 
 - `parsePadFile(string $content): array{frontmatter, body}`
 - `serialize(array $frontmatter, string $body): string`
-- `withExportSnapshot(...)` updates export metadata + snapshot body
-- `withStateAndSnapshot(...)` updates state + snapshot
-- `getTextSnapshotForRestore(...)` and `getHtmlSnapshotForRestore(...)` read stored snapshots from the body
+- `readPad(string $content): ParsedPadFile` parses once and hands back the frontmatter, the body and the fields derived from them
+- `withExportSnapshot(ParsedPadFile $pad, ...)` updates export metadata + snapshot body
+- `withStateAndSnapshot(ParsedPadFile $pad, ...)` updates state + snapshot
+- `getSnapshotPartsFromBody(string $body): array{text, html}` splits a stored snapshot into its two halves, from a body a caller already has
+- `buildInitialDocument(...)` takes `snapshotHtml` and `snapshotRev` for a document that starts out with content
 
 Snapshot write flow:
 

--- a/docs/pad-format.md
+++ b/docs/pad-format.md
@@ -117,7 +117,7 @@ Implementation: `lib/Service/PadFileService.php`
 - `withExportSnapshot(ParsedPadFile $pad, ...)` updates export metadata + snapshot body
 - `withStateAndSnapshot(ParsedPadFile $pad, ...)` updates state + snapshot
 - `getSnapshotPartsFromBody(string $body): array{text, html}` splits a stored snapshot into its two halves, from a body a caller already has
-- `buildInitialDocument(...)` takes `snapshotHtml` and `snapshotRev` for a document that starts out with content
+- `buildInitialDocument(...)` takes an optional `PadSnapshot` for a document that starts out with content; without one the document is unsnapshotted (`snapshot_rev: -1`) and its body is empty
 
 Snapshot write flow:
 

--- a/lib/Service/ExternalPadSeeder.php
+++ b/lib/Service/ExternalPadSeeder.php
@@ -46,14 +46,14 @@ class ExternalPadSeeder {
 			$fileId,
 			$externalPadId,
 			BindingService::ACCESS_PUBLIC,
-			'',
+			$external['text'],
 			$external['pad_url'],
 			[
 				'pad_origin' => $external['origin'],
 				'remote_pad_id' => $external['pad_id'],
-			]
+			],
+			snapshotRev: 0,
 		);
-		$content = $this->padFileService->withExportSnapshot($content, $external['text'], '', 0, false);
 
 		$result = [
 			'file_id' => $fileId,

--- a/lib/Service/ExternalPadSeeder.php
+++ b/lib/Service/ExternalPadSeeder.php
@@ -46,12 +46,12 @@ class ExternalPadSeeder {
 			$fileId,
 			$externalPadId,
 			BindingService::ACCESS_PUBLIC,
-			$external['pad_url'],
-			[
+			snapshot: new PadSnapshot($external['text'], null, 0),
+			padUrl: $external['pad_url'],
+			extraFrontmatter: [
 				'pad_origin' => $external['origin'],
 				'remote_pad_id' => $external['pad_id'],
 			],
-			new PadSnapshot($external['text'], null, 0),
 		);
 
 		$result = [

--- a/lib/Service/ExternalPadSeeder.php
+++ b/lib/Service/ExternalPadSeeder.php
@@ -46,13 +46,12 @@ class ExternalPadSeeder {
 			$fileId,
 			$externalPadId,
 			BindingService::ACCESS_PUBLIC,
-			$external['text'],
 			$external['pad_url'],
 			[
 				'pad_origin' => $external['origin'],
 				'remote_pad_id' => $external['pad_id'],
 			],
-			snapshotRev: 0,
+			new PadSnapshot($external['text'], null, 0),
 		);
 
 		$result = [

--- a/lib/Service/LifecycleService.php
+++ b/lib/Service/LifecycleService.php
@@ -185,7 +185,12 @@ class LifecycleService {
 					$snapshot = $this->etherpadClient->getText($padId);
 					$html = $this->etherpadClient->getHTML($padId);
 					$revision = $this->etherpadClient->getRevisionsCount($padId);
-					$updatedContent = $this->padFileService->withExportSnapshot($currentContent, $snapshot, $html, $revision);
+					$updatedContent = $this->padFileService->withExportSnapshot(
+						$this->padFileService->readPad($currentContent),
+						$snapshot,
+						$html,
+						$revision,
+					);
 				} catch (\Throwable $snapshotError) {
 					$this->logger->warning('Could not fetch fresh Etherpad snapshot during trash. Using current .pad snapshot/body.', [
 						'app' => 'etherpad_nextcloud',
@@ -312,13 +317,15 @@ class LifecycleService {
 				throw new LockedException('Injected test fault: restore_read_lock');
 			}
 			$currentContent = (string)$file->getContent();
-			$snapshot = $this->padFileService->getTextSnapshotForRestore($currentContent);
-			$htmlSnapshot = $this->padFileService->getHtmlSnapshotForRestore($currentContent);
+			$pad = $this->padFileService->readPad($currentContent);
+			$snapshotParts = $this->padFileService->getSnapshotPartsFromBody($pad->body);
+			$snapshot = $snapshotParts['text'];
+			$htmlSnapshot = $snapshotParts['html'];
 
 			$this->restoreSnapshotToManagedPad($fileId, $oldPadId, $newPadId, $snapshot, $htmlSnapshot);
 
 			$updatedContent = $this->padFileService->withStateAndSnapshot(
-				$currentContent,
+				$pad,
 				BindingService::STATE_ACTIVE,
 				$snapshot,
 				$newPadId,
@@ -449,7 +456,7 @@ class LifecycleService {
 			$managedPadCreated = true;
 			$this->restoreSnapshotToManagedPad($fileId, $oldPadId, $newPadId, $snapshot, $htmlSnapshot);
 			$updatedContent = $this->padFileService->withStateAndSnapshot(
-				$currentContent,
+				$pad,
 				BindingService::STATE_ACTIVE,
 				$snapshot,
 				$newPadId,

--- a/lib/Service/LifecycleService.php
+++ b/lib/Service/LifecycleService.php
@@ -324,12 +324,11 @@ class LifecycleService {
 
 			$this->restoreSnapshotToManagedPad($fileId, $oldPadId, $newPadId, $snapshot, $htmlSnapshot);
 
-			$updatedContent = $this->padFileService->withStateAndSnapshot(
+			$updatedContent = $this->padFileService->withRestoredSnapshot(
 				$pad,
-				BindingService::STATE_ACTIVE,
 				$snapshot,
+				$htmlSnapshot,
 				$newPadId,
-				null,
 				$this->etherpadClient->buildPadUrl($newPadId),
 			);
 			if ($this->isTestFaultActive(self::TEST_FAULT_RESTORE_WRITE_LOCK)) {
@@ -442,8 +441,7 @@ class LifecycleService {
 			if ($this->isTestFaultActive(self::TEST_FAULT_RESTORE_READ_LOCK)) {
 				throw new LockedException('Injected test fault: restore_read_lock');
 			}
-			$currentContent = (string)$file->getContent();
-			$pad = $this->padFileService->readPad($currentContent);
+			$pad = $this->padFileService->readPad((string)$file->getContent());
 			$oldPadId = $pad->padId;
 			$accessMode = $pad->accessMode;
 			if (str_starts_with($oldPadId, 'ext.') || $pad->isExternal) {
@@ -455,12 +453,11 @@ class LifecycleService {
 			$newPadId = $this->provisionRestorePadId($accessMode, $oldPadId);
 			$managedPadCreated = true;
 			$this->restoreSnapshotToManagedPad($fileId, $oldPadId, $newPadId, $snapshot, $htmlSnapshot);
-			$updatedContent = $this->padFileService->withStateAndSnapshot(
+			$updatedContent = $this->padFileService->withRestoredSnapshot(
 				$pad,
-				BindingService::STATE_ACTIVE,
 				$snapshot,
+				$htmlSnapshot,
 				$newPadId,
-				null,
 				$this->etherpadClient->buildPadUrl($newPadId),
 			);
 			// Claim the binding row before touching the file. The unique

--- a/lib/Service/LifecycleService.php
+++ b/lib/Service/LifecycleService.php
@@ -187,9 +187,7 @@ class LifecycleService {
 					$revision = $this->etherpadClient->getRevisionsCount($padId);
 					$updatedContent = $this->padFileService->withExportSnapshot(
 						$this->padFileService->readPad($currentContent),
-						$snapshot,
-						$html,
-						$revision,
+						new PadSnapshot($snapshot, $html, $revision),
 					);
 				} catch (\Throwable $snapshotError) {
 					$this->logger->warning('Could not fetch fresh Etherpad snapshot during trash. Using current .pad snapshot/body.', [

--- a/lib/Service/PadBootstrapService.php
+++ b/lib/Service/PadBootstrapService.php
@@ -129,7 +129,7 @@ class PadBootstrapService {
 			}
 
 			$padUrl = $this->etherpadClient->buildPadUrl($padId);
-			$doc = $this->padFileService->buildInitialDocument($fileId, $padId, $accessMode, '', $padUrl);
+			$doc = $this->padFileService->buildInitialDocument($fileId, $padId, $accessMode, $padUrl);
 			// Re-resolve after provisioning: the original File still writes to its remembered path.
 			$this->writeInitialDocument($uid, $fileId, $existingContent, $doc);
 		} catch (\Throwable $e) {

--- a/lib/Service/PadBootstrapService.php
+++ b/lib/Service/PadBootstrapService.php
@@ -129,7 +129,7 @@ class PadBootstrapService {
 			}
 
 			$padUrl = $this->etherpadClient->buildPadUrl($padId);
-			$doc = $this->padFileService->buildInitialDocument($fileId, $padId, $accessMode, $padUrl);
+			$doc = $this->padFileService->buildInitialDocument($fileId, $padId, $accessMode, padUrl: $padUrl);
 			// Re-resolve after provisioning: the original File still writes to its remembered path.
 			$this->writeInitialDocument($uid, $fileId, $existingContent, $doc);
 		} catch (\Throwable $e) {

--- a/lib/Service/PadCreationService.php
+++ b/lib/Service/PadCreationService.php
@@ -371,8 +371,8 @@ class PadCreationService {
 				$fileId,
 				$padId,
 				$accessMode,
-				$padUrl,
 				snapshot: new PadSnapshot($resolvedText, $resolvedHtml, 0),
+				padUrl: $padUrl,
 			);
 			$this->writeCreatedFile($claim, $content);
 			$this->bindingService->createBinding($fileId, $padId, $accessMode);
@@ -464,7 +464,7 @@ class PadCreationService {
 		$attempt->recordPad($padId);
 		$padUrl = $this->etherpadClient->buildPadUrl($padId);
 
-		$content = $this->padFileService->buildInitialDocument($fileId, $padId, $accessMode, $padUrl);
+		$content = $this->padFileService->buildInitialDocument($fileId, $padId, $accessMode, padUrl: $padUrl);
 		$this->writeCreatedFile($claim, $content);
 		$this->bindingService->createBinding($fileId, $padId, $accessMode);
 

--- a/lib/Service/PadCreationService.php
+++ b/lib/Service/PadCreationService.php
@@ -371,10 +371,8 @@ class PadCreationService {
 				$fileId,
 				$padId,
 				$accessMode,
-				$resolvedText,
 				$padUrl,
-				snapshotHtml: $resolvedHtml,
-				snapshotRev: 0,
+				snapshot: new PadSnapshot($resolvedText, $resolvedHtml, 0),
 			);
 			$this->writeCreatedFile($claim, $content);
 			$this->bindingService->createBinding($fileId, $padId, $accessMode);
@@ -466,7 +464,7 @@ class PadCreationService {
 		$attempt->recordPad($padId);
 		$padUrl = $this->etherpadClient->buildPadUrl($padId);
 
-		$content = $this->padFileService->buildInitialDocument($fileId, $padId, $accessMode, '', $padUrl);
+		$content = $this->padFileService->buildInitialDocument($fileId, $padId, $accessMode, $padUrl);
 		$this->writeCreatedFile($claim, $content);
 		$this->bindingService->createBinding($fileId, $padId, $accessMode);
 

--- a/lib/Service/PadCreationService.php
+++ b/lib/Service/PadCreationService.php
@@ -373,13 +373,8 @@ class PadCreationService {
 				$accessMode,
 				$resolvedText,
 				$padUrl,
-			);
-			$content = $this->padFileService->withExportSnapshot(
-				$content,
-				$resolvedText,
-				$resolvedHtml,
-				0,
-				true,
+				snapshotHtml: $resolvedHtml,
+				snapshotRev: 0,
 			);
 			$this->writeCreatedFile($claim, $content);
 			$this->bindingService->createBinding($fileId, $padId, $accessMode);

--- a/lib/Service/PadFileService.php
+++ b/lib/Service/PadFileService.php
@@ -73,9 +73,9 @@ class PadFileService {
 		int $fileId,
 		string $padId,
 		string $accessMode,
+		?PadSnapshot $snapshot = null,
 		?string $padUrl = null,
 		array $extraFrontmatter = [],
-		?PadSnapshot $snapshot = null,
 	): string {
 		$now = gmdate('c');
 		$frontmatter = [
@@ -105,10 +105,7 @@ class PadFileService {
 		// sectioned body here rather than building a document and parsing it
 		// straight back to put the snapshot in.
 		$frontmatter['snapshot_rev'] = $snapshot->revision;
-		return $this->serialize(
-			$frontmatter,
-			$this->buildSnapshotBody($snapshot->text, $snapshot->html ?? '', $snapshot->html !== null),
-		);
+		return $this->serialize($frontmatter, $this->snapshotBody($snapshot));
 	}
 
 	/** @return array{url: string, pad_id: string}|null */
@@ -175,6 +172,7 @@ class PadFileService {
 			accessMode: $meta['access_mode'],
 			padUrl: $meta['pad_url'],
 			isExternal: $this->isExternalFrontmatter($frontmatter, $padId),
+			snapshotRev: $this->getSnapshotRevisionFromFrontmatter($frontmatter),
 		);
 	}
 
@@ -217,28 +215,23 @@ class PadFileService {
 		$frontmatter['updated_at'] = gmdate('c');
 		$frontmatter['deleted_at'] = null;
 		$frontmatter['pad_id'] = $padId;
-		$frontmatter['pad_url'] = $padUrl;
+		if ($padUrl !== '') {
+			$frontmatter['pad_url'] = $padUrl;
+		}
 
 		return $this->serialize($frontmatter, $this->buildSnapshotBody($text, $html));
 	}
 
-	/** @throws PadFileFormatException */
-	public function withExportSnapshot(ParsedPadFile $pad, string $text, string $html, int $exportedRev, bool $includeHtmlSection = true): string {
-		// Same rule as PadSnapshot: -1 is the format's "never synced", so a
-		// snapshot cannot be written at a negative revision. Raising it to 0
-		// instead would leave a never-synced pad looking synced.
-		if ($exportedRev < 0) {
-			throw new PadFileFormatException('A snapshot revision cannot be negative.');
-		}
+	public function withExportSnapshot(ParsedPadFile $pad, PadSnapshot $snapshot): string {
 		$frontmatter = $pad->frontmatter;
 		$frontmatter['updated_at'] = gmdate('c');
-		$frontmatter['snapshot_rev'] = $exportedRev;
+		$frontmatter['snapshot_rev'] = $snapshot->revision;
 
-		return $this->serialize($frontmatter, $this->buildSnapshotBody($text, $html, $includeHtmlSection));
+		return $this->serialize($frontmatter, $this->snapshotBody($snapshot));
 	}
 
 	/** @param array<string,mixed> $frontmatter */
-	public function getSnapshotRevisionFromFrontmatter(array $frontmatter): int {
+	private function getSnapshotRevisionFromFrontmatter(array $frontmatter): int {
 		$rev = $frontmatter['snapshot_rev'] ?? null;
 		if (!is_numeric($rev)) {
 			return -1;
@@ -412,6 +405,10 @@ class PadFileService {
 			throw new PadFileFormatException('Invalid ' . $key . ' in frontmatter.');
 		}
 		return (string)$value;
+	}
+
+	private function snapshotBody(PadSnapshot $snapshot): string {
+		return $this->buildSnapshotBody($snapshot->text, $snapshot->html ?? '', $snapshot->html !== null);
 	}
 
 	private function buildSnapshotBody(string $text, string $html, bool $includeHtmlSection = true): string {

--- a/lib/Service/PadFileService.php
+++ b/lib/Service/PadFileService.php
@@ -64,13 +64,23 @@ class PadFileService {
 		return "---\n" . implode("\n", $lines) . "\n---\n" . $body;
 	}
 
+	/**
+	 * @param array<string,mixed> $extraFrontmatter
+	 * @param ?string $snapshotHtml an HTML half for the snapshot body, or null
+	 *                              for a text-only one
+	 * @param ?int $snapshotRev the revision the snapshot was taken at; null
+	 *                          leaves the document unsnapshotted, which is
+	 *                          what a pad that starts empty wants
+	 */
 	public function buildInitialDocument(
 		int $fileId,
 		string $padId,
 		string $accessMode,
 		string $snapshot = '',
 		?string $padUrl = null,
-		array $extraFrontmatter = []
+		array $extraFrontmatter = [],
+		?string $snapshotHtml = null,
+		?int $snapshotRev = null,
 	): string {
 		$now = gmdate('c');
 		$frontmatter = [
@@ -92,7 +102,18 @@ class PadFileService {
 				$frontmatter[$key] = (string)$value;
 			}
 		}
-		return $this->serialize($frontmatter, $snapshot);
+		if ($snapshotRev === null) {
+			return $this->serialize($frontmatter, $snapshot);
+		}
+
+		// A caller that arrives with content already in hand gets the
+		// sectioned body here rather than building a document and parsing it
+		// straight back to put the snapshot in.
+		$frontmatter['snapshot_rev'] = max(0, $snapshotRev);
+		return $this->serialize(
+			$frontmatter,
+			$this->buildSnapshotBody($snapshot, $snapshotHtml ?? '', $snapshotHtml !== null),
+		);
 	}
 
 	/** @return array{url: string, pad_id: string}|null */
@@ -182,16 +203,15 @@ class PadFileService {
 	}
 
 	public function withStateAndSnapshot(
-		string $content,
+		ParsedPadFile $pad,
 		string $state,
 		string $snapshot,
 		?string $padId = null,
 		?int $deletedAtTs = null,
 		?string $padUrl = null
 	): string {
-		$parsed = $this->parsePadFile($content);
-		$frontmatter = $parsed['frontmatter'];
-		$bodyParts = $this->splitSnapshotBody((string)$parsed['body']);
+		$frontmatter = $pad->frontmatter;
+		$bodyParts = $this->splitSnapshotBody($pad->body);
 		$frontmatter['state'] = $state;
 		$frontmatter['updated_at'] = gmdate('c');
 		$frontmatter['deleted_at'] = $deletedAtTs === null ? null : gmdate('c', $deletedAtTs);
@@ -205,18 +225,12 @@ class PadFileService {
 		return $this->serialize($frontmatter, $this->buildSnapshotBody($snapshot, $bodyParts['html']));
 	}
 
-	public function withExportSnapshot(string $content, string $text, string $html, int $exportedRev, bool $includeHtmlSection = true): string {
-		$parsed = $this->parsePadFile($content);
-		$frontmatter = $parsed['frontmatter'];
+	public function withExportSnapshot(ParsedPadFile $pad, string $text, string $html, int $exportedRev, bool $includeHtmlSection = true): string {
+		$frontmatter = $pad->frontmatter;
 		$frontmatter['updated_at'] = gmdate('c');
 		$frontmatter['snapshot_rev'] = max(0, $exportedRev);
 
 		return $this->serialize($frontmatter, $this->buildSnapshotBody($text, $html, $includeHtmlSection));
-	}
-
-	public function getSnapshotRevision(string $content): int {
-		$parsed = $this->parsePadFile($content);
-		return $this->getSnapshotRevisionFromFrontmatter($parsed['frontmatter']);
 	}
 
 	/** @param array<string,mixed> $frontmatter */
@@ -226,16 +240,6 @@ class PadFileService {
 			return -1;
 		}
 		return (int)$rev;
-	}
-
-	public function getTextSnapshotForRestore(string $content): string {
-		$parsed = $this->parsePadFile($content);
-		return $this->getSnapshotPartsFromBody((string)$parsed['body'])['text'];
-	}
-
-	public function getHtmlSnapshotForRestore(string $content): string {
-		$parsed = $this->parsePadFile($content);
-		return $this->getSnapshotPartsFromBody((string)$parsed['body'])['html'];
 	}
 
 	/** @return array{text:string,html:string} */

--- a/lib/Service/PadFileService.php
+++ b/lib/Service/PadFileService.php
@@ -66,21 +66,16 @@ class PadFileService {
 
 	/**
 	 * @param array<string,mixed> $extraFrontmatter
-	 * @param ?string $snapshotHtml an HTML half for the snapshot body, or null
-	 *                              for a text-only one
-	 * @param ?int $snapshotRev the revision the snapshot was taken at; null
-	 *                          leaves the document unsnapshotted, which is
-	 *                          what a pad that starts empty wants
+	 * @param ?PadSnapshot $snapshot content the document starts out with, or
+	 *                               null for a pad that starts empty
 	 */
 	public function buildInitialDocument(
 		int $fileId,
 		string $padId,
 		string $accessMode,
-		string $snapshot = '',
 		?string $padUrl = null,
 		array $extraFrontmatter = [],
-		?string $snapshotHtml = null,
-		?int $snapshotRev = null,
+		?PadSnapshot $snapshot = null,
 	): string {
 		$now = gmdate('c');
 		$frontmatter = [
@@ -102,17 +97,17 @@ class PadFileService {
 				$frontmatter[$key] = (string)$value;
 			}
 		}
-		if ($snapshotRev === null) {
-			return $this->serialize($frontmatter, $snapshot);
+		if ($snapshot === null) {
+			return $this->serialize($frontmatter, '');
 		}
 
 		// A caller that arrives with content already in hand gets the
 		// sectioned body here rather than building a document and parsing it
 		// straight back to put the snapshot in.
-		$frontmatter['snapshot_rev'] = max(0, $snapshotRev);
+		$frontmatter['snapshot_rev'] = $snapshot->revision;
 		return $this->serialize(
 			$frontmatter,
-			$this->buildSnapshotBody($snapshot, $snapshotHtml ?? '', $snapshotHtml !== null),
+			$this->buildSnapshotBody($snapshot->text, $snapshot->html ?? '', $snapshot->html !== null),
 		);
 	}
 

--- a/lib/Service/PadFileService.php
+++ b/lib/Service/PadFileService.php
@@ -197,27 +197,29 @@ class PadFileService {
 		return str_starts_with($padId, 'ext.') && $remotePadId !== '' && $padOrigin !== '';
 	}
 
-	public function withStateAndSnapshot(
+	/**
+	 * The document a restore writes: active again, no deletion timestamp, and
+	 * pointed at the pad that was provisioned to replace the old one.
+	 *
+	 * The caller has already split the snapshot it is restoring, so both
+	 * halves arrive here rather than the body being taken apart a second time
+	 * to recover the HTML.
+	 */
+	public function withRestoredSnapshot(
 		ParsedPadFile $pad,
-		string $state,
-		string $snapshot,
-		?string $padId = null,
-		?int $deletedAtTs = null,
-		?string $padUrl = null
+		string $text,
+		string $html,
+		string $padId,
+		string $padUrl,
 	): string {
 		$frontmatter = $pad->frontmatter;
-		$bodyParts = $this->splitSnapshotBody($pad->body);
-		$frontmatter['state'] = $state;
+		$frontmatter['state'] = BindingService::STATE_ACTIVE;
 		$frontmatter['updated_at'] = gmdate('c');
-		$frontmatter['deleted_at'] = $deletedAtTs === null ? null : gmdate('c', $deletedAtTs);
-		if ($padId !== null) {
-			$frontmatter['pad_id'] = $padId;
-		}
-		if ($padUrl !== null) {
-			$frontmatter['pad_url'] = $padUrl;
-		}
+		$frontmatter['deleted_at'] = null;
+		$frontmatter['pad_id'] = $padId;
+		$frontmatter['pad_url'] = $padUrl;
 
-		return $this->serialize($frontmatter, $this->buildSnapshotBody($snapshot, $bodyParts['html']));
+		return $this->serialize($frontmatter, $this->buildSnapshotBody($text, $html));
 	}
 
 	/** @throws PadFileFormatException */

--- a/lib/Service/PadFileService.php
+++ b/lib/Service/PadFileService.php
@@ -220,10 +220,17 @@ class PadFileService {
 		return $this->serialize($frontmatter, $this->buildSnapshotBody($snapshot, $bodyParts['html']));
 	}
 
+	/** @throws PadFileFormatException */
 	public function withExportSnapshot(ParsedPadFile $pad, string $text, string $html, int $exportedRev, bool $includeHtmlSection = true): string {
+		// Same rule as PadSnapshot: -1 is the format's "never synced", so a
+		// snapshot cannot be written at a negative revision. Raising it to 0
+		// instead would leave a never-synced pad looking synced.
+		if ($exportedRev < 0) {
+			throw new PadFileFormatException('A snapshot revision cannot be negative.');
+		}
 		$frontmatter = $pad->frontmatter;
 		$frontmatter['updated_at'] = gmdate('c');
-		$frontmatter['snapshot_rev'] = max(0, $exportedRev);
+		$frontmatter['snapshot_rev'] = $exportedRev;
 
 		return $this->serialize($frontmatter, $this->buildSnapshotBody($text, $html, $includeHtmlSection));
 	}

--- a/lib/Service/PadLegacyMigrationService.php
+++ b/lib/Service/PadLegacyMigrationService.php
@@ -222,7 +222,7 @@ class PadLegacyMigrationService {
 			$fileId,
 			$padId,
 			$accessMode,
-			$padUrl,
+			padUrl: $padUrl,
 		);
 		$file->putContent($content);
 	}

--- a/lib/Service/PadLegacyMigrationService.php
+++ b/lib/Service/PadLegacyMigrationService.php
@@ -222,7 +222,6 @@ class PadLegacyMigrationService {
 			$fileId,
 			$padId,
 			$accessMode,
-			'',
 			$padUrl,
 		);
 		$file->putContent($content);

--- a/lib/Service/PadSnapshot.php
+++ b/lib/Service/PadSnapshot.php
@@ -8,8 +8,6 @@ declare(strict_types=1);
 
 namespace OCA\EtherpadNextcloud\Service;
 
-use OCA\EtherpadNextcloud\Exception\PadFileFormatException;
-
 /**
  * Content a `.pad` starts out with, as one value.
  *
@@ -21,7 +19,7 @@ class PadSnapshot {
 	/**
 	 * @param ?string $html the HTML half, or null for a text-only snapshot —
 	 *                      which is not the same as an empty HTML half
-	 * @throws PadFileFormatException
+	 * @throws \InvalidArgumentException
 	 */
 	public function __construct(
 		public readonly string $text,
@@ -30,9 +28,10 @@ class PadSnapshot {
 	) {
 		// -1 is how the format says "no snapshot yet"; a snapshot that exists
 		// cannot be at that revision, and silently raising it to 0 would make
-		// a never-synced pad look synced.
+		// a never-synced pad look synced. This is a caller's mistake, so it is
+		// not the exception that tells a user their .pad is malformed.
 		if ($revision < 0) {
-			throw new PadFileFormatException('A snapshot revision cannot be negative.');
+			throw new \InvalidArgumentException('A snapshot revision cannot be negative.');
 		}
 	}
 }

--- a/lib/Service/PadSnapshot.php
+++ b/lib/Service/PadSnapshot.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * Copyright (c) 2026 Jacob Bühler
+ */
+
+namespace OCA\EtherpadNextcloud\Service;
+
+use OCA\EtherpadNextcloud\Exception\PadFileFormatException;
+
+/**
+ * Content a `.pad` starts out with, as one value.
+ *
+ * A document either carries a snapshot or does not, and the two cases write
+ * different bodies. Passing the text, its HTML half and the revision
+ * separately let a caller ask for half of one and half of the other.
+ */
+class PadSnapshot {
+	/**
+	 * @param ?string $html the HTML half, or null for a text-only snapshot —
+	 *                      which is not the same as an empty HTML half
+	 * @throws PadFileFormatException
+	 */
+	public function __construct(
+		public readonly string $text,
+		public readonly ?string $html,
+		public readonly int $revision,
+	) {
+		// -1 is how the format says "no snapshot yet"; a snapshot that exists
+		// cannot be at that revision, and silently raising it to 0 would make
+		// a never-synced pad look synced.
+		if ($revision < 0) {
+			throw new PadFileFormatException('A snapshot revision cannot be negative.');
+		}
+	}
+}

--- a/lib/Service/PadSyncService.php
+++ b/lib/Service/PadSyncService.php
@@ -108,7 +108,7 @@ class PadSyncService {
 			}
 
 			$currentRev = $this->etherpadClient->getRevisionsCount($padId);
-			$snapshotRev = $this->padFileService->getSnapshotRevisionFromFrontmatter($pad->frontmatter);
+			$snapshotRev = $pad->snapshotRev;
 			$inSync = $snapshotRev >= $currentRev;
 
 			return new PadSyncStatus(
@@ -156,9 +156,9 @@ class PadSyncService {
 			);
 		}
 
-		$previousRev = $this->padFileService->getSnapshotRevisionFromFrontmatter($pad->frontmatter);
+		$previousRev = $pad->snapshotRev;
 		$nextRev = max(0, $previousRev + 1);
-		$updatedContent = $this->padFileService->withExportSnapshot($pad, $text, '', $nextRev, false);
+		$updatedContent = $this->padFileService->withExportSnapshot($pad, new PadSnapshot($text, null, $nextRev));
 		$lockRetries = $this->lockRetryService->putContentWithSyncLockRetry($node, $updatedContent);
 
 		return new PadSyncResult(
@@ -180,7 +180,7 @@ class PadSyncService {
 	): PadSyncResult {
 		$padId = $pad->padId;
 		$currentRev = $this->etherpadClient->getRevisionsCount($padId);
-		$snapshotRev = $this->padFileService->getSnapshotRevisionFromFrontmatter($pad->frontmatter);
+		$snapshotRev = $pad->snapshotRev;
 		if (!$force && $snapshotRev >= $currentRev) {
 			return new PadSyncResult(
 				status: self::STATUS_UNCHANGED,
@@ -211,7 +211,7 @@ class PadSyncService {
 			}
 		}
 
-		$updatedContent = $this->padFileService->withExportSnapshot($pad, $text, $html, $currentRev);
+		$updatedContent = $this->padFileService->withExportSnapshot($pad, new PadSnapshot($text, $html, $currentRev));
 		$lockRetries = $this->lockRetryService->putContentWithSyncLockRetry($node, $updatedContent);
 
 		return new PadSyncResult(

--- a/lib/Service/PadSyncService.php
+++ b/lib/Service/PadSyncService.php
@@ -53,8 +53,7 @@ class PadSyncService {
 		$lockRetries = 0;
 
 		try {
-			$currentContent = (string)$node->getContent();
-			$pad = $this->padFileService->readPad((string)$currentContent);
+			$pad = $this->padFileService->readPad((string)$node->getContent());
 			$padId = $pad->padId;
 			$accessMode = $pad->accessMode;
 			$padUrl = $pad->padUrl;
@@ -64,10 +63,10 @@ class PadSyncService {
 			}
 
 			if ($isExternal) {
-				return $this->syncExternalPad($node, $fileId, $padId, $padUrl, (string)$currentContent, $force);
+				return $this->syncExternalPad($node, $fileId, $padId, $padUrl, $pad, $force);
 			}
 
-			return $this->syncInternalPad($node, $fileId, $padId, (string)$currentContent, $force);
+			return $this->syncInternalPad($node, $fileId, $padId, $pad, $force);
 		} catch (PadFileLockRetryExhaustedException $e) {
 			$lockRetries = $e->getRetryAttempts();
 			return $this->lockedSyncResponse($e->getLockedException(), $fileId, $absolutePath, $padId, $accessMode, $isExternal, $force, $lockRetries);
@@ -94,8 +93,7 @@ class PadSyncService {
 		$node = $this->userNodeResolver->resolveUserFileNodeById($uid, $fileId);
 
 		try {
-			$content = (string)$node->getContent();
-			$pad = $this->padFileService->readPad((string)$content);
+			$pad = $this->padFileService->readPad((string)$node->getContent());
 			$padId = $pad->padId;
 			$accessMode = $pad->accessMode;
 			$isExternal = $pad->isExternal;
@@ -111,7 +109,7 @@ class PadSyncService {
 			}
 
 			$currentRev = $this->etherpadClient->getRevisionsCount($padId);
-			$snapshotRev = $this->padFileService->getSnapshotRevision((string)$content);
+			$snapshotRev = $this->padFileService->getSnapshotRevisionFromFrontmatter($pad->frontmatter);
 			$inSync = $snapshotRev >= $currentRev;
 
 			return new PadSyncStatus(
@@ -137,7 +135,7 @@ class PadSyncService {
 		int $fileId,
 		string $padId,
 		string $padUrl,
-		string $currentContent,
+		ParsedPadFile $pad,
 		bool $force,
 	): PadSyncResult {
 		if ($padUrl === '') {
@@ -148,7 +146,7 @@ class PadSyncService {
 		$external = $this->externalPadExportFetcher->normalizeAndFetchExternalPublicPadText($padUrl);
 		$text = $external['text'];
 
-		$existingText = $this->padFileService->getTextSnapshotForRestore($currentContent);
+		$existingText = $this->padFileService->getSnapshotPartsFromBody($pad->body)['text'];
 		if ($existingText === $text) {
 			return new PadSyncResult(
 				status: self::STATUS_UNCHANGED,
@@ -159,9 +157,9 @@ class PadSyncService {
 			);
 		}
 
-		$previousRev = $this->padFileService->getSnapshotRevision($currentContent);
+		$previousRev = $this->padFileService->getSnapshotRevisionFromFrontmatter($pad->frontmatter);
 		$nextRev = max(0, $previousRev + 1);
-		$updatedContent = $this->padFileService->withExportSnapshot($currentContent, $text, '', $nextRev, false);
+		$updatedContent = $this->padFileService->withExportSnapshot($pad, $text, '', $nextRev, false);
 		$lockRetries = $this->lockRetryService->putContentWithSyncLockRetry($node, $updatedContent);
 
 		return new PadSyncResult(
@@ -179,11 +177,11 @@ class PadSyncService {
 		File $node,
 		int $fileId,
 		string $padId,
-		string $currentContent,
+		ParsedPadFile $pad,
 		bool $force,
 	): PadSyncResult {
 		$currentRev = $this->etherpadClient->getRevisionsCount($padId);
-		$snapshotRev = $this->padFileService->getSnapshotRevision($currentContent);
+		$snapshotRev = $this->padFileService->getSnapshotRevisionFromFrontmatter($pad->frontmatter);
 		if (!$force && $snapshotRev >= $currentRev) {
 			return new PadSyncResult(
 				status: self::STATUS_UNCHANGED,
@@ -200,9 +198,8 @@ class PadSyncService {
 		$html = $this->etherpadClient->getHTML($padId);
 		if ($force && $snapshotRev >= $currentRev) {
 			// force=1 bypasses the cheap revision short-circuit and performs a live content re-check.
-			$existingText = $this->padFileService->getTextSnapshotForRestore($currentContent);
-			$existingHtml = $this->padFileService->getHtmlSnapshotForRestore($currentContent);
-			if ($existingText === $text && $existingHtml === $html) {
+			$existing = $this->padFileService->getSnapshotPartsFromBody($pad->body);
+			if ($existing['text'] === $text && $existing['html'] === $html) {
 				return new PadSyncResult(
 					status: self::STATUS_UNCHANGED,
 					fileId: $fileId,
@@ -215,7 +212,7 @@ class PadSyncService {
 			}
 		}
 
-		$updatedContent = $this->padFileService->withExportSnapshot($currentContent, $text, $html, $currentRev);
+		$updatedContent = $this->padFileService->withExportSnapshot($pad, $text, $html, $currentRev);
 		$lockRetries = $this->lockRetryService->putContentWithSyncLockRetry($node, $updatedContent);
 
 		return new PadSyncResult(

--- a/lib/Service/PadSyncService.php
+++ b/lib/Service/PadSyncService.php
@@ -56,17 +56,16 @@ class PadSyncService {
 			$pad = $this->padFileService->readPad((string)$node->getContent());
 			$padId = $pad->padId;
 			$accessMode = $pad->accessMode;
-			$padUrl = $pad->padUrl;
 			$isExternal = $pad->isExternal;
 			if (!$isExternal) {
 				$this->bindingService->assertConsistentMapping($fileId, $padId, $accessMode);
 			}
 
 			if ($isExternal) {
-				return $this->syncExternalPad($node, $fileId, $padId, $padUrl, $pad, $force);
+				return $this->syncExternalPad($node, $fileId, $pad, $force);
 			}
 
-			return $this->syncInternalPad($node, $fileId, $padId, $pad, $force);
+			return $this->syncInternalPad($node, $fileId, $pad, $force);
 		} catch (PadFileLockRetryExhaustedException $e) {
 			$lockRetries = $e->getRetryAttempts();
 			return $this->lockedSyncResponse($e->getLockedException(), $fileId, $absolutePath, $padId, $accessMode, $isExternal, $force, $lockRetries);
@@ -133,11 +132,11 @@ class PadSyncService {
 	private function syncExternalPad(
 		File $node,
 		int $fileId,
-		string $padId,
-		string $padUrl,
 		ParsedPadFile $pad,
 		bool $force,
 	): PadSyncResult {
+		$padId = $pad->padId;
+		$padUrl = $pad->padUrl;
 		if ($padUrl === '') {
 			throw new EtherpadClientException('External pad URL metadata is missing or invalid.');
 		}
@@ -176,10 +175,10 @@ class PadSyncService {
 	private function syncInternalPad(
 		File $node,
 		int $fileId,
-		string $padId,
 		ParsedPadFile $pad,
 		bool $force,
 	): PadSyncResult {
+		$padId = $pad->padId;
 		$currentRev = $this->etherpadClient->getRevisionsCount($padId);
 		$snapshotRev = $this->padFileService->getSnapshotRevisionFromFrontmatter($pad->frontmatter);
 		if (!$force && $snapshotRev >= $currentRev) {

--- a/lib/Service/ParsedPadFile.php
+++ b/lib/Service/ParsedPadFile.php
@@ -25,6 +25,7 @@ class ParsedPadFile {
 		public readonly string $accessMode,
 		public readonly string $padUrl,
 		public readonly bool $isExternal,
+		public readonly int $snapshotRev,
 	) {
 	}
 }

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -188,11 +188,6 @@
       <code><![CDATA[__construct]]></code>
     </PossiblyUnusedMethod>
   </file>
-  <file src="lib/Service/ParsedPadFile.php">
-    <PossiblyUnusedProperty>
-      <code><![CDATA[$frontmatter]]></code>
-    </PossiblyUnusedProperty>
-  </file>
   <file src="lib/Service/PendingDeleteRetryService.php">
     <PossiblyUnusedMethod>
       <code><![CDATA[__construct]]></code>

--- a/tests/phpunit/unit/ExternalPadSeederTest.php
+++ b/tests/phpunit/unit/ExternalPadSeederTest.php
@@ -37,12 +37,12 @@ class ExternalPadSeederTest extends TestCase {
 				999,
 				'ext.RemotePad',
 				BindingService::ACCESS_PUBLIC,
+				new PadSnapshot('snapshot-body', null, 0),
 				'https://pad.remote.test/p/RemotePad',
 				[
 					'pad_origin' => 'https://pad.remote.test',
 					'remote_pad_id' => 'RemotePad',
 				],
-				new PadSnapshot('snapshot-body', null, 0),
 			)
 			->willReturn('seeded-frontmatter');
 		$padFileService->expects($this->never())->method('withExportSnapshot');

--- a/tests/phpunit/unit/ExternalPadSeederTest.php
+++ b/tests/phpunit/unit/ExternalPadSeederTest.php
@@ -36,18 +36,17 @@ class ExternalPadSeederTest extends TestCase {
 				999,
 				'ext.RemotePad',
 				BindingService::ACCESS_PUBLIC,
-				'',
+				'snapshot-body',
 				'https://pad.remote.test/p/RemotePad',
 				[
 					'pad_origin' => 'https://pad.remote.test',
 					'remote_pad_id' => 'RemotePad',
 				],
+				null,
+				0,
 			)
-			->willReturn('initial-doc');
-		$padFileService->expects($this->once())
-			->method('withExportSnapshot')
-			->with('initial-doc', 'snapshot-body', '', 0, false)
 			->willReturn('seeded-frontmatter');
+		$padFileService->expects($this->never())->method('withExportSnapshot');
 
 		$result = (new ExternalPadSeeder($padFileService, $fetcher))
 			->seed($fileNode, 999, 'https://pad.remote.test/p/RemotePad');
@@ -73,7 +72,6 @@ class ExternalPadSeederTest extends TestCase {
 
 		$padFileService = $this->createMock(PadFileService::class);
 		$padFileService->method('buildInitialDocument')->willReturn('doc');
-		$padFileService->method('withExportSnapshot')->willReturn('doc');
 
 		$result = (new ExternalPadSeeder($padFileService, $fetcher))
 			->seed($this->createMock(File::class), 1, 'https://pad.remote.test/p/RemotePad');

--- a/tests/phpunit/unit/ExternalPadSeederTest.php
+++ b/tests/phpunit/unit/ExternalPadSeederTest.php
@@ -8,6 +8,7 @@ use OCA\EtherpadNextcloud\Service\BindingService;
 use OCA\EtherpadNextcloud\Service\ExternalPadExportFetcher;
 use OCA\EtherpadNextcloud\Service\ExternalPadSeeder;
 use OCA\EtherpadNextcloud\Service\PadFileService;
+use OCA\EtherpadNextcloud\Service\PadSnapshot;
 use OCP\Files\File;
 use PHPUnit\Framework\TestCase;
 
@@ -36,14 +37,12 @@ class ExternalPadSeederTest extends TestCase {
 				999,
 				'ext.RemotePad',
 				BindingService::ACCESS_PUBLIC,
-				'snapshot-body',
 				'https://pad.remote.test/p/RemotePad',
 				[
 					'pad_origin' => 'https://pad.remote.test',
 					'remote_pad_id' => 'RemotePad',
 				],
-				null,
-				0,
+				new PadSnapshot('snapshot-body', null, 0),
 			)
 			->willReturn('seeded-frontmatter');
 		$padFileService->expects($this->never())->method('withExportSnapshot');

--- a/tests/phpunit/unit/LifecycleServiceTest.php
+++ b/tests/phpunit/unit/LifecycleServiceTest.php
@@ -111,17 +111,18 @@ class LifecycleServiceTest extends TestCase {
 		$padFileService = $this->createMock(PadFileService::class);
 		$padFileService->expects($this->never())->method('parsePadFile');
 		$padFileService->expects($this->never())->method('isExternalFrontmatter');
-		$padFileService->method('readPad')->with('doc-current')->willReturn(new ParsedPadFile(
+		$parsedPad = new ParsedPadFile(
 			frontmatter: [],
 			body: '',
 			padId: $padId,
 			accessMode: BindingService::ACCESS_PUBLIC,
 			padUrl: '',
 			isExternal: false,
-		));
+		);
+		$padFileService->method('readPad')->with('doc-current')->willReturn($parsedPad);
 		$padFileService->expects($this->once())
 			->method('withExportSnapshot')
-			->with($this->isInstanceOf(ParsedPadFile::class), 'snapshot-text', '<p>snapshot-html</p>', 7)
+			->with($this->identicalTo($parsedPad), 'snapshot-text', '<p>snapshot-html</p>', 7)
 			->willReturn('doc-trash-updated');
 
 		$etherpadClient = $this->createMock(EtherpadClient::class);
@@ -295,15 +296,16 @@ class LifecycleServiceTest extends TestCase {
 		$bindingService->method('isBoundTo')->with($fileId, $newPadId)->willReturn(true);
 
 		$padFileService = $this->createMock(PadFileService::class);
-		$padFileService->method('readPad')->willReturn(new ParsedPadFile(
+		$parsedPad = new ParsedPadFile(
 			frontmatter: [],
 			body: 'body',
 			padId: $oldPadId,
 			accessMode: BindingService::ACCESS_PUBLIC,
 			padUrl: '',
 			isExternal: false,
-		));
-		$padFileService->method('getSnapshotPartsFromBody')->willReturn(['text' => 'plain text', 'html' => '']);
+		);
+		$padFileService->method('readPad')->with('doc-before')->willReturn($parsedPad);
+		$padFileService->method('getSnapshotPartsFromBody')->with($parsedPad->body)->willReturn(['text' => 'plain text', 'html' => '']);
 		$padFileService->method('withStateAndSnapshot')->willReturn('doc-after');
 
 		$etherpadClient = $this->createMock(EtherpadClient::class);
@@ -353,15 +355,16 @@ class LifecycleServiceTest extends TestCase {
 		$bindingService->expects($this->once())->method('markRestored')->with($fileId, $newPadId);
 
 		$padFileService = $this->createMock(PadFileService::class);
-		$padFileService->method('readPad')->willReturn(new ParsedPadFile(
+		$parsedPad = new ParsedPadFile(
 			frontmatter: [],
 			body: 'body',
 			padId: $oldPadId,
 			accessMode: BindingService::ACCESS_PUBLIC,
 			padUrl: '',
 			isExternal: false,
-		));
-		$padFileService->method('getSnapshotPartsFromBody')->willReturn(['text' => 'plain text', 'html' => '']);
+		);
+		$padFileService->method('readPad')->with('doc-before')->willReturn($parsedPad);
+		$padFileService->method('getSnapshotPartsFromBody')->with($parsedPad->body)->willReturn(['text' => 'plain text', 'html' => '']);
 		$padFileService->method('withStateAndSnapshot')->willReturn('doc-after');
 
 		$etherpadClient = $this->createMock(EtherpadClient::class);
@@ -422,15 +425,16 @@ class LifecycleServiceTest extends TestCase {
 		$bindingService->expects($this->once())->method('markRestored')->with($fileId, $newPadId);
 
 		$padFileService = $this->createMock(PadFileService::class);
-		$padFileService->method('readPad')->willReturn(new ParsedPadFile(
+		$parsedPad = new ParsedPadFile(
 			frontmatter: [],
 			body: 'body',
 			padId: $oldPadId,
 			accessMode: BindingService::ACCESS_PUBLIC,
 			padUrl: '',
 			isExternal: false,
-		));
-		$padFileService->method('getSnapshotPartsFromBody')->willReturn(['text' => 'plain text', 'html' => '']);
+		);
+		$padFileService->method('readPad')->with('doc-before')->willReturn($parsedPad);
+		$padFileService->method('getSnapshotPartsFromBody')->with($parsedPad->body)->willReturn(['text' => 'plain text', 'html' => '']);
 		$padFileService->method('withStateAndSnapshot')->willReturn('doc-after');
 
 		$etherpadClient = $this->createMock(EtherpadClient::class);
@@ -487,19 +491,20 @@ class LifecycleServiceTest extends TestCase {
 			->with($fileId, $newPadId);
 
 		$padFileService = $this->createMock(PadFileService::class);
-		$padFileService->method('readPad')->willReturn(new ParsedPadFile(
+		$parsedPad = new ParsedPadFile(
 			frontmatter: [],
 			body: 'body',
 			padId: $oldPadId,
 			accessMode: BindingService::ACCESS_PUBLIC,
 			padUrl: '',
 			isExternal: false,
-		));
-		$padFileService->expects($this->once())->method('getSnapshotPartsFromBody')->willReturn(['text' => 'plain text', 'html' => '<p>html text</p>']);
+		);
+		$padFileService->method('readPad')->with('doc-before')->willReturn($parsedPad);
+		$padFileService->expects($this->once())->method('getSnapshotPartsFromBody')->with($parsedPad->body)->willReturn(['text' => 'plain text', 'html' => '<p>html text</p>']);
 		$padFileService->expects($this->once())
 			->method('withStateAndSnapshot')
 			->with(
-				$this->isInstanceOf(ParsedPadFile::class),
+				$this->identicalTo($parsedPad),
 				BindingService::STATE_ACTIVE,
 				'plain text',
 				$newPadId,
@@ -571,7 +576,7 @@ class LifecycleServiceTest extends TestCase {
 			->with($fileId, $newPadId, BindingService::ACCESS_PUBLIC);
 
 		$padFileService = $this->createMock(PadFileService::class);
-		$padFileService->method('readPad')->with('doc-before')->willReturn(new ParsedPadFile(
+		$parsedPad = new ParsedPadFile(
 			frontmatter: [
 				'pad_id' => $oldPadId,
 				'access_mode' => BindingService::ACCESS_PUBLIC,
@@ -582,14 +587,15 @@ class LifecycleServiceTest extends TestCase {
 			accessMode: BindingService::ACCESS_PUBLIC,
 			padUrl: 'https://pad.example.test/p/' . rawurlencode($oldPadId),
 			isExternal: false,
-		));
-		$padFileService->method('getSnapshotPartsFromBody')->willReturn([
+		);
+		$padFileService->method('readPad')->with('doc-before')->willReturn($parsedPad);
+		$padFileService->method('getSnapshotPartsFromBody')->with($parsedPad->body)->willReturn([
 			'text' => 'plain text',
 			'html' => '',
 		]);
 		$padFileService->expects($this->once())
 			->method('withStateAndSnapshot')
-			->with($this->isInstanceOf(ParsedPadFile::class), BindingService::STATE_ACTIVE, 'plain text', $newPadId, null, $newPadUrl)
+			->with($this->identicalTo($parsedPad), BindingService::STATE_ACTIVE, 'plain text', $newPadId, null, $newPadUrl)
 			->willReturn('doc-after');
 
 		$etherpadClient = $this->createMock(EtherpadClient::class);

--- a/tests/phpunit/unit/LifecycleServiceTest.php
+++ b/tests/phpunit/unit/LifecycleServiceTest.php
@@ -306,7 +306,7 @@ class LifecycleServiceTest extends TestCase {
 		);
 		$padFileService->method('readPad')->with('doc-before')->willReturn($parsedPad);
 		$padFileService->method('getSnapshotPartsFromBody')->with($parsedPad->body)->willReturn(['text' => 'plain text', 'html' => '']);
-		$padFileService->method('withStateAndSnapshot')->willReturn('doc-after');
+		$padFileService->method('withRestoredSnapshot')->willReturn('doc-after');
 
 		$etherpadClient = $this->createMock(EtherpadClient::class);
 		$etherpadClient->method('buildPadUrl')->willReturn('https://pad.example.test/p/' . $newPadId);
@@ -365,7 +365,7 @@ class LifecycleServiceTest extends TestCase {
 		);
 		$padFileService->method('readPad')->with('doc-before')->willReturn($parsedPad);
 		$padFileService->method('getSnapshotPartsFromBody')->with($parsedPad->body)->willReturn(['text' => 'plain text', 'html' => '']);
-		$padFileService->method('withStateAndSnapshot')->willReturn('doc-after');
+		$padFileService->method('withRestoredSnapshot')->willReturn('doc-after');
 
 		$etherpadClient = $this->createMock(EtherpadClient::class);
 		$etherpadClient->method('createGroup')->willReturn('g.NEWGROUPID12345');
@@ -435,7 +435,7 @@ class LifecycleServiceTest extends TestCase {
 		);
 		$padFileService->method('readPad')->with('doc-before')->willReturn($parsedPad);
 		$padFileService->method('getSnapshotPartsFromBody')->with($parsedPad->body)->willReturn(['text' => 'plain text', 'html' => '']);
-		$padFileService->method('withStateAndSnapshot')->willReturn('doc-after');
+		$padFileService->method('withRestoredSnapshot')->willReturn('doc-after');
 
 		$etherpadClient = $this->createMock(EtherpadClient::class);
 		$etherpadClient->method('buildPadUrl')->willReturn('https://pad.example.test/p/' . $newPadId);
@@ -502,13 +502,12 @@ class LifecycleServiceTest extends TestCase {
 		$padFileService->method('readPad')->with('doc-before')->willReturn($parsedPad);
 		$padFileService->expects($this->once())->method('getSnapshotPartsFromBody')->with($parsedPad->body)->willReturn(['text' => 'plain text', 'html' => '<p>html text</p>']);
 		$padFileService->expects($this->once())
-			->method('withStateAndSnapshot')
+			->method('withRestoredSnapshot')
 			->with(
 				$this->identicalTo($parsedPad),
-				BindingService::STATE_ACTIVE,
 				'plain text',
+				'<p>html text</p>',
 				$newPadId,
-				null,
 				$newPadUrl
 			)
 			->willReturn('doc-after');
@@ -594,8 +593,8 @@ class LifecycleServiceTest extends TestCase {
 			'html' => '',
 		]);
 		$padFileService->expects($this->once())
-			->method('withStateAndSnapshot')
-			->with($this->identicalTo($parsedPad), BindingService::STATE_ACTIVE, 'plain text', $newPadId, null, $newPadUrl)
+			->method('withRestoredSnapshot')
+			->with($this->identicalTo($parsedPad), 'plain text', '', $newPadId, $newPadUrl)
 			->willReturn('doc-after');
 
 		$etherpadClient = $this->createMock(EtherpadClient::class);
@@ -711,7 +710,7 @@ class LifecycleServiceTest extends TestCase {
 			isExternal: false,
 		));
 		$padFileService->method('getSnapshotPartsFromBody')->willReturn(['text' => 'plain text', 'html' => '']);
-		$padFileService->method('withStateAndSnapshot')->willReturn('doc-after');
+		$padFileService->method('withRestoredSnapshot')->willReturn('doc-after');
 
 		$secureRandom = $this->createMock(ISecureRandom::class);
 		$secureRandom->method('generate')->willReturn('abc123def456');
@@ -757,7 +756,7 @@ class LifecycleServiceTest extends TestCase {
 			isExternal: true,
 		));
 		$padFileService->expects($this->never())->method('getSnapshotPartsFromBody');
-		$padFileService->expects($this->never())->method('withStateAndSnapshot');
+		$padFileService->expects($this->never())->method('withRestoredSnapshot');
 
 		$etherpadClient = $this->createMock(EtherpadClient::class);
 		$etherpadClient->expects($this->never())->method('createPad');
@@ -816,7 +815,7 @@ class LifecycleServiceTest extends TestCase {
 			'text' => 'external snapshot',
 			'html' => '',
 		]);
-		$padFileService->expects($this->never())->method('withStateAndSnapshot');
+		$padFileService->expects($this->never())->method('withRestoredSnapshot');
 
 		$etherpadClient = $this->createMock(EtherpadClient::class);
 		$etherpadClient->expects($this->never())->method('createPad');
@@ -880,7 +879,7 @@ class LifecycleServiceTest extends TestCase {
 			'text' => 'external snapshot',
 			'html' => '',
 		]);
-		$padFileService->expects($this->never())->method('withStateAndSnapshot');
+		$padFileService->expects($this->never())->method('withRestoredSnapshot');
 
 		$etherpadClient = $this->createMock(EtherpadClient::class);
 		$etherpadClient->expects($this->never())->method('createPad');
@@ -943,7 +942,7 @@ class LifecycleServiceTest extends TestCase {
 			'text' => 'recovered content',
 			'html' => '',
 		]);
-		$padFileService->method('withStateAndSnapshot')->willReturn('doc-after');
+		$padFileService->method('withRestoredSnapshot')->willReturn('doc-after');
 
 		$etherpadClient = $this->createMock(EtherpadClient::class);
 		$etherpadClient->expects($this->once())->method('createPad')->with($newPadId);
@@ -1006,7 +1005,7 @@ class LifecycleServiceTest extends TestCase {
 			isExternal: false,
 		));
 		$padFileService->method('getSnapshotPartsFromBody')->willReturn(['text' => 'content', 'html' => '']);
-		$padFileService->method('withStateAndSnapshot')->willReturn('doc-after');
+		$padFileService->method('withRestoredSnapshot')->willReturn('doc-after');
 
 		$etherpadClient = $this->createMock(EtherpadClient::class);
 		$etherpadClient->expects($this->once())->method('createPad');

--- a/tests/phpunit/unit/LifecycleServiceTest.php
+++ b/tests/phpunit/unit/LifecycleServiceTest.php
@@ -111,9 +111,17 @@ class LifecycleServiceTest extends TestCase {
 		$padFileService = $this->createMock(PadFileService::class);
 		$padFileService->expects($this->never())->method('parsePadFile');
 		$padFileService->expects($this->never())->method('isExternalFrontmatter');
+		$padFileService->method('readPad')->with('doc-current')->willReturn(new ParsedPadFile(
+			frontmatter: [],
+			body: '',
+			padId: $padId,
+			accessMode: BindingService::ACCESS_PUBLIC,
+			padUrl: '',
+			isExternal: false,
+		));
 		$padFileService->expects($this->once())
 			->method('withExportSnapshot')
-			->with('doc-current', 'snapshot-text', '<p>snapshot-html</p>', 7)
+			->with($this->isInstanceOf(ParsedPadFile::class), 'snapshot-text', '<p>snapshot-html</p>', 7)
 			->willReturn('doc-trash-updated');
 
 		$etherpadClient = $this->createMock(EtherpadClient::class);
@@ -287,8 +295,15 @@ class LifecycleServiceTest extends TestCase {
 		$bindingService->method('isBoundTo')->with($fileId, $newPadId)->willReturn(true);
 
 		$padFileService = $this->createMock(PadFileService::class);
-		$padFileService->method('getTextSnapshotForRestore')->willReturn('plain text');
-		$padFileService->method('getHtmlSnapshotForRestore')->willReturn('');
+		$padFileService->method('readPad')->willReturn(new ParsedPadFile(
+			frontmatter: [],
+			body: 'body',
+			padId: $oldPadId,
+			accessMode: BindingService::ACCESS_PUBLIC,
+			padUrl: '',
+			isExternal: false,
+		));
+		$padFileService->method('getSnapshotPartsFromBody')->willReturn(['text' => 'plain text', 'html' => '']);
 		$padFileService->method('withStateAndSnapshot')->willReturn('doc-after');
 
 		$etherpadClient = $this->createMock(EtherpadClient::class);
@@ -338,8 +353,15 @@ class LifecycleServiceTest extends TestCase {
 		$bindingService->expects($this->once())->method('markRestored')->with($fileId, $newPadId);
 
 		$padFileService = $this->createMock(PadFileService::class);
-		$padFileService->method('getTextSnapshotForRestore')->willReturn('plain text');
-		$padFileService->method('getHtmlSnapshotForRestore')->willReturn('');
+		$padFileService->method('readPad')->willReturn(new ParsedPadFile(
+			frontmatter: [],
+			body: 'body',
+			padId: $oldPadId,
+			accessMode: BindingService::ACCESS_PUBLIC,
+			padUrl: '',
+			isExternal: false,
+		));
+		$padFileService->method('getSnapshotPartsFromBody')->willReturn(['text' => 'plain text', 'html' => '']);
 		$padFileService->method('withStateAndSnapshot')->willReturn('doc-after');
 
 		$etherpadClient = $this->createMock(EtherpadClient::class);
@@ -400,8 +422,15 @@ class LifecycleServiceTest extends TestCase {
 		$bindingService->expects($this->once())->method('markRestored')->with($fileId, $newPadId);
 
 		$padFileService = $this->createMock(PadFileService::class);
-		$padFileService->method('getTextSnapshotForRestore')->willReturn('plain text');
-		$padFileService->method('getHtmlSnapshotForRestore')->willReturn('');
+		$padFileService->method('readPad')->willReturn(new ParsedPadFile(
+			frontmatter: [],
+			body: 'body',
+			padId: $oldPadId,
+			accessMode: BindingService::ACCESS_PUBLIC,
+			padUrl: '',
+			isExternal: false,
+		));
+		$padFileService->method('getSnapshotPartsFromBody')->willReturn(['text' => 'plain text', 'html' => '']);
 		$padFileService->method('withStateAndSnapshot')->willReturn('doc-after');
 
 		$etherpadClient = $this->createMock(EtherpadClient::class);
@@ -458,12 +487,19 @@ class LifecycleServiceTest extends TestCase {
 			->with($fileId, $newPadId);
 
 		$padFileService = $this->createMock(PadFileService::class);
-		$padFileService->expects($this->once())->method('getTextSnapshotForRestore')->with('doc-before')->willReturn('plain text');
-		$padFileService->expects($this->once())->method('getHtmlSnapshotForRestore')->with('doc-before')->willReturn('<p>html text</p>');
+		$padFileService->method('readPad')->willReturn(new ParsedPadFile(
+			frontmatter: [],
+			body: 'body',
+			padId: $oldPadId,
+			accessMode: BindingService::ACCESS_PUBLIC,
+			padUrl: '',
+			isExternal: false,
+		));
+		$padFileService->expects($this->once())->method('getSnapshotPartsFromBody')->willReturn(['text' => 'plain text', 'html' => '<p>html text</p>']);
 		$padFileService->expects($this->once())
 			->method('withStateAndSnapshot')
 			->with(
-				'doc-before',
+				$this->isInstanceOf(ParsedPadFile::class),
 				BindingService::STATE_ACTIVE,
 				'plain text',
 				$newPadId,
@@ -553,7 +589,7 @@ class LifecycleServiceTest extends TestCase {
 		]);
 		$padFileService->expects($this->once())
 			->method('withStateAndSnapshot')
-			->with('doc-before', BindingService::STATE_ACTIVE, 'plain text', $newPadId, null, $newPadUrl)
+			->with($this->isInstanceOf(ParsedPadFile::class), BindingService::STATE_ACTIVE, 'plain text', $newPadId, null, $newPadUrl)
 			->willReturn('doc-after');
 
 		$etherpadClient = $this->createMock(EtherpadClient::class);

--- a/tests/phpunit/unit/LifecycleServiceTest.php
+++ b/tests/phpunit/unit/LifecycleServiceTest.php
@@ -14,6 +14,7 @@ use OCA\EtherpadNextcloud\Service\EtherpadClient;
 use OCA\EtherpadNextcloud\Service\ManagedPadLifecycle;
 use OCA\EtherpadNextcloud\Service\LifecycleService;
 use OCA\EtherpadNextcloud\Service\PadFileService;
+use OCA\EtherpadNextcloud\Service\PadSnapshot;
 use OCA\EtherpadNextcloud\Service\ParsedPadFile;
 use OCA\EtherpadNextcloud\Service\UserNodeResolver;
 use OCA\EtherpadNextcloud\Util\PathNormalizer;
@@ -118,11 +119,12 @@ class LifecycleServiceTest extends TestCase {
 			accessMode: BindingService::ACCESS_PUBLIC,
 			padUrl: '',
 			isExternal: false,
+			snapshotRev: -1,
 		);
 		$padFileService->method('readPad')->with('doc-current')->willReturn($parsedPad);
 		$padFileService->expects($this->once())
 			->method('withExportSnapshot')
-			->with($this->identicalTo($parsedPad), 'snapshot-text', '<p>snapshot-html</p>', 7)
+			->with($this->identicalTo($parsedPad), new PadSnapshot('snapshot-text', '<p>snapshot-html</p>', 7))
 			->willReturn('doc-trash-updated');
 
 		$etherpadClient = $this->createMock(EtherpadClient::class);
@@ -279,6 +281,76 @@ class LifecycleServiceTest extends TestCase {
 	 * and the rollback would put the old content back and delete the pad
 	 * the row now points at.
 	 */
+	public function testHandleRestorePutsTheOriginalContentBackWhenTheRestoreFails(): void {
+		// The mirror of the test below: the update did not land, so the file
+		// must not be left holding the restored document.
+		$fileId = 88;
+		$oldPadId = 'old-pad';
+		$newPadId = 'r-old-pad-abc123def456';
+
+		$bindingService = $this->createMock(BindingService::class);
+		$bindingService->method('findByFileId')->with($fileId)->willReturn([
+			'file_id' => $fileId,
+			'pad_id' => $oldPadId,
+			'access_mode' => BindingService::ACCESS_PUBLIC,
+			'state' => BindingService::STATE_PENDING_DELETE,
+		]);
+		$bindingService->method('markRestored')->willThrowException(new \RuntimeException('connection lost'));
+		$bindingService->method('isBoundTo')->with($fileId, $newPadId)->willReturn(false);
+
+		$padFileService = $this->createMock(PadFileService::class);
+		$parsedPad = new ParsedPadFile(
+			frontmatter: [],
+			body: 'body',
+			padId: $oldPadId,
+			accessMode: BindingService::ACCESS_PUBLIC,
+			padUrl: '',
+			isExternal: false,
+			snapshotRev: -1,
+		);
+		$padFileService->method('readPad')->with('doc-before')->willReturn($parsedPad);
+		$padFileService->method('getSnapshotPartsFromBody')->with($parsedPad->body)->willReturn(['text' => 'plain text', 'html' => '']);
+		$padFileService->method('withRestoredSnapshot')->willReturn('doc-after');
+
+		$etherpadClient = $this->createMock(EtherpadClient::class);
+		$etherpadClient->method('buildPadUrl')->willReturn('https://pad.example.test/p/' . $newPadId);
+
+		$secureRandom = $this->createMock(ISecureRandom::class);
+		$secureRandom->method('generate')->willReturn('abc123def456');
+
+		$written = [];
+		$file = $this->createMock(File::class);
+		$file->method('getId')->willReturn($fileId);
+		$file->method('getName')->willReturn('Restored.pad');
+		$file->method('getContent')->willReturn('doc-before');
+		$file->expects($this->exactly(2))
+			->method('putContent')
+			->willReturnCallback(static function (string $content) use (&$written): void {
+				$written[] = $content;
+			});
+
+		$service = new LifecycleService(
+			$bindingService,
+			$padFileService,
+			$etherpadClient,
+			new ManagedPadLifecycle($etherpadClient, $this->createMock(LoggerInterface::class)),
+			$this->buildDeleteOnTrashEnabledConfig(),
+			$this->createMock(LoggerInterface::class),
+			$secureRandom,
+			$this->createMock(UserNodeResolver::class),
+			$this->createMock(PathNormalizer::class),
+		);
+
+		try {
+			$service->handleRestore($file);
+			$this->fail('Expected the restore to fail.');
+		} catch (LifecycleException) {
+			// The point of the test is what the file holds afterwards.
+		}
+
+		$this->assertSame(['doc-after', 'doc-before'], $written);
+	}
+
 	public function testHandleRestoreDoesNotUndoARestoreThatLanded(): void {
 		$fileId = 87;
 		$oldPadId = 'old-pad';
@@ -303,6 +375,7 @@ class LifecycleServiceTest extends TestCase {
 			accessMode: BindingService::ACCESS_PUBLIC,
 			padUrl: '',
 			isExternal: false,
+			snapshotRev: -1,
 		);
 		$padFileService->method('readPad')->with('doc-before')->willReturn($parsedPad);
 		$padFileService->method('getSnapshotPartsFromBody')->with($parsedPad->body)->willReturn(['text' => 'plain text', 'html' => '']);
@@ -362,6 +435,7 @@ class LifecycleServiceTest extends TestCase {
 			accessMode: BindingService::ACCESS_PUBLIC,
 			padUrl: '',
 			isExternal: false,
+			snapshotRev: -1,
 		);
 		$padFileService->method('readPad')->with('doc-before')->willReturn($parsedPad);
 		$padFileService->method('getSnapshotPartsFromBody')->with($parsedPad->body)->willReturn(['text' => 'plain text', 'html' => '']);
@@ -432,6 +506,7 @@ class LifecycleServiceTest extends TestCase {
 			accessMode: BindingService::ACCESS_PUBLIC,
 			padUrl: '',
 			isExternal: false,
+			snapshotRev: -1,
 		);
 		$padFileService->method('readPad')->with('doc-before')->willReturn($parsedPad);
 		$padFileService->method('getSnapshotPartsFromBody')->with($parsedPad->body)->willReturn(['text' => 'plain text', 'html' => '']);
@@ -498,6 +573,7 @@ class LifecycleServiceTest extends TestCase {
 			accessMode: BindingService::ACCESS_PUBLIC,
 			padUrl: '',
 			isExternal: false,
+			snapshotRev: -1,
 		);
 		$padFileService->method('readPad')->with('doc-before')->willReturn($parsedPad);
 		$padFileService->expects($this->once())->method('getSnapshotPartsFromBody')->with($parsedPad->body)->willReturn(['text' => 'plain text', 'html' => '<p>html text</p>']);
@@ -586,6 +662,7 @@ class LifecycleServiceTest extends TestCase {
 			accessMode: BindingService::ACCESS_PUBLIC,
 			padUrl: 'https://pad.example.test/p/' . rawurlencode($oldPadId),
 			isExternal: false,
+			snapshotRev: -1,
 		);
 		$padFileService->method('readPad')->with('doc-before')->willReturn($parsedPad);
 		$padFileService->method('getSnapshotPartsFromBody')->with($parsedPad->body)->willReturn([
@@ -708,6 +785,7 @@ class LifecycleServiceTest extends TestCase {
 			accessMode: BindingService::ACCESS_PUBLIC,
 			padUrl: 'https://pad.example.test/p/' . rawurlencode($oldPadId),
 			isExternal: false,
+			snapshotRev: -1,
 		));
 		$padFileService->method('getSnapshotPartsFromBody')->willReturn(['text' => 'plain text', 'html' => '']);
 		$padFileService->method('withRestoredSnapshot')->willReturn('doc-after');
@@ -754,6 +832,7 @@ class LifecycleServiceTest extends TestCase {
 			accessMode: BindingService::ACCESS_PUBLIC,
 			padUrl: $padUrl,
 			isExternal: true,
+			snapshotRev: -1,
 		));
 		$padFileService->expects($this->never())->method('getSnapshotPartsFromBody');
 		$padFileService->expects($this->never())->method('withRestoredSnapshot');
@@ -810,6 +889,7 @@ class LifecycleServiceTest extends TestCase {
 			accessMode: BindingService::ACCESS_PUBLIC,
 			padUrl: '',
 			isExternal: false,
+			snapshotRev: -1,
 		));
 		$padFileService->method('getSnapshotPartsFromBody')->willReturn([
 			'text' => 'external snapshot',
@@ -874,6 +954,7 @@ class LifecycleServiceTest extends TestCase {
 			accessMode: BindingService::ACCESS_PUBLIC,
 			padUrl: $padUrl,
 			isExternal: true,
+			snapshotRev: -1,
 		));
 		$padFileService->method('getSnapshotPartsFromBody')->willReturn([
 			'text' => 'external snapshot',
@@ -937,6 +1018,7 @@ class LifecycleServiceTest extends TestCase {
 			accessMode: BindingService::ACCESS_PUBLIC,
 			padUrl: 'https://pad.example.test/p/' . rawurlencode($oldPadId),
 			isExternal: false,
+			snapshotRev: -1,
 		));
 		$padFileService->method('getSnapshotPartsFromBody')->willReturn([
 			'text' => 'recovered content',
@@ -1003,6 +1085,7 @@ class LifecycleServiceTest extends TestCase {
 			accessMode: BindingService::ACCESS_PUBLIC,
 			padUrl: '',
 			isExternal: false,
+			snapshotRev: -1,
 		));
 		$padFileService->method('getSnapshotPartsFromBody')->willReturn(['text' => 'content', 'html' => '']);
 		$padFileService->method('withRestoredSnapshot')->willReturn('doc-after');
@@ -1278,6 +1361,7 @@ class LifecycleServiceTest extends TestCase {
 				accessMode: BindingService::ACCESS_PUBLIC,
 				padUrl: '',
 				isExternal: true,
+				snapshotRev: -1,
 			));
 
 		$file = $this->createMock(File::class);

--- a/tests/phpunit/unit/LivePadHtmlFetcherTest.php
+++ b/tests/phpunit/unit/LivePadHtmlFetcherTest.php
@@ -116,6 +116,7 @@ class LivePadHtmlFetcherTest extends TestCase {
 			accessMode: BindingService::ACCESS_PROTECTED,
 			padUrl: '',
 			isExternal: false,
+			snapshotRev: -1,
 		);
 	}
 
@@ -130,6 +131,7 @@ class LivePadHtmlFetcherTest extends TestCase {
 			accessMode: $accessMode,
 			padUrl: $padUrl,
 			isExternal: true,
+			snapshotRev: -1,
 		);
 	}
 

--- a/tests/phpunit/unit/PadBootstrapServiceTest.php
+++ b/tests/phpunit/unit/PadBootstrapServiceTest.php
@@ -40,7 +40,7 @@ class PadBootstrapServiceTest extends TestCase {
 			->willReturn(null);
 		$padFileService->expects($this->once())
 			->method('buildInitialDocument')
-			->with($fileId, $padId, BindingService::ACCESS_PROTECTED, $padUrl)
+			->with($fileId, $padId, BindingService::ACCESS_PROTECTED, null, $padUrl)
 			->willReturn('doc-content');
 
 		$etherpadClient = $this->createMock(EtherpadClient::class);

--- a/tests/phpunit/unit/PadBootstrapServiceTest.php
+++ b/tests/phpunit/unit/PadBootstrapServiceTest.php
@@ -40,7 +40,7 @@ class PadBootstrapServiceTest extends TestCase {
 			->willReturn(null);
 		$padFileService->expects($this->once())
 			->method('buildInitialDocument')
-			->with($fileId, $padId, BindingService::ACCESS_PROTECTED, '', $padUrl)
+			->with($fileId, $padId, BindingService::ACCESS_PROTECTED, $padUrl)
 			->willReturn('doc-content');
 
 		$etherpadClient = $this->createMock(EtherpadClient::class);

--- a/tests/phpunit/unit/PadContentServiceTest.php
+++ b/tests/phpunit/unit/PadContentServiceTest.php
@@ -56,6 +56,7 @@ class PadContentServiceTest extends TestCase {
 			accessMode: BindingService::ACCESS_PROTECTED,
 			padUrl: '',
 			isExternal: false,
+			snapshotRev: -1,
 		);
 	}
 

--- a/tests/phpunit/unit/PadCreationServiceTest.php
+++ b/tests/phpunit/unit/PadCreationServiceTest.php
@@ -249,9 +249,9 @@ class PadCreationServiceTest extends TestCase {
 		));
 		$padFileService->method('getSnapshotPartsFromBody')->willReturn(['text' => 'hello', 'html' => '<p>hello</p>']);
 		$padFileService->method('buildInitialDocument')
-			->with(4321, 'g.grp$pad', BindingService::ACCESS_PROTECTED, 'hello', 'https://pad.example.test/p/x')
-			->willReturn('doc');
-		$padFileService->method('withExportSnapshot')->willReturn('doc-with-snapshot');
+			->with(4321, 'g.grp$pad', BindingService::ACCESS_PROTECTED, 'hello', 'https://pad.example.test/p/x', [], '<p>hello</p>', 0)
+			->willReturn('doc-with-snapshot');
+		$padFileService->expects($this->never())->method('withExportSnapshot');
 
 		$bootstrap = $this->createMock(PadBootstrapService::class);
 		$bootstrap->expects(self::once())
@@ -306,18 +306,17 @@ class PadCreationServiceTest extends TestCase {
 				321,
 				'ext.RemotePad',
 				BindingService::ACCESS_PUBLIC,
-				'',
+				"Initial snapshot\nfrom remote pad",
 				'https://pad.remote.test/p/RemotePad',
 				[
 					'pad_origin' => 'https://pad.remote.test',
 					'remote_pad_id' => 'RemotePad',
-				]
+				],
+				null,
+				0,
 			)
-			->willReturn('external-empty-frontmatter');
-		$padFileService->expects($this->once())
-			->method('withExportSnapshot')
-			->with('external-empty-frontmatter', "Initial snapshot\nfrom remote pad", '', 0, false)
 			->willReturn('external-frontmatter');
+		$padFileService->expects($this->never())->method('withExportSnapshot');
 
 		$bindingService = $this->createMock(BindingService::class);
 		$bindingService->expects($this->never())->method('createBinding');
@@ -357,11 +356,22 @@ class PadCreationServiceTest extends TestCase {
 			]);
 
 		$padFileService = $this->createMock(PadFileService::class);
-		$padFileService->method('buildInitialDocument')->willReturn('external-empty-frontmatter');
+		// An unavailable remote export still produces a snapshotted document;
+		// the snapshot is simply empty.
 		$padFileService->expects($this->once())
-			->method('withExportSnapshot')
-			->with('external-empty-frontmatter', '', '', 0, false)
+			->method('buildInitialDocument')
+			->with(
+				$this->anything(),
+				$this->anything(),
+				BindingService::ACCESS_PUBLIC,
+				'',
+				$this->anything(),
+				$this->anything(),
+				null,
+				0,
+			)
 			->willReturn('external-frontmatter');
+		$padFileService->expects($this->never())->method('withExportSnapshot');
 
 		$bindingService = $this->createMock(BindingService::class);
 		$bindingService->expects($this->never())->method('createBinding');

--- a/tests/phpunit/unit/PadCreationServiceTest.php
+++ b/tests/phpunit/unit/PadCreationServiceTest.php
@@ -47,7 +47,7 @@ class PadCreationServiceTest extends TestCase {
 		$padFileService = $this->createMock(PadFileService::class);
 		$padFileService->expects($this->once())
 			->method('buildInitialDocument')
-			->with(123, 'g.ABC$pad', BindingService::ACCESS_PROTECTED, 'https://pad.example.test/p/g.ABC$pad')
+			->with(123, 'g.ABC$pad', BindingService::ACCESS_PROTECTED, null, 'https://pad.example.test/p/g.ABC$pad')
 			->willReturn('frontmatter');
 
 		$bindingService = $this->createMock(BindingService::class);
@@ -213,6 +213,7 @@ class PadCreationServiceTest extends TestCase {
 			accessMode: BindingService::ACCESS_PROTECTED,
 			padUrl: '',
 			isExternal: false,
+			snapshotRev: -1,
 		));
 
 		$padPaths = $this->createMock(PathNormalizer::class);
@@ -247,10 +248,11 @@ class PadCreationServiceTest extends TestCase {
 			accessMode: BindingService::ACCESS_PUBLIC,
 			padUrl: '',
 			isExternal: false,
+			snapshotRev: -1,
 		));
 		$padFileService->method('getSnapshotPartsFromBody')->willReturn(['text' => 'hello', 'html' => '<p>hello</p>']);
 		$padFileService->method('buildInitialDocument')
-			->with(4321, 'g.grp$pad', BindingService::ACCESS_PROTECTED, 'https://pad.example.test/p/x', [], new PadSnapshot('hello', '<p>hello</p>', 0))
+			->with(4321, 'g.grp$pad', BindingService::ACCESS_PROTECTED, new PadSnapshot('hello', '<p>hello</p>', 0), 'https://pad.example.test/p/x')
 			->willReturn('doc-with-snapshot');
 		$padFileService->expects($this->never())->method('withExportSnapshot');
 
@@ -307,12 +309,12 @@ class PadCreationServiceTest extends TestCase {
 				321,
 				'ext.RemotePad',
 				BindingService::ACCESS_PUBLIC,
+				new PadSnapshot("Initial snapshot\nfrom remote pad", null, 0),
 				'https://pad.remote.test/p/RemotePad',
 				[
 					'pad_origin' => 'https://pad.remote.test',
 					'remote_pad_id' => 'RemotePad',
 				],
-				new PadSnapshot("Initial snapshot\nfrom remote pad", null, 0),
 			)
 			->willReturn('external-frontmatter');
 		$padFileService->expects($this->never())->method('withExportSnapshot');
@@ -363,9 +365,9 @@ class PadCreationServiceTest extends TestCase {
 				$this->anything(),
 				$this->anything(),
 				BindingService::ACCESS_PUBLIC,
-				$this->anything(),
-				$this->anything(),
 				new PadSnapshot('', null, 0),
+				$this->anything(),
+				$this->anything(),
 			)
 			->willReturn('external-frontmatter');
 		$padFileService->expects($this->never())->method('withExportSnapshot');
@@ -489,6 +491,7 @@ class PadCreationServiceTest extends TestCase {
 			accessMode: BindingService::ACCESS_PROTECTED,
 			padUrl: '',
 			isExternal: false,
+			snapshotRev: -1,
 		));
 		$padFileService->method('getSnapshotPartsFromBody')->willReturn([
 			'text' => 'Datum: {{date:next monday|d.m.Y}}',
@@ -496,7 +499,7 @@ class PadCreationServiceTest extends TestCase {
 		]);
 		$padFileService->expects($this->once())
 			->method('buildInitialDocument')
-			->with(99, 'p-fresh', BindingService::ACCESS_PROTECTED, $this->isType('string'), [], new PadSnapshot('Datum: 18.05.2026', '', 0))
+			->with(99, 'p-fresh', BindingService::ACCESS_PROTECTED, new PadSnapshot('Datum: 18.05.2026', '', 0), $this->isType('string'))
 			->willReturn('doc');
 		$padFileService->expects($this->never())->method('withExportSnapshot');
 
@@ -598,6 +601,7 @@ class PadCreationServiceTest extends TestCase {
 			accessMode: BindingService::ACCESS_PUBLIC,
 			padUrl: '',
 			isExternal: false,
+			snapshotRev: -1,
 		));
 		$padFileService->method('getSnapshotPartsFromBody')->willReturn(['text' => 'text', 'html' => '']);
 		$padFileService->method('buildInitialDocument')->willReturn('doc');
@@ -654,6 +658,7 @@ class PadCreationServiceTest extends TestCase {
 			accessMode: BindingService::ACCESS_PUBLIC,
 			padUrl: '',
 			isExternal: false,
+			snapshotRev: -1,
 		));
 		$padFileService->method('getSnapshotPartsFromBody')->willReturn(['text' => 'text', 'html' => '']);
 		$padFileService->method('buildInitialDocument')->willReturn('doc');
@@ -837,6 +842,7 @@ class PadCreationServiceTest extends TestCase {
 			accessMode: BindingService::ACCESS_PROTECTED,
 			padUrl: '',
 			isExternal: false,
+			snapshotRev: -1,
 		));
 		$padFileService->method('getSnapshotPartsFromBody')->willReturn(['text' => 'hello', 'html' => '']);
 		$padFileService->method('buildInitialDocument')->willReturn('doc');
@@ -905,6 +911,7 @@ class PadCreationServiceTest extends TestCase {
 			accessMode: '',
 			padUrl: '',
 			isExternal: true,
+			snapshotRev: -1,
 		));
 
 		$padPaths = $this->createMock(PathNormalizer::class);

--- a/tests/phpunit/unit/PadCreationServiceTest.php
+++ b/tests/phpunit/unit/PadCreationServiceTest.php
@@ -414,7 +414,7 @@ class PadCreationServiceTest extends TestCase {
 
 		$padFileService = $this->createMock(PadFileService::class);
 		$padFileService->method('buildInitialDocument')->willReturn('frontmatter');
-		$padFileService->method('withExportSnapshot')->willReturn('frontmatter');
+		$padFileService->expects($this->never())->method('withExportSnapshot');
 
 		$result = $this->buildService(
 			$padFileService,
@@ -499,9 +499,9 @@ class PadCreationServiceTest extends TestCase {
 		]);
 		$padFileService->expects($this->once())
 			->method('buildInitialDocument')
-			->with(99, 'p-fresh', BindingService::ACCESS_PROTECTED, 'Datum: 18.05.2026', $this->isType('string'))
+			->with(99, 'p-fresh', BindingService::ACCESS_PROTECTED, 'Datum: 18.05.2026', $this->isType('string'), [], '', 0)
 			->willReturn('doc');
-		$padFileService->method('withExportSnapshot')->willReturn('doc-with-snapshot');
+		$padFileService->expects($this->never())->method('withExportSnapshot');
 
 		$bootstrap = $this->createMock(PadBootstrapService::class);
 		$bootstrap->expects($this->once())
@@ -604,7 +604,7 @@ class PadCreationServiceTest extends TestCase {
 		));
 		$padFileService->method('getSnapshotPartsFromBody')->willReturn(['text' => 'text', 'html' => '']);
 		$padFileService->method('buildInitialDocument')->willReturn('doc');
-		$padFileService->method('withExportSnapshot')->willReturn('doc');
+		$padFileService->expects($this->never())->method('withExportSnapshot');
 
 		$bootstrap = $this->createMock(PadBootstrapService::class);
 		$bootstrap->method('provisionPadId')->willReturn('p-fresh');
@@ -660,7 +660,7 @@ class PadCreationServiceTest extends TestCase {
 		));
 		$padFileService->method('getSnapshotPartsFromBody')->willReturn(['text' => 'text', 'html' => '']);
 		$padFileService->method('buildInitialDocument')->willReturn('doc');
-		$padFileService->method('withExportSnapshot')->willReturn('doc');
+		$padFileService->expects($this->never())->method('withExportSnapshot');
 
 		$bootstrap = $this->createMock(PadBootstrapService::class);
 		$bootstrap->method('provisionPadId')->willReturn('p-fresh');
@@ -843,7 +843,7 @@ class PadCreationServiceTest extends TestCase {
 		));
 		$padFileService->method('getSnapshotPartsFromBody')->willReturn(['text' => 'hello', 'html' => '']);
 		$padFileService->method('buildInitialDocument')->willReturn('doc');
-		$padFileService->method('withExportSnapshot')->willReturn('doc-with-snapshot');
+		$padFileService->expects($this->never())->method('withExportSnapshot');
 
 		$bootstrap = $this->createMock(PadBootstrapService::class);
 		$bootstrap->method('provisionPadId')->willReturn($padId);

--- a/tests/phpunit/unit/PadCreationServiceTest.php
+++ b/tests/phpunit/unit/PadCreationServiceTest.php
@@ -18,6 +18,7 @@ use OCA\EtherpadNextcloud\Service\PadCreateRollbackService;
 use OCA\EtherpadNextcloud\Service\PadCreationService;
 use OCA\EtherpadNextcloud\Service\PadFileCreator;
 use OCA\EtherpadNextcloud\Service\PadFileService;
+use OCA\EtherpadNextcloud\Service\PadSnapshot;
 use OCA\EtherpadNextcloud\Service\ParsedPadFile;
 use OCA\EtherpadNextcloud\Service\UserNodeResolver;
 use OCA\EtherpadNextcloud\Util\PathNormalizer;
@@ -46,7 +47,7 @@ class PadCreationServiceTest extends TestCase {
 		$padFileService = $this->createMock(PadFileService::class);
 		$padFileService->expects($this->once())
 			->method('buildInitialDocument')
-			->with(123, 'g.ABC$pad', BindingService::ACCESS_PROTECTED, '', 'https://pad.example.test/p/g.ABC$pad')
+			->with(123, 'g.ABC$pad', BindingService::ACCESS_PROTECTED, 'https://pad.example.test/p/g.ABC$pad')
 			->willReturn('frontmatter');
 
 		$bindingService = $this->createMock(BindingService::class);
@@ -249,7 +250,7 @@ class PadCreationServiceTest extends TestCase {
 		));
 		$padFileService->method('getSnapshotPartsFromBody')->willReturn(['text' => 'hello', 'html' => '<p>hello</p>']);
 		$padFileService->method('buildInitialDocument')
-			->with(4321, 'g.grp$pad', BindingService::ACCESS_PROTECTED, 'hello', 'https://pad.example.test/p/x', [], '<p>hello</p>', 0)
+			->with(4321, 'g.grp$pad', BindingService::ACCESS_PROTECTED, 'https://pad.example.test/p/x', [], new PadSnapshot('hello', '<p>hello</p>', 0))
 			->willReturn('doc-with-snapshot');
 		$padFileService->expects($this->never())->method('withExportSnapshot');
 
@@ -306,14 +307,12 @@ class PadCreationServiceTest extends TestCase {
 				321,
 				'ext.RemotePad',
 				BindingService::ACCESS_PUBLIC,
-				"Initial snapshot\nfrom remote pad",
 				'https://pad.remote.test/p/RemotePad',
 				[
 					'pad_origin' => 'https://pad.remote.test',
 					'remote_pad_id' => 'RemotePad',
 				],
-				null,
-				0,
+				new PadSnapshot("Initial snapshot\nfrom remote pad", null, 0),
 			)
 			->willReturn('external-frontmatter');
 		$padFileService->expects($this->never())->method('withExportSnapshot');
@@ -364,11 +363,9 @@ class PadCreationServiceTest extends TestCase {
 				$this->anything(),
 				$this->anything(),
 				BindingService::ACCESS_PUBLIC,
-				'',
 				$this->anything(),
 				$this->anything(),
-				null,
-				0,
+				new PadSnapshot('', null, 0),
 			)
 			->willReturn('external-frontmatter');
 		$padFileService->expects($this->never())->method('withExportSnapshot');
@@ -499,7 +496,7 @@ class PadCreationServiceTest extends TestCase {
 		]);
 		$padFileService->expects($this->once())
 			->method('buildInitialDocument')
-			->with(99, 'p-fresh', BindingService::ACCESS_PROTECTED, 'Datum: 18.05.2026', $this->isType('string'), [], '', 0)
+			->with(99, 'p-fresh', BindingService::ACCESS_PROTECTED, $this->isType('string'), [], new PadSnapshot('Datum: 18.05.2026', '', 0))
 			->willReturn('doc');
 		$padFileService->expects($this->never())->method('withExportSnapshot');
 

--- a/tests/phpunit/unit/PadFileServiceTest.php
+++ b/tests/phpunit/unit/PadFileServiceTest.php
@@ -190,10 +190,12 @@ class PadFileServiceTest extends TestCase {
 
 		$updated = $service->withExportSnapshot($service->readPad($base), "line-a\nline-b", '<p>line-a</p>', 7);
 
-		$parsed = $service->parsePadFile($updated);
-		$this->assertSame(7, $parsed['frontmatter']['snapshot_rev']);
-		$this->assertSame("line-a\nline-b", $service->getSnapshotPartsFromBody($service->readPad($updated)->body)['text']);
-		$this->assertSame('<p>line-a</p>', $service->getSnapshotPartsFromBody($service->readPad($updated)->body)['html']);
+		$parsed = $service->readPad($updated);
+		$this->assertSame(7, $parsed->frontmatter['snapshot_rev']);
+		$this->assertSame(
+			['text' => "line-a\nline-b", 'html' => '<p>line-a</p>'],
+			$service->getSnapshotPartsFromBody($parsed->body),
+		);
 	}
 
 	public function testWithExportSnapshotEmptyValuesOverwritePreviousSnapshot(): void {
@@ -206,9 +208,9 @@ class PadFileServiceTest extends TestCase {
 
 		$cleared = $service->withExportSnapshot($service->readPad($withContent), '', '', 6);
 
-		$this->assertSame('', $service->getSnapshotPartsFromBody($service->readPad($cleared)->body)['text']);
-		$this->assertSame('', $service->getSnapshotPartsFromBody($service->readPad($cleared)->body)['html']);
-		$this->assertSame(6, $service->readPad($cleared)->frontmatter['snapshot_rev']);
+		$parsed = $service->readPad($cleared);
+		$this->assertSame(['text' => '', 'html' => ''], $service->getSnapshotPartsFromBody($parsed->body));
+		$this->assertSame(6, $parsed->frontmatter['snapshot_rev']);
 	}
 
 	public function testWithExportSnapshotOmitsHtmlSectionWhenRequested(): void {
@@ -219,14 +221,15 @@ class PadFileServiceTest extends TestCase {
 
 		$this->assertStringNotContainsString('[HTML-BEGIN]', $textOnly);
 		$this->assertStringNotContainsString('[HTML-END]', $textOnly);
-		$this->assertSame('just text', $service->getSnapshotPartsFromBody($service->readPad($textOnly)->body)['text']);
-		$this->assertSame('', $service->getSnapshotPartsFromBody($service->readPad($textOnly)->body)['html']);
+		$this->assertSame(
+			['text' => 'just text', 'html' => ''],
+			$service->getSnapshotPartsFromBody($service->readPad($textOnly)->body),
+		);
 	}
 
 	public function testBuildInitialDocumentWithSnapshotMatchesTheTwoStepItReplaces(): void {
-		// The template path used to build a document and parse it straight
-		// back to put the snapshot in. Byte-identical output is the whole
-		// claim of the one-step form, so it is asserted rather than sampled.
+		// The one-step form claims to write exactly what the two-step one
+		// wrote, so the two are compared rather than sampled.
 		$service = new PadFileService();
 
 		$oneStep = $service->buildInitialDocument(
@@ -253,7 +256,7 @@ class PadFileServiceTest extends TestCase {
 			true,
 		);
 
-		$this->assertSame($twoStep, $oneStep);
+		$this->assertSame(self::withoutWallClock($twoStep), self::withoutWallClock($oneStep));
 
 		$parsed = $service->readPad($oneStep);
 		$this->assertSame(0, $parsed->frontmatter['snapshot_rev']);
@@ -264,8 +267,7 @@ class PadFileServiceTest extends TestCase {
 	}
 
 	public function testBuildInitialDocumentWithoutHtmlOmitsTheHtmlSection(): void {
-		// The external path stores text only, which is what snapshotHtml: null
-		// means here — not "an empty HTML half".
+		// snapshotHtml: null means text only, not "an empty HTML half".
 		$service = new PadFileService();
 
 		$oneStep = $service->buildInitialDocument(
@@ -293,7 +295,7 @@ class PadFileServiceTest extends TestCase {
 			false,
 		);
 
-		$this->assertSame($twoStep, $oneStep);
+		$this->assertSame(self::withoutWallClock($twoStep), self::withoutWallClock($oneStep));
 		$this->assertStringNotContainsString('[HTML-BEGIN]', $oneStep);
 
 		$parsed = $service->readPad($oneStep);
@@ -302,6 +304,15 @@ class PadFileServiceTest extends TestCase {
 			['text' => 'remote text', 'html' => ''],
 			$service->getSnapshotPartsFromBody($parsed->body),
 		);
+	}
+
+	/**
+	 * created_at and updated_at are read from the wall clock as each document
+	 * is built, so two documents built moments apart differ whenever a second
+	 * ticks between them. Everything else is what the comparison is about.
+	 */
+	private static function withoutWallClock(string $document): string {
+		return (string)preg_replace('/^(created_at|updated_at): ".*"$/m', '$1: "<time>"', $document);
 	}
 
 	public function testGetSnapshotPartsFromBodyHandlesBodyWithoutMarkers(): void {
@@ -328,10 +339,12 @@ class PadFileServiceTest extends TestCase {
 			1700000000
 		);
 
-		$this->assertSame('replaced text', $service->getSnapshotPartsFromBody($service->readPad($updated)->body)['text']);
-		$this->assertSame('<p>kept html</p>', $service->getSnapshotPartsFromBody($service->readPad($updated)->body)['html']);
-		$parsed = $service->parsePadFile($updated);
-		$this->assertSame('2023-11-14T22:13:20+00:00', (string)$parsed['frontmatter']['deleted_at']);
+		$parsed = $service->readPad($updated);
+		$this->assertSame(
+			['text' => 'replaced text', 'html' => '<p>kept html</p>'],
+			$service->getSnapshotPartsFromBody($parsed->body),
+		);
+		$this->assertSame('2023-11-14T22:13:20+00:00', (string)$parsed->frontmatter['deleted_at']);
 	}
 
 	public function testGetSnapshotRevisionReturnsMinusOneForNonNumericValue(): void {

--- a/tests/phpunit/unit/PadFileServiceTest.php
+++ b/tests/phpunit/unit/PadFileServiceTest.php
@@ -223,6 +223,87 @@ class PadFileServiceTest extends TestCase {
 		$this->assertSame('', $service->getSnapshotPartsFromBody($service->readPad($textOnly)->body)['html']);
 	}
 
+	public function testBuildInitialDocumentWithSnapshotMatchesTheTwoStepItReplaces(): void {
+		// The template path used to build a document and parse it straight
+		// back to put the snapshot in. Byte-identical output is the whole
+		// claim of the one-step form, so it is asserted rather than sampled.
+		$service = new PadFileService();
+
+		$oneStep = $service->buildInitialDocument(
+			1,
+			'g.grp$pad',
+			BindingService::ACCESS_PROTECTED,
+			'hello',
+			'https://pad.example.test/p/x',
+			[],
+			'<p>hello</p>',
+			0,
+		);
+		$twoStep = $service->withExportSnapshot(
+			$service->readPad($service->buildInitialDocument(
+				1,
+				'g.grp$pad',
+				BindingService::ACCESS_PROTECTED,
+				'hello',
+				'https://pad.example.test/p/x',
+			)),
+			'hello',
+			'<p>hello</p>',
+			0,
+			true,
+		);
+
+		$this->assertSame($twoStep, $oneStep);
+
+		$parsed = $service->readPad($oneStep);
+		$this->assertSame(0, $parsed->frontmatter['snapshot_rev']);
+		$this->assertSame(
+			['text' => 'hello', 'html' => '<p>hello</p>'],
+			$service->getSnapshotPartsFromBody($parsed->body),
+		);
+	}
+
+	public function testBuildInitialDocumentWithoutHtmlOmitsTheHtmlSection(): void {
+		// The external path stores text only, which is what snapshotHtml: null
+		// means here — not "an empty HTML half".
+		$service = new PadFileService();
+
+		$oneStep = $service->buildInitialDocument(
+			2,
+			'ext.RemotePad',
+			BindingService::ACCESS_PUBLIC,
+			'remote text',
+			'https://pad.remote.test/p/RemotePad',
+			['pad_origin' => 'https://pad.remote.test'],
+			null,
+			0,
+		);
+		$twoStep = $service->withExportSnapshot(
+			$service->readPad($service->buildInitialDocument(
+				2,
+				'ext.RemotePad',
+				BindingService::ACCESS_PUBLIC,
+				'',
+				'https://pad.remote.test/p/RemotePad',
+				['pad_origin' => 'https://pad.remote.test'],
+			)),
+			'remote text',
+			'',
+			0,
+			false,
+		);
+
+		$this->assertSame($twoStep, $oneStep);
+		$this->assertStringNotContainsString('[HTML-BEGIN]', $oneStep);
+
+		$parsed = $service->readPad($oneStep);
+		$this->assertSame(0, $parsed->frontmatter['snapshot_rev']);
+		$this->assertSame(
+			['text' => 'remote text', 'html' => ''],
+			$service->getSnapshotPartsFromBody($parsed->body),
+		);
+	}
+
 	public function testGetSnapshotPartsFromBodyHandlesBodyWithoutMarkers(): void {
 		$service = new PadFileService();
 		$parts = $service->getSnapshotPartsFromBody('raw text without sections');

--- a/tests/phpunit/unit/PadFileServiceTest.php
+++ b/tests/phpunit/unit/PadFileServiceTest.php
@@ -390,28 +390,32 @@ class PadFileServiceTest extends TestCase {
 		$this->assertSame('', $parts['html']);
 	}
 
-	public function testWithStateAndSnapshotPreservesExistingHtmlBody(): void {
-		// withStateAndSnapshot writes a new text snapshot but should keep the
-		// HTML body part already on disk. Used by trash flow when only fresh
-		// text is available.
+	public function testWithRestoredSnapshotWritesTheRestoreInvariant(): void {
 		$service = new PadFileService();
-		$base = $service->buildInitialDocument(1, 'demo-pad', BindingService::ACCESS_PUBLIC);
-		$withExport = $service->withExportSnapshot($service->readPad($base), 'original text', '<p>kept html</p>', 4);
+		$trashed = $service->readPad($service->withExportSnapshot(
+			$service->readPad($service->buildInitialDocument(1, 'old-pad', BindingService::ACCESS_PUBLIC)),
+			'original text',
+			'<p>original html</p>',
+			4,
+		));
 
-		$updated = $service->withStateAndSnapshot(
-			$service->readPad($withExport),
-			BindingService::STATE_ACTIVE,
+		$restored = $service->readPad($service->withRestoredSnapshot(
+			$trashed,
 			'replaced text',
-			null,
-			1700000000
-		);
+			'<p>replaced html</p>',
+			'new-pad',
+			'https://pad.example.test/p/new-pad',
+		));
 
-		$parsed = $service->readPad($updated);
+		// Active and undeleted are not the caller's to get wrong any more.
+		$this->assertSame(BindingService::STATE_ACTIVE, $restored->frontmatter['state']);
+		$this->assertNull($restored->frontmatter['deleted_at']);
+		$this->assertSame('new-pad', $restored->padId);
+		$this->assertSame('https://pad.example.test/p/new-pad', $restored->padUrl);
 		$this->assertSame(
-			['text' => 'replaced text', 'html' => '<p>kept html</p>'],
-			$service->getSnapshotPartsFromBody($parsed->body),
+			['text' => 'replaced text', 'html' => '<p>replaced html</p>'],
+			$service->getSnapshotPartsFromBody($restored->body),
 		);
-		$this->assertSame('2023-11-14T22:13:20+00:00', (string)$parsed->frontmatter['deleted_at']);
 	}
 
 	public function testGetSnapshotRevisionReturnsMinusOneForNonNumericValue(): void {

--- a/tests/phpunit/unit/PadFileServiceTest.php
+++ b/tests/phpunit/unit/PadFileServiceTest.php
@@ -8,6 +8,7 @@ use OCA\EtherpadNextcloud\Exception\MissingFrontmatterException;
 use OCA\EtherpadNextcloud\Exception\PadFileFormatException;
 use OCA\EtherpadNextcloud\Service\BindingService;
 use OCA\EtherpadNextcloud\Service\PadFileService;
+use OCA\EtherpadNextcloud\Service\PadSnapshot;
 use PHPUnit\Framework\TestCase;
 
 class PadFileServiceTest extends TestCase {
@@ -21,7 +22,6 @@ class PadFileServiceTest extends TestCase {
 			42,
 			'g.abc$demo',
 			BindingService::ACCESS_PROTECTED,
-			'snapshot body'
 		);
 
 		$parsed = $service->parsePadFile($document);
@@ -33,7 +33,7 @@ class PadFileServiceTest extends TestCase {
 		$this->assertSame(BindingService::STATE_ACTIVE, $parsed['frontmatter']['state']);
 		$this->assertNull($parsed['frontmatter']['deleted_at']);
 		$this->assertSame(-1, $parsed['frontmatter']['snapshot_rev']);
-		$this->assertSame('snapshot body', $parsed['body']);
+		$this->assertSame('', $parsed['body']);
 	}
 
 	public function testParsePadFileNormalizesCrlfLineEndings(): void {
@@ -41,13 +41,21 @@ class PadFileServiceTest extends TestCase {
 		$document = str_replace(
 			"\n",
 			"\r\n",
-			$service->buildInitialDocument(1, 'demo-pad', BindingService::ACCESS_PUBLIC, 'body')
+			$service->buildInitialDocument(
+				1,
+				'demo-pad',
+				BindingService::ACCESS_PUBLIC,
+				snapshot: new PadSnapshot('body', null, 0),
+			)
 		);
 
 		$parsed = $service->parsePadFile($document);
 
 		$this->assertSame('demo-pad', $parsed['frontmatter']['pad_id']);
-		$this->assertSame('body', $parsed['body']);
+		$this->assertSame(
+			['text' => 'body', 'html' => ''],
+			$service->getSnapshotPartsFromBody($parsed['body']),
+		);
 	}
 
 	public function testSerializeIncludesOptionalPadUrlOnlyWhenSet(): void {
@@ -56,7 +64,6 @@ class PadFileServiceTest extends TestCase {
 			10,
 			'demo-pad',
 			BindingService::ACCESS_PUBLIC,
-			'',
 			'https://pad.example.test/p/demo-pad'
 		);
 		$withoutPadUrl = $service->buildInitialDocument(11, 'demo-pad', BindingService::ACCESS_PUBLIC);
@@ -72,7 +79,6 @@ class PadFileServiceTest extends TestCase {
 			51,
 			'demo-pad',
 			BindingService::ACCESS_PUBLIC,
-			'',
 			$padUrl
 		);
 
@@ -87,7 +93,6 @@ class PadFileServiceTest extends TestCase {
 			7,
 			'ext.remote-pad-id',
 			BindingService::ACCESS_PUBLIC,
-			'',
 			'https://pad.remote.example/p/remote-pad-id',
 			[
 				'pad_origin' => 'https://pad.remote.example',
@@ -236,18 +241,15 @@ class PadFileServiceTest extends TestCase {
 			1,
 			'g.grp$pad',
 			BindingService::ACCESS_PROTECTED,
-			'hello',
 			'https://pad.example.test/p/x',
 			[],
-			'<p>hello</p>',
-			0,
+			new PadSnapshot('hello', '<p>hello</p>', 0),
 		);
 		$twoStep = $service->withExportSnapshot(
 			$service->readPad($service->buildInitialDocument(
 				1,
 				'g.grp$pad',
 				BindingService::ACCESS_PROTECTED,
-				'hello',
 				'https://pad.example.test/p/x',
 			)),
 			'hello',
@@ -274,18 +276,15 @@ class PadFileServiceTest extends TestCase {
 			2,
 			'ext.RemotePad',
 			BindingService::ACCESS_PUBLIC,
-			'remote text',
 			'https://pad.remote.test/p/RemotePad',
 			['pad_origin' => 'https://pad.remote.test'],
-			null,
-			0,
+			new PadSnapshot('remote text', null, 0),
 		);
 		$twoStep = $service->withExportSnapshot(
 			$service->readPad($service->buildInitialDocument(
 				2,
 				'ext.RemotePad',
 				BindingService::ACCESS_PUBLIC,
-				'',
 				'https://pad.remote.test/p/RemotePad',
 				['pad_origin' => 'https://pad.remote.test'],
 			)),
@@ -313,6 +312,14 @@ class PadFileServiceTest extends TestCase {
 	 */
 	private static function withoutWallClock(string $document): string {
 		return (string)preg_replace('/^(created_at|updated_at): ".*"$/m', '$1: "<time>"', $document);
+	}
+
+	public function testASnapshotCannotClaimTheNoSnapshotRevision(): void {
+		// -1 is how the format says "never synced". A snapshot at that
+		// revision would make a never-synced pad look synced to the next
+		// sync's `$snapshotRev >= $currentRev` short circuit.
+		$this->expectException(PadFileFormatException::class);
+		new PadSnapshot('text', null, -1);
 	}
 
 	public function testGetSnapshotPartsFromBodyHandlesBodyWithoutMarkers(): void {

--- a/tests/phpunit/unit/PadFileServiceTest.php
+++ b/tests/phpunit/unit/PadFileServiceTest.php
@@ -188,12 +188,12 @@ class PadFileServiceTest extends TestCase {
 		$service = new PadFileService();
 		$base = $service->buildInitialDocument(1, 'demo-pad', BindingService::ACCESS_PUBLIC);
 
-		$updated = $service->withExportSnapshot($base, "line-a\nline-b", '<p>line-a</p>', 7);
+		$updated = $service->withExportSnapshot($service->readPad($base), "line-a\nline-b", '<p>line-a</p>', 7);
 
 		$parsed = $service->parsePadFile($updated);
 		$this->assertSame(7, $parsed['frontmatter']['snapshot_rev']);
-		$this->assertSame("line-a\nline-b", $service->getTextSnapshotForRestore($updated));
-		$this->assertSame('<p>line-a</p>', $service->getHtmlSnapshotForRestore($updated));
+		$this->assertSame("line-a\nline-b", $service->getSnapshotPartsFromBody($service->readPad($updated)->body)['text']);
+		$this->assertSame('<p>line-a</p>', $service->getSnapshotPartsFromBody($service->readPad($updated)->body)['html']);
 	}
 
 	public function testWithExportSnapshotEmptyValuesOverwritePreviousSnapshot(): void {
@@ -202,25 +202,25 @@ class PadFileServiceTest extends TestCase {
 		// become empty (otherwise stale content would resurface on restore).
 		$service = new PadFileService();
 		$base = $service->buildInitialDocument(1, 'demo-pad', BindingService::ACCESS_PUBLIC);
-		$withContent = $service->withExportSnapshot($base, 'previous text', '<p>previous html</p>', 5);
+		$withContent = $service->withExportSnapshot($service->readPad($base), 'previous text', '<p>previous html</p>', 5);
 
-		$cleared = $service->withExportSnapshot($withContent, '', '', 6);
+		$cleared = $service->withExportSnapshot($service->readPad($withContent), '', '', 6);
 
-		$this->assertSame('', $service->getTextSnapshotForRestore($cleared));
-		$this->assertSame('', $service->getHtmlSnapshotForRestore($cleared));
-		$this->assertSame(6, $service->getSnapshotRevision($cleared));
+		$this->assertSame('', $service->getSnapshotPartsFromBody($service->readPad($cleared)->body)['text']);
+		$this->assertSame('', $service->getSnapshotPartsFromBody($service->readPad($cleared)->body)['html']);
+		$this->assertSame(6, $service->readPad($cleared)->frontmatter['snapshot_rev']);
 	}
 
 	public function testWithExportSnapshotOmitsHtmlSectionWhenRequested(): void {
 		$service = new PadFileService();
 		$base = $service->buildInitialDocument(1, 'demo-pad', BindingService::ACCESS_PUBLIC);
 
-		$textOnly = $service->withExportSnapshot($base, 'just text', '<p>ignored</p>', 1, false);
+		$textOnly = $service->withExportSnapshot($service->readPad($base), 'just text', '<p>ignored</p>', 1, false);
 
 		$this->assertStringNotContainsString('[HTML-BEGIN]', $textOnly);
 		$this->assertStringNotContainsString('[HTML-END]', $textOnly);
-		$this->assertSame('just text', $service->getTextSnapshotForRestore($textOnly));
-		$this->assertSame('', $service->getHtmlSnapshotForRestore($textOnly));
+		$this->assertSame('just text', $service->getSnapshotPartsFromBody($service->readPad($textOnly)->body)['text']);
+		$this->assertSame('', $service->getSnapshotPartsFromBody($service->readPad($textOnly)->body)['html']);
 	}
 
 	public function testGetSnapshotPartsFromBodyHandlesBodyWithoutMarkers(): void {
@@ -237,18 +237,18 @@ class PadFileServiceTest extends TestCase {
 		// text is available.
 		$service = new PadFileService();
 		$base = $service->buildInitialDocument(1, 'demo-pad', BindingService::ACCESS_PUBLIC);
-		$withExport = $service->withExportSnapshot($base, 'original text', '<p>kept html</p>', 4);
+		$withExport = $service->withExportSnapshot($service->readPad($base), 'original text', '<p>kept html</p>', 4);
 
 		$updated = $service->withStateAndSnapshot(
-			$withExport,
+			$service->readPad($withExport),
 			BindingService::STATE_ACTIVE,
 			'replaced text',
 			null,
 			1700000000
 		);
 
-		$this->assertSame('replaced text', $service->getTextSnapshotForRestore($updated));
-		$this->assertSame('<p>kept html</p>', $service->getHtmlSnapshotForRestore($updated));
+		$this->assertSame('replaced text', $service->getSnapshotPartsFromBody($service->readPad($updated)->body)['text']);
+		$this->assertSame('<p>kept html</p>', $service->getSnapshotPartsFromBody($service->readPad($updated)->body)['html']);
 		$parsed = $service->parsePadFile($updated);
 		$this->assertSame('2023-11-14T22:13:20+00:00', (string)$parsed['frontmatter']['deleted_at']);
 	}

--- a/tests/phpunit/unit/PadFileServiceTest.php
+++ b/tests/phpunit/unit/PadFileServiceTest.php
@@ -64,7 +64,7 @@ class PadFileServiceTest extends TestCase {
 			10,
 			'demo-pad',
 			BindingService::ACCESS_PUBLIC,
-			'https://pad.example.test/p/demo-pad'
+			padUrl: 'https://pad.example.test/p/demo-pad',
 		);
 		$withoutPadUrl = $service->buildInitialDocument(11, 'demo-pad', BindingService::ACCESS_PUBLIC);
 
@@ -79,7 +79,7 @@ class PadFileServiceTest extends TestCase {
 			51,
 			'demo-pad',
 			BindingService::ACCESS_PUBLIC,
-			$padUrl
+			padUrl: $padUrl,
 		);
 
 		$parsed = $service->parsePadFile($document);
@@ -93,8 +93,8 @@ class PadFileServiceTest extends TestCase {
 			7,
 			'ext.remote-pad-id',
 			BindingService::ACCESS_PUBLIC,
-			'https://pad.remote.example/p/remote-pad-id',
-			[
+			padUrl: 'https://pad.remote.example/p/remote-pad-id',
+			extraFrontmatter: [
 				'pad_origin' => 'https://pad.remote.example',
 				'remote_pad_id' => 'remote-pad-id',
 			]
@@ -193,7 +193,7 @@ class PadFileServiceTest extends TestCase {
 		$service = new PadFileService();
 		$base = $service->buildInitialDocument(1, 'demo-pad', BindingService::ACCESS_PUBLIC);
 
-		$updated = $service->withExportSnapshot($service->readPad($base), "line-a\nline-b", '<p>line-a</p>', 7);
+		$updated = $service->withExportSnapshot($service->readPad($base), new PadSnapshot("line-a\nline-b", '<p>line-a</p>', 7));
 
 		$parsed = $service->readPad($updated);
 		$this->assertSame(7, $parsed->frontmatter['snapshot_rev']);
@@ -209,9 +209,9 @@ class PadFileServiceTest extends TestCase {
 		// become empty (otherwise stale content would resurface on restore).
 		$service = new PadFileService();
 		$base = $service->buildInitialDocument(1, 'demo-pad', BindingService::ACCESS_PUBLIC);
-		$withContent = $service->withExportSnapshot($service->readPad($base), 'previous text', '<p>previous html</p>', 5);
+		$withContent = $service->withExportSnapshot($service->readPad($base), new PadSnapshot('previous text', '<p>previous html</p>', 5));
 
-		$cleared = $service->withExportSnapshot($service->readPad($withContent), '', '', 6);
+		$cleared = $service->withExportSnapshot($service->readPad($withContent), new PadSnapshot('', '', 6));
 
 		$parsed = $service->readPad($cleared);
 		$this->assertSame(['text' => '', 'html' => ''], $service->getSnapshotPartsFromBody($parsed->body));
@@ -222,7 +222,7 @@ class PadFileServiceTest extends TestCase {
 		$service = new PadFileService();
 		$base = $service->buildInitialDocument(1, 'demo-pad', BindingService::ACCESS_PUBLIC);
 
-		$textOnly = $service->withExportSnapshot($service->readPad($base), 'just text', '<p>ignored</p>', 1, false);
+		$textOnly = $service->withExportSnapshot($service->readPad($base), new PadSnapshot('just text', null, 1));
 
 		$this->assertStringNotContainsString('[HTML-BEGIN]', $textOnly);
 		$this->assertStringNotContainsString('[HTML-END]', $textOnly);
@@ -241,21 +241,17 @@ class PadFileServiceTest extends TestCase {
 			1,
 			'g.grp$pad',
 			BindingService::ACCESS_PROTECTED,
-			'https://pad.example.test/p/x',
-			[],
-			new PadSnapshot('hello', '<p>hello</p>', 0),
+			snapshot: new PadSnapshot('hello', '<p>hello</p>', 0),
+			padUrl: 'https://pad.example.test/p/x',
 		);
 		$twoStep = $service->withExportSnapshot(
 			$service->readPad($service->buildInitialDocument(
 				1,
 				'g.grp$pad',
 				BindingService::ACCESS_PROTECTED,
-				'https://pad.example.test/p/x',
+				padUrl: 'https://pad.example.test/p/x',
 			)),
-			'hello',
-			'<p>hello</p>',
-			0,
-			true,
+			new PadSnapshot('hello', '<p>hello</p>', 0),
 		);
 
 		$this->assertSame(self::withoutWallClock($twoStep), self::withoutWallClock($oneStep));
@@ -276,22 +272,19 @@ class PadFileServiceTest extends TestCase {
 			2,
 			'ext.RemotePad',
 			BindingService::ACCESS_PUBLIC,
-			'https://pad.remote.test/p/RemotePad',
-			['pad_origin' => 'https://pad.remote.test'],
-			new PadSnapshot('remote text', null, 0),
+			snapshot: new PadSnapshot('remote text', null, 0),
+			padUrl: 'https://pad.remote.test/p/RemotePad',
+			extraFrontmatter: ['pad_origin' => 'https://pad.remote.test'],
 		);
 		$twoStep = $service->withExportSnapshot(
 			$service->readPad($service->buildInitialDocument(
 				2,
 				'ext.RemotePad',
 				BindingService::ACCESS_PUBLIC,
-				'https://pad.remote.test/p/RemotePad',
-				['pad_origin' => 'https://pad.remote.test'],
+				padUrl: 'https://pad.remote.test/p/RemotePad',
+				extraFrontmatter: ['pad_origin' => 'https://pad.remote.test'],
 			)),
-			'remote text',
-			'',
-			0,
-			false,
+			new PadSnapshot('remote text', null, 0),
 		);
 
 		$this->assertSame(self::withoutWallClock($twoStep), self::withoutWallClock($oneStep));
@@ -353,19 +346,11 @@ class PadFileServiceTest extends TestCase {
 		);
 	}
 
-	public function testAnExportCannotBeWrittenAtANegativeRevision(): void {
-		$service = new PadFileService();
-		$pad = $service->readPad($service->buildInitialDocument(1, 'demo-pad', BindingService::ACCESS_PUBLIC));
-
-		$this->expectException(PadFileFormatException::class);
-		$service->withExportSnapshot($pad, 'text', '', -1);
-	}
-
 	public function testASnapshotCannotClaimTheNoSnapshotRevision(): void {
 		// -1 is how the format says "never synced". A snapshot at that
 		// revision would make a never-synced pad look synced to the next
 		// sync's `$snapshotRev >= $currentRev` short circuit.
-		$this->expectException(PadFileFormatException::class);
+		$this->expectException(\InvalidArgumentException::class);
 		new PadSnapshot('text', null, -1);
 	}
 
@@ -377,8 +362,8 @@ class PadFileServiceTest extends TestCase {
 			321,
 			'ext.RemotePad',
 			BindingService::ACCESS_PUBLIC,
-			'https://pad.remote.test/p/x',
-			['remote_pad_id' => "a\npad_id: g.victim\$secret\naccess_mode: protected"],
+			padUrl: 'https://pad.remote.test/p/x',
+			extraFrontmatter: ['remote_pad_id' => "a\npad_id: g.victim\$secret\naccess_mode: protected"],
 		);
 	}
 
@@ -394,9 +379,7 @@ class PadFileServiceTest extends TestCase {
 		$service = new PadFileService();
 		$trashed = $service->readPad($service->withExportSnapshot(
 			$service->readPad($service->buildInitialDocument(1, 'old-pad', BindingService::ACCESS_PUBLIC)),
-			'original text',
-			'<p>original html</p>',
-			4,
+			new PadSnapshot('original text', '<p>original html</p>', 4),
 		));
 
 		$restored = $service->readPad($service->withRestoredSnapshot(
@@ -418,11 +401,20 @@ class PadFileServiceTest extends TestCase {
 		);
 	}
 
-	public function testGetSnapshotRevisionReturnsMinusOneForNonNumericValue(): void {
+	public function testTheParsedDocumentCarriesTheSnapshotRevision(): void {
 		$service = new PadFileService();
-		$this->assertSame(-1, $service->getSnapshotRevisionFromFrontmatter([]));
-		$this->assertSame(-1, $service->getSnapshotRevisionFromFrontmatter(['snapshot_rev' => 'abc']));
-		$this->assertSame(12, $service->getSnapshotRevisionFromFrontmatter(['snapshot_rev' => 12]));
+		$base = $service->buildInitialDocument(1, 'demo-pad', BindingService::ACCESS_PUBLIC);
+
+		$this->assertSame(-1, $service->readPad($base)->snapshotRev);
+		$this->assertSame(12, $service->readPad(str_replace('snapshot_rev: -1', 'snapshot_rev: 12', $base))->snapshotRev);
+	}
+
+	public function testANonNumericSnapshotRevisionIsAFormatError(): void {
+		$service = new PadFileService();
+		$base = $service->buildInitialDocument(1, 'demo-pad', BindingService::ACCESS_PUBLIC);
+
+		$this->expectException(PadFileFormatException::class);
+		$service->readPad(str_replace('snapshot_rev: -1', 'snapshot_rev: abc', $base));
 	}
 
 	// ------------------------------------------------------------------

--- a/tests/phpunit/unit/PadFileServiceTest.php
+++ b/tests/phpunit/unit/PadFileServiceTest.php
@@ -330,7 +330,6 @@ class PadFileServiceTest extends TestCase {
 			321,
 			'ext.RemotePad',
 			BindingService::ACCESS_PUBLIC,
-			'body',
 			'https://pad.remote.test/p/x',
 			['remote_pad_id' => "a\npad_id: g.victim\$secret\naccess_mode: protected"],
 		);

--- a/tests/phpunit/unit/PadFileServiceTest.php
+++ b/tests/phpunit/unit/PadFileServiceTest.php
@@ -308,10 +308,57 @@ class PadFileServiceTest extends TestCase {
 	/**
 	 * created_at and updated_at are read from the wall clock as each document
 	 * is built, so two documents built moments apart differ whenever a second
-	 * ticks between them. Everything else is what the comparison is about.
+	 * ticks between them. Everything else is what the comparison is about —
+	 * including a body that happens to hold a line shaped like one of those
+	 * keys, which is why only the frontmatter block is touched.
 	 */
 	private static function withoutWallClock(string $document): string {
-		return (string)preg_replace('/^(created_at|updated_at): ".*"$/m', '$1: "<time>"', $document);
+		if (preg_match('/^(---\n.*?\n---\n)(.*)$/s', $document, $matches) !== 1) {
+			return $document;
+		}
+
+		return (string)preg_replace('/^(created_at|updated_at): ".*"$/m', '$1: "<time>"', $matches[1])
+			. $matches[2];
+	}
+
+	public function testTheWallClockHelperNormalisesTheFrontmatterAndNothingElse(): void {
+		$service = new PadFileService();
+		$document = $service->buildInitialDocument(
+			1,
+			'demo-pad',
+			BindingService::ACCESS_PUBLIC,
+			snapshot: new PadSnapshot("created_at: \"in the body\"", null, 0),
+		);
+		// The frontmatter timestamps are the first two matches; the body's
+		// look-alike line comes after them.
+		$aSecondLater = (string)preg_replace(
+			'/^(created_at|updated_at): ".*"$/m',
+			'$1: "2026-01-01T00:00:00+00:00"',
+			$document,
+			2,
+		);
+
+		// What the comparison is meant to ignore.
+		$this->assertNotSame($document, $aSecondLater);
+		$this->assertSame(
+			self::withoutWallClock($document),
+			self::withoutWallClock($aSecondLater),
+		);
+
+		// And what it must not: a body that looks like a timestamp line.
+		$this->assertStringContainsString("created_at: \"in the body\"", self::withoutWallClock($document));
+		$this->assertNotSame(
+			self::withoutWallClock($document),
+			self::withoutWallClock(str_replace('in the body', 'changed', $document)),
+		);
+	}
+
+	public function testAnExportCannotBeWrittenAtANegativeRevision(): void {
+		$service = new PadFileService();
+		$pad = $service->readPad($service->buildInitialDocument(1, 'demo-pad', BindingService::ACCESS_PUBLIC));
+
+		$this->expectException(PadFileFormatException::class);
+		$service->withExportSnapshot($pad, 'text', '', -1);
 	}
 
 	public function testASnapshotCannotClaimTheNoSnapshotRevision(): void {

--- a/tests/phpunit/unit/PadInitializationServiceTest.php
+++ b/tests/phpunit/unit/PadInitializationServiceTest.php
@@ -48,6 +48,7 @@ class PadInitializationServiceTest extends TestCase {
 				accessMode: BindingService::ACCESS_PUBLIC,
 				padUrl: '',
 				isExternal: false,
+				snapshotRev: -1,
 			));
 
 		$bootstrap = $this->createMock(PadBootstrapService::class);
@@ -88,6 +89,7 @@ class PadInitializationServiceTest extends TestCase {
 				accessMode: BindingService::ACCESS_PUBLIC,
 				padUrl: '',
 				isExternal: false,
+				snapshotRev: -1,
 			));
 
 		$bootstrap = $this->createMock(PadBootstrapService::class);
@@ -138,6 +140,7 @@ class PadInitializationServiceTest extends TestCase {
 				accessMode: BindingService::ACCESS_PUBLIC,
 				padUrl: '',
 				isExternal: false,
+				snapshotRev: -1,
 			));
 
 		$bootstrap = $this->createMock(PadBootstrapService::class);
@@ -181,6 +184,7 @@ class PadInitializationServiceTest extends TestCase {
 					accessMode: BindingService::ACCESS_PROTECTED,
 					padUrl: '',
 					isExternal: false,
+					snapshotRev: -1,
 				);
 			});
 
@@ -227,6 +231,7 @@ class PadInitializationServiceTest extends TestCase {
 					accessMode: BindingService::ACCESS_PUBLIC,
 					padUrl: '',
 					isExternal: false,
+					snapshotRev: -1,
 				);
 			});
 

--- a/tests/phpunit/unit/PadLegacyMigrationServiceTest.php
+++ b/tests/phpunit/unit/PadLegacyMigrationServiceTest.php
@@ -65,7 +65,7 @@ class PadLegacyMigrationServiceTest extends TestCase {
 			->willReturn(BindingService::ACCESS_PUBLIC);
 		$padFileService->expects($this->once())
 			->method('buildInitialDocument')
-			->with(202, 'team-pad', BindingService::ACCESS_PUBLIC, '', 'https://pad.our-server.test/p/team-pad')
+			->with(202, 'team-pad', BindingService::ACCESS_PUBLIC, 'https://pad.our-server.test/p/team-pad')
 			->willReturn('written-frontmatter');
 
 		$etherpadClient = $this->createMock(EtherpadClient::class);

--- a/tests/phpunit/unit/PadLegacyMigrationServiceTest.php
+++ b/tests/phpunit/unit/PadLegacyMigrationServiceTest.php
@@ -65,7 +65,7 @@ class PadLegacyMigrationServiceTest extends TestCase {
 			->willReturn(BindingService::ACCESS_PUBLIC);
 		$padFileService->expects($this->once())
 			->method('buildInitialDocument')
-			->with(202, 'team-pad', BindingService::ACCESS_PUBLIC, 'https://pad.our-server.test/p/team-pad')
+			->with(202, 'team-pad', BindingService::ACCESS_PUBLIC, null, 'https://pad.our-server.test/p/team-pad')
 			->willReturn('written-frontmatter');
 
 		$etherpadClient = $this->createMock(EtherpadClient::class);

--- a/tests/phpunit/unit/PadLifecycleControllerTest.php
+++ b/tests/phpunit/unit/PadLifecycleControllerTest.php
@@ -64,7 +64,7 @@ class PadLifecycleControllerTest extends TestCase {
 		$rootFolder->method('getById')->with(138)->willReturn([$file]);
 
 		$padFileService = $this->createMock(PadFileService::class);
-		$padFileService->method('readPad')->willReturn(new ParsedPadFile(
+		$parsedPad = new ParsedPadFile(
 			frontmatter: [
 				'pad_id' => 'g.ABCDEFGHIJKLMNOP$pad-1',
 				'access_mode' => BindingService::ACCESS_PROTECTED,
@@ -74,9 +74,10 @@ class PadLifecycleControllerTest extends TestCase {
 			accessMode: BindingService::ACCESS_PROTECTED,
 			padUrl: '',
 			isExternal: false,
-		));
-		$padFileService->method('getSnapshotRevisionFromFrontmatter')->willReturn(4);
-		$padFileService->method('withExportSnapshot')->with($this->isInstanceOf(ParsedPadFile::class), 'hello', '<p>hello</p>', 5)->willReturn('updated-content');
+		);
+		$padFileService->method('readPad')->willReturn($parsedPad);
+		$padFileService->method('getSnapshotRevisionFromFrontmatter')->with($parsedPad->frontmatter)->willReturn(4);
+		$padFileService->method('withExportSnapshot')->with($this->identicalTo($parsedPad), 'hello', '<p>hello</p>', 5)->willReturn('updated-content');
 
 		$bindingService = $this->createMock(BindingService::class);
 		$bindingService->expects($this->once())
@@ -118,7 +119,7 @@ class PadLifecycleControllerTest extends TestCase {
 		$rootFolder->method('getById')->with(138)->willReturn([$file]);
 
 		$padFileService = $this->createMock(PadFileService::class);
-		$padFileService->method('readPad')->willReturn(new ParsedPadFile(
+		$parsedPad = new ParsedPadFile(
 			frontmatter: [
 				'pad_id' => 'g.ABCDEFGHIJKLMNOP$pad-1',
 				'access_mode' => BindingService::ACCESS_PROTECTED,
@@ -128,9 +129,10 @@ class PadLifecycleControllerTest extends TestCase {
 			accessMode: BindingService::ACCESS_PROTECTED,
 			padUrl: '',
 			isExternal: false,
-		));
-		$padFileService->method('getSnapshotRevisionFromFrontmatter')->willReturn(1);
-		$padFileService->method('withExportSnapshot')->with($this->isInstanceOf(ParsedPadFile::class), 'hello', '<p>hello</p>', 5)->willReturn('updated-content');
+		);
+		$padFileService->method('readPad')->willReturn($parsedPad);
+		$padFileService->method('getSnapshotRevisionFromFrontmatter')->with($parsedPad->frontmatter)->willReturn(1);
+		$padFileService->method('withExportSnapshot')->with($this->identicalTo($parsedPad), 'hello', '<p>hello</p>', 5)->willReturn('updated-content');
 
 		$bindingService = $this->createMock(BindingService::class);
 		$bindingService->method('assertConsistentMapping');
@@ -166,7 +168,7 @@ class PadLifecycleControllerTest extends TestCase {
 		$rootFolder->method('getById')->with(138)->willReturn([$file]);
 
 		$padFileService = $this->createMock(PadFileService::class);
-		$padFileService->method('readPad')->willReturn(new ParsedPadFile(
+		$parsedPad = new ParsedPadFile(
 			frontmatter: [
 				'pad_id' => 'g.ABCDEFGHIJKLMNOP$pad-1',
 				'access_mode' => BindingService::ACCESS_PROTECTED,
@@ -176,9 +178,10 @@ class PadLifecycleControllerTest extends TestCase {
 			accessMode: BindingService::ACCESS_PROTECTED,
 			padUrl: '',
 			isExternal: false,
-		));
-		$padFileService->method('getSnapshotRevisionFromFrontmatter')->willReturn(5);
-		$padFileService->method('getSnapshotPartsFromBody')->willReturn(['text' => 'hello', 'html' => '<p>hello</p>']);
+		);
+		$padFileService->method('readPad')->willReturn($parsedPad);
+		$padFileService->method('getSnapshotRevisionFromFrontmatter')->with($parsedPad->frontmatter)->willReturn(5);
+		$padFileService->method('getSnapshotPartsFromBody')->with($parsedPad->body)->willReturn(['text' => 'hello', 'html' => '<p>hello</p>']);
 
 		$bindingService = $this->createMock(BindingService::class);
 		$bindingService->method('assertConsistentMapping');
@@ -219,7 +222,7 @@ class PadLifecycleControllerTest extends TestCase {
 		$rootFolder->method('getById')->with(138)->willReturn([$file]);
 
 		$padFileService = $this->createMock(PadFileService::class);
-		$padFileService->method('readPad')->willReturn(new ParsedPadFile(
+		$parsedPad = new ParsedPadFile(
 			frontmatter: [
 				'pad_id' => 'ext.remote-pad',
 				'access_mode' => BindingService::ACCESS_PUBLIC,
@@ -232,8 +235,9 @@ class PadLifecycleControllerTest extends TestCase {
 			accessMode: BindingService::ACCESS_PUBLIC,
 			padUrl: 'https://pad.example.test/p/public-pad',
 			isExternal: true,
-		));
-		$padFileService->method('getSnapshotPartsFromBody')->willReturn(['text' => 'same text', 'html' => '']);
+		);
+		$padFileService->method('readPad')->willReturn($parsedPad);
+		$padFileService->method('getSnapshotPartsFromBody')->with($parsedPad->body)->willReturn(['text' => 'same text', 'html' => '']);
 
 		$bindingService = $this->createMock(BindingService::class);
 		$bindingService->method('assertConsistentMapping');
@@ -291,14 +295,15 @@ class PadLifecycleControllerTest extends TestCase {
 		$userSession->method('getUser')->willReturn($user);
 
 		$padFileService = $this->createMock(PadFileService::class);
-		$padFileService->method('readPad')->willReturn(new ParsedPadFile(
+		$parsedPad = new ParsedPadFile(
 			frontmatter: ['pad_id' => 'orig'],
 			body: '',
 			padId: 'orig',
 			accessMode: '',
 			padUrl: '',
 			isExternal: false,
-		));
+		);
+		$padFileService->method('readPad')->willReturn($parsedPad);
 
 		$bindingService = $this->createMock(BindingService::class);
 		$bindingService->method('findByPadId')
@@ -360,14 +365,15 @@ class PadLifecycleControllerTest extends TestCase {
 		$rootFolder->method('getById')->with(800)->willReturn([$orphan]);
 
 		$padFileService = $this->createMock(PadFileService::class);
-		$padFileService->method('readPad')->willReturn(new ParsedPadFile(
+		$parsedPad = new ParsedPadFile(
 			frontmatter: ['pad_id' => 'orphan'],
 			body: '',
 			padId: 'orphan',
 			accessMode: '',
 			padUrl: '',
 			isExternal: false,
-		));
+		);
+		$padFileService->method('readPad')->willReturn($parsedPad);
 
 		$controller = $this->buildController(
 			$this->createMock(IRequest::class),

--- a/tests/phpunit/unit/PadLifecycleControllerTest.php
+++ b/tests/phpunit/unit/PadLifecycleControllerTest.php
@@ -75,7 +75,7 @@ class PadLifecycleControllerTest extends TestCase {
 			padUrl: '',
 			isExternal: false,
 		);
-		$padFileService->method('readPad')->willReturn($parsedPad);
+		$padFileService->method('readPad')->with('frontmatter')->willReturn($parsedPad);
 		$padFileService->method('getSnapshotRevisionFromFrontmatter')->with($parsedPad->frontmatter)->willReturn(4);
 		$padFileService->method('withExportSnapshot')->with($this->identicalTo($parsedPad), 'hello', '<p>hello</p>', 5)->willReturn('updated-content');
 
@@ -130,7 +130,7 @@ class PadLifecycleControllerTest extends TestCase {
 			padUrl: '',
 			isExternal: false,
 		);
-		$padFileService->method('readPad')->willReturn($parsedPad);
+		$padFileService->method('readPad')->with('frontmatter')->willReturn($parsedPad);
 		$padFileService->method('getSnapshotRevisionFromFrontmatter')->with($parsedPad->frontmatter)->willReturn(1);
 		$padFileService->method('withExportSnapshot')->with($this->identicalTo($parsedPad), 'hello', '<p>hello</p>', 5)->willReturn('updated-content');
 
@@ -179,7 +179,7 @@ class PadLifecycleControllerTest extends TestCase {
 			padUrl: '',
 			isExternal: false,
 		);
-		$padFileService->method('readPad')->willReturn($parsedPad);
+		$padFileService->method('readPad')->with('frontmatter')->willReturn($parsedPad);
 		$padFileService->method('getSnapshotRevisionFromFrontmatter')->with($parsedPad->frontmatter)->willReturn(5);
 		$padFileService->method('getSnapshotPartsFromBody')->with($parsedPad->body)->willReturn(['text' => 'hello', 'html' => '<p>hello</p>']);
 
@@ -236,7 +236,7 @@ class PadLifecycleControllerTest extends TestCase {
 			padUrl: 'https://pad.example.test/p/public-pad',
 			isExternal: true,
 		);
-		$padFileService->method('readPad')->willReturn($parsedPad);
+		$padFileService->method('readPad')->with('frontmatter')->willReturn($parsedPad);
 		$padFileService->method('getSnapshotPartsFromBody')->with($parsedPad->body)->willReturn(['text' => 'same text', 'html' => '']);
 
 		$bindingService = $this->createMock(BindingService::class);
@@ -303,7 +303,7 @@ class PadLifecycleControllerTest extends TestCase {
 			padUrl: '',
 			isExternal: false,
 		);
-		$padFileService->method('readPad')->willReturn($parsedPad);
+		$padFileService->method('readPad')->with('doc')->willReturn($parsedPad);
 
 		$bindingService = $this->createMock(BindingService::class);
 		$bindingService->method('findByPadId')
@@ -373,7 +373,7 @@ class PadLifecycleControllerTest extends TestCase {
 			padUrl: '',
 			isExternal: false,
 		);
-		$padFileService->method('readPad')->willReturn($parsedPad);
+		$padFileService->method('readPad')->with('frontmatter')->willReturn($parsedPad);
 
 		$controller = $this->buildController(
 			$this->createMock(IRequest::class),

--- a/tests/phpunit/unit/PadLifecycleControllerTest.php
+++ b/tests/phpunit/unit/PadLifecycleControllerTest.php
@@ -75,8 +75,8 @@ class PadLifecycleControllerTest extends TestCase {
 			padUrl: '',
 			isExternal: false,
 		));
-		$padFileService->method('getSnapshotRevision')->willReturn(4);
-		$padFileService->method('withExportSnapshot')->with("frontmatter", 'hello', '<p>hello</p>', 5)->willReturn('updated-content');
+		$padFileService->method('getSnapshotRevisionFromFrontmatter')->willReturn(4);
+		$padFileService->method('withExportSnapshot')->with($this->isInstanceOf(ParsedPadFile::class), 'hello', '<p>hello</p>', 5)->willReturn('updated-content');
 
 		$bindingService = $this->createMock(BindingService::class);
 		$bindingService->expects($this->once())
@@ -129,8 +129,8 @@ class PadLifecycleControllerTest extends TestCase {
 			padUrl: '',
 			isExternal: false,
 		));
-		$padFileService->method('getSnapshotRevision')->willReturn(1);
-		$padFileService->method('withExportSnapshot')->with("frontmatter", 'hello', '<p>hello</p>', 5)->willReturn('updated-content');
+		$padFileService->method('getSnapshotRevisionFromFrontmatter')->willReturn(1);
+		$padFileService->method('withExportSnapshot')->with($this->isInstanceOf(ParsedPadFile::class), 'hello', '<p>hello</p>', 5)->willReturn('updated-content');
 
 		$bindingService = $this->createMock(BindingService::class);
 		$bindingService->method('assertConsistentMapping');
@@ -177,9 +177,8 @@ class PadLifecycleControllerTest extends TestCase {
 			padUrl: '',
 			isExternal: false,
 		));
-		$padFileService->method('getSnapshotRevision')->willReturn(5);
-		$padFileService->method('getTextSnapshotForRestore')->with('frontmatter')->willReturn('hello');
-		$padFileService->method('getHtmlSnapshotForRestore')->with('frontmatter')->willReturn('<p>hello</p>');
+		$padFileService->method('getSnapshotRevisionFromFrontmatter')->willReturn(5);
+		$padFileService->method('getSnapshotPartsFromBody')->willReturn(['text' => 'hello', 'html' => '<p>hello</p>']);
 
 		$bindingService = $this->createMock(BindingService::class);
 		$bindingService->method('assertConsistentMapping');
@@ -234,7 +233,7 @@ class PadLifecycleControllerTest extends TestCase {
 			padUrl: 'https://pad.example.test/p/public-pad',
 			isExternal: true,
 		));
-		$padFileService->method('getTextSnapshotForRestore')->willReturn('same text');
+		$padFileService->method('getSnapshotPartsFromBody')->willReturn(['text' => 'same text', 'html' => '']);
 
 		$bindingService = $this->createMock(BindingService::class);
 		$bindingService->method('assertConsistentMapping');

--- a/tests/phpunit/unit/PadLifecycleControllerTest.php
+++ b/tests/phpunit/unit/PadLifecycleControllerTest.php
@@ -17,6 +17,7 @@ use OCA\EtherpadNextcloud\Service\PadFileService;
 use OCA\EtherpadNextcloud\Service\PadMetadataService;
 use OCA\EtherpadNextcloud\Service\PadResponseService;
 use OCA\EtherpadNextcloud\Service\PadSyncService;
+use OCA\EtherpadNextcloud\Service\PadSnapshot;
 use OCA\EtherpadNextcloud\Service\ParsedPadFile;
 use OCA\EtherpadNextcloud\Service\UserNodeResolver;
 use OCA\EtherpadNextcloud\Util\PathNormalizer;
@@ -74,10 +75,10 @@ class PadLifecycleControllerTest extends TestCase {
 			accessMode: BindingService::ACCESS_PROTECTED,
 			padUrl: '',
 			isExternal: false,
+			snapshotRev: 4,
 		);
 		$padFileService->method('readPad')->with('frontmatter')->willReturn($parsedPad);
-		$padFileService->method('getSnapshotRevisionFromFrontmatter')->with($parsedPad->frontmatter)->willReturn(4);
-		$padFileService->method('withExportSnapshot')->with($this->identicalTo($parsedPad), 'hello', '<p>hello</p>', 5)->willReturn('updated-content');
+		$padFileService->method('withExportSnapshot')->with($this->identicalTo($parsedPad), new PadSnapshot('hello', '<p>hello</p>', 5))->willReturn('updated-content');
 
 		$bindingService = $this->createMock(BindingService::class);
 		$bindingService->expects($this->once())
@@ -129,10 +130,10 @@ class PadLifecycleControllerTest extends TestCase {
 			accessMode: BindingService::ACCESS_PROTECTED,
 			padUrl: '',
 			isExternal: false,
+			snapshotRev: 1,
 		);
 		$padFileService->method('readPad')->with('frontmatter')->willReturn($parsedPad);
-		$padFileService->method('getSnapshotRevisionFromFrontmatter')->with($parsedPad->frontmatter)->willReturn(1);
-		$padFileService->method('withExportSnapshot')->with($this->identicalTo($parsedPad), 'hello', '<p>hello</p>', 5)->willReturn('updated-content');
+		$padFileService->method('withExportSnapshot')->with($this->identicalTo($parsedPad), new PadSnapshot('hello', '<p>hello</p>', 5))->willReturn('updated-content');
 
 		$bindingService = $this->createMock(BindingService::class);
 		$bindingService->method('assertConsistentMapping');
@@ -178,9 +179,9 @@ class PadLifecycleControllerTest extends TestCase {
 			accessMode: BindingService::ACCESS_PROTECTED,
 			padUrl: '',
 			isExternal: false,
+			snapshotRev: 5,
 		);
 		$padFileService->method('readPad')->with('frontmatter')->willReturn($parsedPad);
-		$padFileService->method('getSnapshotRevisionFromFrontmatter')->with($parsedPad->frontmatter)->willReturn(5);
 		$padFileService->method('getSnapshotPartsFromBody')->with($parsedPad->body)->willReturn(['text' => 'hello', 'html' => '<p>hello</p>']);
 
 		$bindingService = $this->createMock(BindingService::class);
@@ -235,6 +236,7 @@ class PadLifecycleControllerTest extends TestCase {
 			accessMode: BindingService::ACCESS_PUBLIC,
 			padUrl: 'https://pad.example.test/p/public-pad',
 			isExternal: true,
+			snapshotRev: -1,
 		);
 		$padFileService->method('readPad')->with('frontmatter')->willReturn($parsedPad);
 		$padFileService->method('getSnapshotPartsFromBody')->with($parsedPad->body)->willReturn(['text' => 'same text', 'html' => '']);
@@ -302,6 +304,7 @@ class PadLifecycleControllerTest extends TestCase {
 			accessMode: '',
 			padUrl: '',
 			isExternal: false,
+			snapshotRev: -1,
 		);
 		$padFileService->method('readPad')->with('doc')->willReturn($parsedPad);
 
@@ -372,6 +375,7 @@ class PadLifecycleControllerTest extends TestCase {
 			accessMode: '',
 			padUrl: '',
 			isExternal: false,
+			snapshotRev: -1,
 		);
 		$padFileService->method('readPad')->with('frontmatter')->willReturn($parsedPad);
 

--- a/tests/phpunit/unit/PadMetadataServiceTest.php
+++ b/tests/phpunit/unit/PadMetadataServiceTest.php
@@ -43,6 +43,7 @@ class PadMetadataServiceTest extends TestCase {
 			accessMode: BindingService::ACCESS_PUBLIC,
 			padUrl: 'https://pad.example.test/p/External',
 			isExternal: true,
+			snapshotRev: -1,
 		));
 
 		$fetcher = $this->createMock(ExternalPadExportFetcher::class);
@@ -102,6 +103,7 @@ class PadMetadataServiceTest extends TestCase {
 			accessMode: BindingService::ACCESS_PUBLIC,
 			padUrl: '',
 			isExternal: false,
+			snapshotRev: -1,
 		));
 
 		$etherpadClient = $this->createMock(EtherpadClient::class);
@@ -146,6 +148,7 @@ class PadMetadataServiceTest extends TestCase {
 			accessMode: BindingService::ACCESS_PUBLIC,
 			padUrl: '',
 			isExternal: false,
+			snapshotRev: -1,
 		));
 
 		$etherpadClient = $this->createMock(EtherpadClient::class);
@@ -187,6 +190,7 @@ class PadMetadataServiceTest extends TestCase {
 			// not survive as the answer.
 			padUrl: 'https://pad.example.test/p/g.ABC$pad',
 			isExternal: false,
+			snapshotRev: -1,
 		));
 
 		$etherpadClient = $this->createMock(EtherpadClient::class);
@@ -221,6 +225,7 @@ class PadMetadataServiceTest extends TestCase {
 			accessMode: '',
 			padUrl: '',
 			isExternal: false,
+			snapshotRev: -1,
 		));
 
 		$bindingService = $this->createMock(BindingService::class);
@@ -266,6 +271,7 @@ class PadMetadataServiceTest extends TestCase {
 			accessMode: '',
 			padUrl: '',
 			isExternal: false,
+			snapshotRev: -1,
 		));
 
 		$bindingService = $this->createMock(BindingService::class);
@@ -293,6 +299,7 @@ class PadMetadataServiceTest extends TestCase {
 			accessMode: '',
 			padUrl: '',
 			isExternal: false,
+			snapshotRev: -1,
 		));
 
 		$bindingService = $this->createMock(BindingService::class);
@@ -322,6 +329,7 @@ class PadMetadataServiceTest extends TestCase {
 			accessMode: '',
 			padUrl: '',
 			isExternal: true,
+			snapshotRev: -1,
 		));
 
 		$bindingService = $this->createMock(BindingService::class);
@@ -386,6 +394,7 @@ class PadMetadataServiceTest extends TestCase {
 			accessMode: '',
 			padUrl: '',
 			isExternal: false,
+			snapshotRev: -1,
 		));
 
 		$bindingService = $this->createMock(BindingService::class);

--- a/tests/phpunit/unit/PadOpenServiceTest.php
+++ b/tests/phpunit/unit/PadOpenServiceTest.php
@@ -165,6 +165,7 @@ class PadOpenServiceTest extends TestCase {
 			accessMode: $accessMode,
 			padUrl: '',
 			isExternal: false,
+			snapshotRev: -1,
 		));
 
 		$client = $etherpadClient ?? $this->createMock(EtherpadClient::class);

--- a/tests/phpunit/unit/PadSessionControllerTest.php
+++ b/tests/phpunit/unit/PadSessionControllerTest.php
@@ -80,6 +80,7 @@ class PadSessionControllerTest extends TestCase {
 				accessMode: BindingService::ACCESS_PUBLIC,
 				padUrl: '',
 				isExternal: false,
+				snapshotRev: -1,
 			));
 
 		$bindingService = $this->createMock(BindingService::class);
@@ -204,6 +205,7 @@ class PadSessionControllerTest extends TestCase {
 				accessMode: BindingService::ACCESS_PUBLIC,
 				padUrl: 'https://pad.portal.fzs.de/p/Test',
 				isExternal: true,
+				snapshotRev: -1,
 			));
 		// The open no longer reads the stored copy at all — the preview
 		// loads the pad from its own server over `content_url`.

--- a/tests/phpunit/unit/PadSessionControllerTest.php
+++ b/tests/phpunit/unit/PadSessionControllerTest.php
@@ -207,8 +207,7 @@ class PadSessionControllerTest extends TestCase {
 			));
 		// The open no longer reads the stored copy at all — the preview
 		// loads the pad from its own server over `content_url`.
-		$padFileService->expects($this->never())->method('getTextSnapshotForRestore');
-		$padFileService->expects($this->never())->method('getHtmlSnapshotForRestore');
+		$padFileService->expects($this->never())->method('getSnapshotPartsFromBody');
 
 		$bindingService = $this->createMock(BindingService::class);
 		$bindingService->expects($this->never())->method('assertConsistentMapping');

--- a/tests/phpunit/unit/PadSyncServiceTest.php
+++ b/tests/phpunit/unit/PadSyncServiceTest.php
@@ -10,6 +10,7 @@ use OCA\EtherpadNextcloud\Service\ExternalPadExportFetcher;
 use OCA\EtherpadNextcloud\Service\PadFileLockRetryService;
 use OCA\EtherpadNextcloud\Service\PadFileService;
 use OCA\EtherpadNextcloud\Service\PadSyncService;
+use OCA\EtherpadNextcloud\Service\PadSnapshot;
 use OCA\EtherpadNextcloud\Service\ParsedPadFile;
 use OCA\EtherpadNextcloud\Service\UserNodeResolver;
 use OCP\Files\File;
@@ -35,6 +36,7 @@ class PadSyncServiceTest extends TestCase {
 			accessMode: BindingService::ACCESS_PUBLIC,
 			padUrl: 'https://pad.example.test/p/remote',
 			isExternal: true,
+			snapshotRev: -1,
 		));
 
 		$bindingService = $this->createMock(BindingService::class);
@@ -66,9 +68,9 @@ class PadSyncServiceTest extends TestCase {
 			accessMode: BindingService::ACCESS_PROTECTED,
 			padUrl: '',
 			isExternal: false,
+			snapshotRev: 3,
 		);
 		$padFileService->method('readPad')->with('frontmatter')->willReturn($parsedPad);
-		$padFileService->method('getSnapshotRevisionFromFrontmatter')->with($parsedPad->frontmatter)->willReturn(3);
 
 		$bindingService = $this->createMock(BindingService::class);
 		$bindingService->expects($this->once())
@@ -110,6 +112,7 @@ class PadSyncServiceTest extends TestCase {
 			accessMode: BindingService::ACCESS_PUBLIC,
 			padUrl: 'https://pad.example.test/p/remote',
 			isExternal: true,
+			snapshotRev: 4,
 		);
 		$padFileService->method('readPad')->with('frontmatter')->willReturn($parsedPad);
 		$padFileService->expects($this->once())
@@ -117,12 +120,8 @@ class PadSyncServiceTest extends TestCase {
 			->with($parsedPad->body)
 			->willReturn(['text' => 'previous text', 'html' => '']);
 		$padFileService->expects($this->once())
-			->method('getSnapshotRevisionFromFrontmatter')
-			->with($parsedPad->frontmatter)
-			->willReturn(4);
-		$padFileService->expects($this->once())
 			->method('withExportSnapshot')
-			->with($this->identicalTo($parsedPad), "remote text\nfrom export", '', 5, false)
+			->with($this->identicalTo($parsedPad), new PadSnapshot("remote text\nfrom export", null, 5))
 			->willReturn('updated-frontmatter');
 
 		$bindingService = $this->createMock(BindingService::class);

--- a/tests/phpunit/unit/PadSyncServiceTest.php
+++ b/tests/phpunit/unit/PadSyncServiceTest.php
@@ -67,7 +67,7 @@ class PadSyncServiceTest extends TestCase {
 			padUrl: '',
 			isExternal: false,
 		));
-		$padFileService->method('getSnapshotRevision')->with('frontmatter')->willReturn(3);
+		$padFileService->method('getSnapshotRevisionFromFrontmatter')->willReturn(3);
 
 		$bindingService = $this->createMock(BindingService::class);
 		$bindingService->expects($this->once())
@@ -111,16 +111,14 @@ class PadSyncServiceTest extends TestCase {
 			isExternal: true,
 		));
 		$padFileService->expects($this->once())
-			->method('getTextSnapshotForRestore')
-			->with('frontmatter')
-			->willReturn('previous text');
+			->method('getSnapshotPartsFromBody')
+			->willReturn(['text' => 'previous text', 'html' => '']);
 		$padFileService->expects($this->once())
-			->method('getSnapshotRevision')
-			->with('frontmatter')
+			->method('getSnapshotRevisionFromFrontmatter')
 			->willReturn(4);
 		$padFileService->expects($this->once())
 			->method('withExportSnapshot')
-			->with('frontmatter', "remote text\nfrom export", '', 5, false)
+			->with($this->isInstanceOf(ParsedPadFile::class), "remote text\nfrom export", '', 5, false)
 			->willReturn('updated-frontmatter');
 
 		$bindingService = $this->createMock(BindingService::class);

--- a/tests/phpunit/unit/PadSyncServiceTest.php
+++ b/tests/phpunit/unit/PadSyncServiceTest.php
@@ -56,7 +56,7 @@ class PadSyncServiceTest extends TestCase {
 		$userNodeResolver->method('resolveUserFileNodeById')->with('alice', 138)->willReturn($file);
 
 		$padFileService = $this->createMock(PadFileService::class);
-		$padFileService->method('readPad')->with('frontmatter')->willReturn(new ParsedPadFile(
+		$parsedPad = new ParsedPadFile(
 			frontmatter: [
 				'pad_id' => 'g.ABC$pad',
 				'access_mode' => BindingService::ACCESS_PROTECTED,
@@ -66,8 +66,9 @@ class PadSyncServiceTest extends TestCase {
 			accessMode: BindingService::ACCESS_PROTECTED,
 			padUrl: '',
 			isExternal: false,
-		));
-		$padFileService->method('getSnapshotRevisionFromFrontmatter')->willReturn(3);
+		);
+		$padFileService->method('readPad')->with('frontmatter')->willReturn($parsedPad);
+		$padFileService->method('getSnapshotRevisionFromFrontmatter')->with($parsedPad->frontmatter)->willReturn(3);
 
 		$bindingService = $this->createMock(BindingService::class);
 		$bindingService->expects($this->once())

--- a/tests/phpunit/unit/PadSyncServiceTest.php
+++ b/tests/phpunit/unit/PadSyncServiceTest.php
@@ -99,7 +99,7 @@ class PadSyncServiceTest extends TestCase {
 		$userNodeResolver->method('toUserAbsolutePath')->with('alice', $file)->willReturn('/Remote.pad');
 
 		$padFileService = $this->createMock(PadFileService::class);
-		$padFileService->method('readPad')->with('frontmatter')->willReturn(new ParsedPadFile(
+		$parsedPad = new ParsedPadFile(
 			frontmatter: [
 				'pad_id' => 'ext.remote',
 				'access_mode' => BindingService::ACCESS_PUBLIC,
@@ -109,16 +109,19 @@ class PadSyncServiceTest extends TestCase {
 			accessMode: BindingService::ACCESS_PUBLIC,
 			padUrl: 'https://pad.example.test/p/remote',
 			isExternal: true,
-		));
+		);
+		$padFileService->method('readPad')->with('frontmatter')->willReturn($parsedPad);
 		$padFileService->expects($this->once())
 			->method('getSnapshotPartsFromBody')
+			->with($parsedPad->body)
 			->willReturn(['text' => 'previous text', 'html' => '']);
 		$padFileService->expects($this->once())
 			->method('getSnapshotRevisionFromFrontmatter')
+			->with($parsedPad->frontmatter)
 			->willReturn(4);
 		$padFileService->expects($this->once())
 			->method('withExportSnapshot')
-			->with($this->isInstanceOf(ParsedPadFile::class), "remote text\nfrom export", '', 5, false)
+			->with($this->identicalTo($parsedPad), "remote text\nfrom export", '', 5, false)
 			->willReturn('updated-frontmatter');
 
 		$bindingService = $this->createMock(BindingService::class);

--- a/tests/phpunit/unit/PadTemplateAdminServiceTest.php
+++ b/tests/phpunit/unit/PadTemplateAdminServiceTest.php
@@ -257,6 +257,7 @@ class PadTemplateAdminServiceTest extends TestCase {
 			accessMode: 'protected',
 			padUrl: '',
 			isExternal: $isExternal,
+			snapshotRev: -1,
 		));
 
 		$l10n = $this->createMock(IL10N::class);

--- a/tests/phpunit/unit/PublicPadContextServiceTest.php
+++ b/tests/phpunit/unit/PublicPadContextServiceTest.php
@@ -55,6 +55,7 @@ class PublicPadContextServiceTest extends TestCase {
 			accessMode: BindingService::ACCESS_PROTECTED,
 			padUrl: '',
 			isExternal: false,
+			snapshotRev: -1,
 		));
 
 		$bindings = $this->createMock(BindingService::class);
@@ -119,6 +120,7 @@ class PublicPadContextServiceTest extends TestCase {
 			accessMode: BindingService::ACCESS_PROTECTED,
 			padUrl: '',
 			isExternal: false,
+			snapshotRev: -1,
 		));
 
 		$fetcher = $this->createMock(LivePadHtmlFetcher::class);

--- a/tests/phpunit/unit/PublicViewerControllerTest.php
+++ b/tests/phpunit/unit/PublicViewerControllerTest.php
@@ -68,8 +68,7 @@ class PublicViewerControllerTest extends TestCase {
 			));
 		// The stored copy plays no part in opening any more: the viewer
 		// loads the pad from the pad server over `content_url`.
-		$padFileService->expects($this->never())->method('getTextSnapshotForRestore');
-		$padFileService->expects($this->never())->method('getHtmlSnapshotForRestore');
+		$padFileService->expects($this->never())->method('getSnapshotPartsFromBody');
 
 		$bindingService = $this->createMock(BindingService::class);
 		$bindingService->expects($this->once())
@@ -135,8 +134,7 @@ class PublicViewerControllerTest extends TestCase {
 				padUrl: 'https://pad.portal.example/p/Test',
 				isExternal: true,
 			));
-		$padFileService->expects($this->never())->method('getTextSnapshotForRestore');
-		$padFileService->expects($this->never())->method('getHtmlSnapshotForRestore');
+		$padFileService->expects($this->never())->method('getSnapshotPartsFromBody');
 
 		$bindingService = $this->createMock(BindingService::class);
 		$bindingService->expects($this->never())->method('assertConsistentMapping');

--- a/tests/phpunit/unit/PublicViewerControllerTest.php
+++ b/tests/phpunit/unit/PublicViewerControllerTest.php
@@ -65,6 +65,7 @@ class PublicViewerControllerTest extends TestCase {
 				accessMode: BindingService::ACCESS_PROTECTED,
 				padUrl: '',
 				isExternal: false,
+				snapshotRev: -1,
 			));
 		// The stored copy plays no part in opening any more: the viewer
 		// loads the pad from the pad server over `content_url`.
@@ -133,6 +134,7 @@ class PublicViewerControllerTest extends TestCase {
 				accessMode: BindingService::ACCESS_PUBLIC,
 				padUrl: 'https://pad.portal.example/p/Test',
 				isExternal: true,
+				snapshotRev: -1,
 			));
 		$padFileService->expects($this->never())->method('getSnapshotPartsFromBody');
 
@@ -199,6 +201,7 @@ class PublicViewerControllerTest extends TestCase {
 				accessMode: BindingService::ACCESS_PROTECTED,
 				padUrl: 'https://remote.example.test/p/demo',
 				isExternal: true,
+				snapshotRev: -1,
 			));
 
 		$bindingService = $this->createMock(BindingService::class);


### PR DESCRIPTION
Finding 9 from the big review: the same `.pad` is analysed several times even though `readPad()` already hands back the frontmatter and the body together. Callers then passed the same string on to methods that parsed it again.

Counted along the call chains, `parsePadFile()` passes per flow:

| Flow | before | after |
|---|---|---|
| Forced internal sync | 5 | 1 |
| Restore | 3 | 1 |
| Sync status | 2 | 1 |
| Create from template | 2 | 1 |
| External pad (create from URL) | 1 | 0 |
| External pad (legacy migration) | 3 | 2 |

## The change is the signatures, not the count

Counting is the effect. The cause was that content and its parse could be passed separately, so `withExportSnapshot()` and `withRestoredSnapshot()` take a `ParsedPadFile` now: a caller *cannot* hand on content it has not looked at. Three methods go entirely, having existed only to parse and pick one field — `getSnapshotRevision()`, and the `getTextSnapshotForRestore()`/`getHtmlSnapshotForRestore()` pair that parsed twice for the two halves of one split.

Two new values, both there to make an invalid combination unrepresentable rather than merely unlikely.

**`PadSnapshot`** is the text, its HTML half and the revision as one thing. `buildInitialDocument`'s `$snapshot` argument used to mean two different bodies depending on an unrelated parameter — raw text when the revision was null, a sectioned `[TEXT]` body when it was not — so half of one shape and half of the other was expressible. `withExportSnapshot` took the same three values plus an `includeHtmlSection` flag, and its own test wrote that state down as `'just text', '<p>ignored</p>', 1, false`, where the argument is named *ignored* because the flag discards it. Both take the value object now.

**`withRestoredSnapshot`** replaces the general `withStateAndSnapshot`. Both callers were restores, both passed `STATE_ACTIVE` and a null deletion timestamp, and the method then split the body a second time to recover the HTML its callers had already split out.

`ParsedPadFile` also carries `snapshotRev`. It was the only frontmatter-derived field callers had to fetch themselves, and `PadSyncService` reached past the value object into the raw array three times to get it.

## What to look at

**The bytes are the sharp check.** `buildInitialDocument(..., snapshot: new PadSnapshot($text, $html, 0))` must write exactly what two steps wrote before. Two tests compare that directly. They normalise `created_at` and `updated_at` out — and only inside the frontmatter block, so a body holding a line of that shape is not silently normalised along with the noise. Widening that normalisation to the whole document fails a test.

**The unsnapshotted branch is unchanged.** Without a `PadSnapshot` a document keeps `snapshot_rev: -1` and an empty body. Pulling the three callers that never had a snapshot into the sectioned form would change the format of freshly created pads.

**A negative revision is refused, not corrected.** `-1` is what the format uses for "before first successful sync", so a snapshot cannot be at that revision; clamping it to `0` would leave a never-synced pad looking synced to the next sync's `$snapshotRev >= $currentRev` short circuit. The refusal is an `InvalidArgumentException`, not `PadFileFormatException`, because it is the caller's mistake — the file exception is mapped to "The selected .pad file has an invalid format." and would send a user to a document that is fine.

**`$snapshot` stayed at parameter four**, where the old string snapshot was, so a call written against the previous signature is a type error rather than a `pad_url` quietly holding a body. That is not hypothetical: reordering it turned up such a call in `PadBootstrapService` immediately.

**In `LifecycleService`, `handleRestore` keeps `$currentContent` as a string** beside the parsed `$pad`, because the failure path writes it back. Removing the apparently redundant variable breaks the rollback — and that is now a test rather than a comment. The identically named one in `restoreWithoutBinding` is inlined, because it carried nothing.

## Deliberately not done

`initializeMissingFrontmatter()` still returns `bool` rather than a result carrying the pad id and access mode. The legacy branch delegates to `PadLegacyMigrationService::migrate()`, which returns `void` and has three paths of its own; the values would have to be threaded through three services, with a new type and around 30 test call sites, to save one `getContent()` plus parse on a path that runs once per file rather than once per open.

The snapshot halves are **not** eager fields on `ParsedPadFile`. Splitting a body is work proportional to its size and would run on every open; the few sync and restore paths split it themselves. Reading an `int` is not, which is why `snapshotRev` went in.

## Verified

- 942 PHPUnit tests, 3110 assertions; Psalm clean against the locked OCP
- e2e against NC 34.0.3: 35 passed, 1 skipped — covers create, sync, restore, trash, templates and external pads, every path this touches
- Each new guarantee shown by mutation: decoupling the HTML section from the snapshot's `html`, dropping `snapshot_rev`, widening the timestamp normalisation, or turning off the restore rollback each fails exactly the test meant to catch it
