### PR TITLE
Repair the mime part the mime-type step leaves behind

### DIFF
--- a/lib/Migration/BackfillPadMimeType.php
+++ b/lib/Migration/BackfillPadMimeType.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace OCA\EtherpadNextcloud\Migration;
 
+use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
 use OCP\IDBConnection;
@@ -17,7 +18,6 @@ use OCP\IDBConnection;
  */
 class BackfillPadMimeType implements IRepairStep {
 	private const MIME_PAD = 'application/x-etherpad-nextcloud';
-	private const MIME_PART = 'application';
 
 	public function __construct(
 		private IDBConnection $connection,
@@ -25,42 +25,69 @@ class BackfillPadMimeType implements IRepairStep {
 	}
 
 	public function getName(): string {
-		return 'Backfill MIME type for existing .pad files';
+		return 'Backfill MIME part for existing .pad files';
 	}
 
 	public function run(IOutput $output): void {
 		$padMimeId = $this->getMimeId(self::MIME_PAD);
 		if ($padMimeId === null) {
-			$output->info('Skipping MIME backfill: application/x-etherpad-nextcloud is not registered.');
+			$output->info('Skipping MIME backfill: ' . self::MIME_PAD . ' is not registered.');
 			return;
 		}
 
-		$mimePartId = $this->getMimeId(self::MIME_PART);
+		$mimePart = explode('/', self::MIME_PAD, 2)[0];
+		$mimePartId = $this->getMimeId($mimePart);
 		if ($mimePartId === null) {
-			$output->info('Skipping MIME backfill: application mimepart is missing.');
+			$output->info('Skipping MIME backfill: the ' . $mimePart . ' mimepart is missing.');
 			return;
 		}
 
 		$queryBuilder = $this->connection->getQueryBuilder();
 		$queryBuilder
 			->update('filecache')
-			->set('mimetype', $queryBuilder->createNamedParameter($padMimeId))
-			->set('mimepart', $queryBuilder->createNamedParameter($mimePartId))
+			->set('mimepart', $queryBuilder->createNamedParameter($mimePartId, IQueryBuilder::PARAM_INT))
 			->where(
-				$queryBuilder->expr()->like(
-					'name',
-					$queryBuilder->createNamedParameter('%.pad'),
+				$queryBuilder->expr()->eq(
+					'mimetype',
+					$queryBuilder->createNamedParameter($padMimeId, IQueryBuilder::PARAM_INT),
 				),
 			)
 			->andWhere(
 				$queryBuilder->expr()->neq(
-					'mimetype',
-					$queryBuilder->createNamedParameter($padMimeId),
+					'mimepart',
+					$queryBuilder->createNamedParameter($mimePartId, IQueryBuilder::PARAM_INT),
 				),
 			);
 
 		$updated = $queryBuilder->executeStatement();
-		$output->info(sprintf('Backfilled MIME type for %d .pad files.', $updated));
+		if ($updated > 0) {
+			$output->info(sprintf('Backfilled MIME part for %d .pad files.', $updated));
+			return;
+		}
+
+		$output->info($this->hasPadRows($padMimeId)
+			? 'MIME part was already correct on every .pad file.'
+			: 'No file carries the pad MIME type; nothing to repair here.');
+	}
+
+	private function hasPadRows(int $padMimeId): bool {
+		$queryBuilder = $this->connection->getQueryBuilder();
+		$queryBuilder
+			->select('fileid')
+			->from('filecache')
+			->where(
+				$queryBuilder->expr()->eq(
+					'mimetype',
+					$queryBuilder->createNamedParameter($padMimeId, IQueryBuilder::PARAM_INT),
+				),
+			)
+			->setMaxResults(1);
+
+		$result = $queryBuilder->executeQuery();
+		$found = $result->fetchOne();
+		$result->closeCursor();
+
+		return $found !== false;
 	}
 
 	private function getMimeId(string $mime): ?int {

--- a/tests/phpunit/unit/BackfillPadMimeTypeTest.php
+++ b/tests/phpunit/unit/BackfillPadMimeTypeTest.php
@@ -11,7 +11,6 @@ use OCP\Migration\IOutput;
 use PHPUnit\Framework\TestCase;
 
 class BackfillPadMimeTypeTest extends TestCase {
-	private const MIME = 'application/x-etherpad-nextcloud';
 
 	public function testSkipsWhenPadMimeTypeIsNotRegistered(): void {
 		// getMimeId('application/x-etherpad-nextcloud') -> not found.
@@ -37,29 +36,65 @@ class BackfillPadMimeTypeTest extends TestCase {
 		$this->assertFalse($qb->executeStatementCalled);
 	}
 
-	public function testUpdatesPadRowsAndOnlyTouchesRowsNotAlreadyTheTarget(): void {
+	public function testRepairsTheMimePartOnRowsThatAlreadyCarryThePadType(): void {
 		// pad mime id = 7, application mimepart id = 1, 3 rows updated.
 		$qb = new BackfillTestQueryBuilder([7, 1], 3);
 		$output = $this->createMock(IOutput::class);
 		$output->expects($this->once())->method('info')
-			->with($this->stringContains('Backfilled MIME type for 3 .pad files.'));
+			->with($this->stringContains('Backfilled MIME part for 3 .pad files.'));
 
 		(new BackfillPadMimeType($this->connection($qb)))->run($output);
 
 		$this->assertTrue($qb->executeStatementCalled);
 		$this->assertSame('filecache', $qb->updateTable);
-		// mimetype + mimepart set to the resolved ids.
-		$this->assertSame(7, $qb->params[$qb->sets['mimetype']]);
+
+		$this->assertSame(['mimepart'], array_keys($qb->sets));
 		$this->assertSame(1, $qb->params[$qb->sets['mimepart']]);
-		// Targets only *.pad rows …
-		$like = $qb->findCondition('like', 'name');
-		$this->assertNotNull($like);
-		$this->assertSame('%.pad', $qb->params[$like[2]]);
-		// … and only rows whose mimetype is NOT already the pad mime: this is
-		// the idempotency guard (a second run updates nothing).
-		$neq = $qb->findCondition('neq', 'mimetype');
+
+		$eq = $qb->findCondition('eq', 'mimetype');
+		$this->assertNotNull($eq);
+		$this->assertSame(7, $qb->params[$eq[2]]);
+		$this->assertNull($qb->findCondition('like', 'name'), 'the name must not be matched here');
+
+		$neq = $qb->findCondition('neq', 'mimepart');
 		$this->assertNotNull($neq);
-		$this->assertSame(7, $qb->params[$neq[2]]);
+		$this->assertSame(1, $qb->params[$neq[2]]);
+
+		$this->assertCount(2, $qb->conditions, 'the update must carry these two conditions and no other');
+
+		foreach ([$qb->sets['mimepart'], $eq[2], $neq[2]] as $parameter) {
+			$this->assertSame(
+				IQueryBuilder::PARAM_INT,
+				$qb->paramTypes[$parameter],
+				'a mime id is a bigint column; binding it as a string casts the column and drops its index',
+			);
+		}
+	}
+
+	/**
+	 * Zero updated rows has two very different causes, and the step is the
+	 * only place that can tell them apart: everything is already correct, or
+	 * nothing carries the type at all - which is what a reordered repair list
+	 * would look like, since the mime-type step has to run first.
+	 */
+	public function testSaysSoWhenEveryPadFileWasAlreadyCorrect(): void {
+		// pad mime 7, application mimepart 1, then one row carrying the type.
+		$qb = new BackfillTestQueryBuilder([7, 1, 4242], 0);
+		$output = $this->createMock(IOutput::class);
+		$output->expects($this->once())->method('info')
+			->with($this->stringContains('already correct'));
+
+		(new BackfillPadMimeType($this->connection($qb)))->run($output);
+	}
+
+	public function testSaysSoWhenNoFileCarriesThePadTypeAtAll(): void {
+		// pad mime 7, application mimepart 1, then no row carrying the type.
+		$qb = new BackfillTestQueryBuilder([7, 1, false], 0);
+		$output = $this->createMock(IOutput::class);
+		$output->expects($this->once())->method('info')
+			->with($this->stringContains('No file carries the pad MIME type'));
+
+		(new BackfillPadMimeType($this->connection($qb)))->run($output);
 	}
 
 	private function connection(BackfillTestQueryBuilder $qb): IDBConnection {
@@ -77,6 +112,8 @@ class BackfillPadMimeTypeTest extends TestCase {
 class BackfillTestQueryBuilder implements IQueryBuilder {
 	/** @var array<string,mixed> */
 	public array $params = [];
+	/** @var array<string,int|null> */
+	public array $paramTypes = [];
 	/** @var array<string,string> field => parameter name */
 	public array $sets = [];
 	/** @var list<array<int,string>> */
@@ -101,6 +138,10 @@ class BackfillTestQueryBuilder implements IQueryBuilder {
 	}
 
 	public function update(string $table): self {
+		// The real getQueryBuilder() hands out a fresh builder per statement;
+		// this double is reused, so a statement starts by forgetting the last.
+		$this->conditions = [];
+		$this->sets = [];
 		$this->updateTable = $table;
 		return $this;
 	}
@@ -127,6 +168,7 @@ class BackfillTestQueryBuilder implements IQueryBuilder {
 	public function createNamedParameter(mixed $value, ?int $type = null): string {
 		$name = 'param' . ++$this->counter;
 		$this->params[$name] = $value;
+		$this->paramTypes[$name] = $type;
 		return $name;
 	}
 


### PR DESCRIPTION
`BackfillPadMimeType` is a post-migration repair step. It runs whenever the app is enabled or upgraded, and it exists for `.pad` files that were already on the instance before the app registered its mime type – a WebDAV upload before enabling the app is enough to produce them. It had two bugs pulling in opposite directions: it changed rows it must not touch, and it never reached the rows it exists for. Both come from the same decision, selecting rows by file name.

## It could rewrite folders

The `UPDATE` matched on the name and the mime type. A folder named `Archive.pad` satisfies both: its name ends in `.pad`, and its `mimetype` is `httpd/unix-directory`, which is not the pad type. The step set `mimetype` and `mimepart` on the folder's own filecache row.

Nextcloud decides folder-ness from that column – `FileInfo::getType()` returns a folder only for `httpd/unix-directory` – so such a folder would be listed as a pad file, `UserNodeResolver` would refuse it because it is not a `File`, and its children would be unreachable in the Files app until a rescan.

## It repaired nothing

`RegisterMimeType` is listed before this step in `<post-migration>` and hands the selection to Nextcloud's own `IMimeTypeLoader::updateFilecache()`, which matches the extension case-insensitively, escapes its `LIKE` pattern, skips directories, and sets `mimetype`. It leaves `mimepart` alone.

This step then ran with `mimetype != padMimeId`, which after that call excludes every pad file there is. So the `mimepart` column it exists to fix was never reached, on any run: a pad uploaded while it was still `text/plain` kept `mimepart = text` indefinitely, and queries keyed on the mime part kept missing it.

## Selecting on the type fixes both

The rows that need repairing are exactly those already carrying the pad type, and the only column left to set is `mimepart`:

```sql
UPDATE filecache SET mimepart = :application
WHERE mimetype = :padMime AND mimepart != :application
```

The case handling, the `LIKE` escaping and the directory exclusion stay in Nextcloud, where they were already correct, rather than being restated here. The `mimepart != :application` half keeps the step idempotent: a second run matches nothing.

## Four smaller repairs alongside

The mimepart is derived from the mime type (`explode('/', MIME_PAD, 2)[0]`) rather than restated as its own constant. The step now selects on one column and writes the other, so a constant that drifted would stamp `mimepart = application` onto rows whose `mimetype` said something else.

The mime ids are bound with `PARAM_INT`, as everywhere else in the app, rather than as strings against two bigint columns.

Zero updated rows no longer reads like success. The step distinguishes "every file was already correct" from "no file carries the pad mime type at all" – the second being what a reordered repair list would look like, since the mime-type step has to run first for this one to match anything.

And the step's name said MIME type while it sets the part.

## Verification

960 PHPUnit tests / 3138 assertions, Psalm 0 errors at `errorLevel=4` with `findUnusedCode=true`, full Playwright suite 35 passed / 1 skipped against Nextcloud 34.

`updateFilecache()` carries `@since 32.0.0` in its OCP docblock, which is inaccurate. It is present in the private implementation and the public interface of Nextcloud 31.0.0 – the declared minimum – as well as 31.0.14 and 34, in each case with the directory exclusion, the case-insensitive `LOWER(name)` match and the escaped `LIKE` pattern, and in each case setting `mimetype` alone.

The e2e matrix installs the app on Nextcloud 31 and 34 for every pull request, which runs both repair steps; a missing `updateFilecache()` would fail that install. What it does not do is assert the resulting rows, so this step's effect is covered by a query-builder double rather than against a real database. Two of the concerns behind this change – binding the mime ids as integers, and what `WHERE mimetype = ?` does to the composite `fs_storage_mimetype` index – are about what PostgreSQL's planner makes of the statement, and a double cannot show that. The binding is pinned by a test; the plan is not, and `EXPLAIN` against a real instance would be the way to settle it. The scan itself is not a regression: the previous `LIKE '%.pad'` scanned too, and core's own `updateFilecache()` has the same shape.

Seven counter-checks each fail exactly the test that covers them: selecting by name instead of type, dropping the `mimepart` inequality, setting `mimetype` again, dropping `PARAM_INT` from the row selector, hardcoding the mimepart prefix, smuggling in a third condition, and replacing the zero-row diagnostics with the old success message.

The test double resets when `update()` is called. It hands out one instance where the real `getQueryBuilder()` hands out a fresh builder per statement, so without that the two mime-id lookups' own conditions were indistinguishable from the update's – which is how an earlier version of this test passed while asserting on the wrong condition.
