### PR TITLE
Refuse the bytes that break the round trip, in both directions

### DIFF
--- a/lib/Service/PadFileService.php
+++ b/lib/Service/PadFileService.php
@@ -358,19 +358,28 @@ class PadFileService {
 		}
 		if (str_starts_with($trimmed, '"') && str_ends_with($trimmed, '"')) {
 			$inner = substr($trimmed, 1, -1);
-			return preg_replace('/\\\\(["\\\\])/', '$1', $inner);
+			return $this->readableScalar((string)preg_replace('/\\\\(["\\\\])/', '$1', $inner));
 		}
 		if (str_starts_with($trimmed, "'") && str_ends_with($trimmed, "'")) {
 			$inner = substr($trimmed, 1, -1);
-			return str_replace("''", "'", $inner);
+			return $this->readableScalar(str_replace("''", "'", $inner));
 		}
-		return $trimmed;
+		return $this->readableScalar($trimmed);
+	}
+
+	private function readableScalar(string $value): string {
+		$this->assertScalarIsRoundTrippable($value);
+		return $value;
+	}
+
+	private function assertScalarIsRoundTrippable(string $value): void {
+		if (preg_match('/[\x00\x0A\x0D]/', $value) === 1) {
+			throw new PadFileFormatException('Frontmatter values must not contain a line terminator or a NUL byte.');
+		}
 	}
 
 	private function stringScalar(string $value): string {
-		if (preg_match('/[\x00-\x1F\x7F]/', $value) === 1) {
-			throw new PadFileFormatException('Frontmatter values must not contain control characters.');
-		}
+		$this->assertScalarIsRoundTrippable($value);
 		$escaped = str_replace(['\\', '"'], ['\\\\', '\\"'], $value);
 		return '"' . $escaped . '"';
 	}

--- a/tests/phpunit/unit/PadFileServiceTest.php
+++ b/tests/phpunit/unit/PadFileServiceTest.php
@@ -9,6 +9,7 @@ use OCA\EtherpadNextcloud\Exception\PadFileFormatException;
 use OCA\EtherpadNextcloud\Service\BindingService;
 use OCA\EtherpadNextcloud\Service\PadFileService;
 use OCA\EtherpadNextcloud\Service\PadSnapshot;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class PadFileServiceTest extends TestCase {
@@ -354,7 +355,7 @@ class PadFileServiceTest extends TestCase {
 		new PadSnapshot('text', null, -1);
 	}
 
-	public function testFrontmatterValuesWithControlCharactersAreRefused(): void {
+	public function testFrontmatterValuesThatWouldBecomeMoreKeysAreRefused(): void {
 		$service = new PadFileService();
 
 		$this->expectException(PadFileFormatException::class);
@@ -365,6 +366,85 @@ class PadFileServiceTest extends TestCase {
 			padUrl: 'https://pad.remote.test/p/x',
 			extraFrontmatter: ['remote_pad_id' => "a\npad_id: g.victim\$secret\naccess_mode: protected"],
 		);
+	}
+
+	/** @return array<string,array{0: string}> */
+	public static function refusedFrontmatterBytes(): array {
+		return [
+			'line feed' => ["\n"],
+			'carriage return' => ["\r"],
+			'nul' => ["\x00"],
+		];
+	}
+
+	#[DataProvider('refusedFrontmatterBytes')]
+	public function testOnlyBytesThatBreakTheRoundTripAreRefused(string $byte): void {
+		$service = new PadFileService();
+
+		$this->expectException(PadFileFormatException::class);
+		$service->buildInitialDocument(1, 'p', BindingService::ACCESS_PUBLIC, extraFrontmatter: ['remote_pad_id' => 'a' . $byte . 'b']);
+	}
+
+	#[DataProvider('refusedFrontmatterBytes')]
+	public function testAFileAlreadyHoldingARefusedByteIsRefusedOnRead(string $byte): void {
+		$service = new PadFileService();
+
+		$this->expectException(PadFileFormatException::class);
+		$service->readPad(self::documentWithRemotePadId('a' . $byte . 'b'));
+	}
+
+	/** @return array<string,array{0: string}> */
+	public static function survivingFrontmatterBytes(): array {
+		return [
+			'start of heading' => ["\x01"],
+			'vertical tab' => ["\x0B"],
+			'form feed' => ["\x0C"],
+			'unit separator' => ["\x1F"],
+			'delete' => ["\x7F"],
+		];
+	}
+
+	#[DataProvider('survivingFrontmatterBytes')]
+	public function testAControlCharacterThatCannotBreakTheRoundTripSurvivesIt(string $byte): void {
+		$service = new PadFileService();
+
+		$document = $service->buildInitialDocument(
+			1,
+			'p',
+			BindingService::ACCESS_PUBLIC,
+			extraFrontmatter: ['remote_pad_id' => 'a' . $byte . 'b'],
+		);
+
+		$this->assertSame('a' . $byte . 'b', $service->readPad($document)->frontmatter['remote_pad_id']);
+	}
+
+	#[DataProvider('survivingFrontmatterBytes')]
+	public function testAStoredPadCarryingSuchAByteCanStillBeSynced(string $byte): void {
+		$service = new PadFileService();
+		$padUrl = 'https://pad.example.test/p/de' . $byte . 'mo';
+
+		$stored = $service->buildInitialDocument(1, 'demo', BindingService::ACCESS_PUBLIC, padUrl: $padUrl);
+		$pad = $service->readPad($stored);
+		$this->assertSame($padUrl, $pad->padUrl);
+
+		$synced = $service->withExportSnapshot($pad, new PadSnapshot('text', '<p>text</p>', 1));
+
+		$this->assertSame($padUrl, $service->readPad($synced)->padUrl);
+	}
+
+	private static function documentWithRemotePadId(string $value): string {
+		return "---\n"
+			. "format: \"etherpad-nextcloud/1\"\n"
+			. "file_id: 1\n"
+			. "pad_id: \"demo\"\n"
+			. "access_mode: \"public\"\n"
+			. "state: \"active\"\n"
+			. "deleted_at: null\n"
+			. "created_at: \"2026-03-06T00:00:00+00:00\"\n"
+			. "updated_at: \"2026-03-06T00:00:00+00:00\"\n"
+			. "snapshot_rev: 0\n"
+			. 'remote_pad_id: "' . $value . "\"\n"
+			. "---\n";
 	}
 
 	public function testGetSnapshotPartsFromBodyHandlesBodyWithoutMarkers(): void {


### PR DESCRIPTION
Follow-up to #229. That fix stopped a frontmatter value from becoming further keys, and did it by refusing the whole control-character range. The property it protects is narrower than that, and the gap between the two had a cost.

## What the guard is actually for

`parsePadFile()` folds `\r\n` to `\n`, splits on `\n`, and matches `^key: value$`. So a value can become a new line via exactly `\n` and `\r`. NUL belongs with them for a different reason: it survives this parser intact, but it truncates where a value goes afterwards — C-level path handling, header emission, logs.

Refusing more than that made a file that opens fine impossible to write back. Any sync or restore re-serialises the frontmatter and threw, leaving the pad readable but unsyncable and unrestorable, fixable only by editing it by hand.

## The rule now holds in both directions

The same three bytes are refused when reading. That is the half that makes it a rule rather than a write-time check, and it closes the asymmetry rather than shrinking it:

- `\n` never reached a value anyway — the block is split on it, so an injected remainder fails the key pattern.
- `\r` and `\x00` did. Both sit inside the quotes, where neither the split nor `parseScalar`'s `trim()` can see them, and both were refused on the way out. A `.pad` carrying one opened normally and then died at its first sync.

**This changes the read path**: such a file is now reported as malformed when it is opened, instead of failing later when it is saved. The check sits on every scalar, including the unquoted ones and `deleted_at`, because it is a format rule rather than a property of particular fields.

## Why this is not about migrating old files

The app is unreleased, so nothing is stranded today. The reason to narrow it is that the asymmetry is permanent rather than transitional: a `.pad` is an ordinary file in the user's own storage, and WebDAV or a desktop client can put such a byte in one at any time. The guard only ever covered our own writes.

The alternative — leaving the writer broad and teaching the reader to match it — would turn a byte that harms nothing into a pad that cannot be opened at all.

## What the tests hold

`\n`, `\r` and NUL are refused on write and on read. `\x01`, `\x0B`, `\x0C`, `\x1F` and `\x7F` round-trip, and one case walks the whole route the narrowing exists for: build a document, read it, write it back through `withExportSnapshot`, compare the value.

`\x0B` and `\x0C` are in that list deliberately. They are harmless only because `parseFrontmatterBlock` splits with `explode("\n")` — PCRE counts both as line terminators — so a later tolerance for `\R` would reopen the gap silently. Two counter-checks, both run:

- removing the read-side guard fails the `\r` and NUL cases and leaves `\n` green, since the split catches that one regardless
- replacing the split with `preg_split('/\R/')` fails exactly `\x0B` and `\x0C`

## Verified

- 958 PHPUnit tests, 3131 assertions; Psalm clean
- The injection this follows up on stays refused — the test from #229 carries a newline payload and is unchanged
