### PR TITLE
Give a pad one way of coming into being

### DIFF
--- a/lib/Service/LifecycleService.php
+++ b/lib/Service/LifecycleService.php
@@ -323,7 +323,7 @@ class LifecycleService {
 			$snapshot = $snapshotParts['text'];
 			$htmlSnapshot = $snapshotParts['html'];
 
-			$this->restoreSnapshotToManagedPad($fileId, $oldPadId, $newPadId, $snapshot, $htmlSnapshot);
+			$this->padLifecycle->seed($newPadId, $snapshot, $htmlSnapshot, ['fileId' => $fileId, 'oldPadId' => $oldPadId]);
 
 			$updatedContent = $this->padFileService->withRestoredSnapshot(
 				$pad,
@@ -453,7 +453,7 @@ class LifecycleService {
 			$htmlSnapshot = $snapshotParts['html'];
 			$newPadId = $this->provisionRestorePadId($accessMode, $oldPadId);
 			$managedPadCreated = true;
-			$this->restoreSnapshotToManagedPad($fileId, $oldPadId, $newPadId, $snapshot, $htmlSnapshot);
+			$this->padLifecycle->seed($newPadId, $snapshot, $htmlSnapshot, ['fileId' => $fileId, 'oldPadId' => $oldPadId]);
 			$updatedContent = $this->padFileService->withRestoredSnapshot(
 				$pad,
 				$snapshot,
@@ -531,14 +531,13 @@ class LifecycleService {
 		}
 	}
 
+	/** The names a pad gets when it is made to carry a restored snapshot. */
 	private function provisionRestorePadId(string $accessMode, string $oldPadId): string {
-		if ($accessMode === BindingService::ACCESS_PROTECTED) {
-			return $this->padLifecycle->provisionGroupPad($this->buildProtectedRestorePadName());
-		}
-
-		$newPadId = $this->buildPublicRestorePadId($oldPadId);
-		$this->padLifecycle->provisionPad($newPadId);
-		return $newPadId;
+		return $this->padLifecycle->provisionFor(
+			$accessMode,
+			fn (): string => $this->buildPublicRestorePadId($oldPadId),
+			fn (): string => $this->buildProtectedRestorePadName(),
+		);
 	}
 
 	/**
@@ -646,25 +645,6 @@ class LifecycleService {
 				'exception' => $e,
 			]);
 		}
-	}
-
-	private function restoreSnapshotToManagedPad(int $fileId, string $oldPadId, string $newPadId, string $snapshot, string $htmlSnapshot): void {
-		if (trim($htmlSnapshot) !== '') {
-			try {
-				$this->etherpadClient->setHTML($newPadId, $htmlSnapshot);
-				return;
-			} catch (\Throwable $htmlRestoreError) {
-				$this->logger->warning('HTML restore failed, falling back to plain text snapshot.', [
-					'app' => 'etherpad_nextcloud',
-					'fileId' => $fileId,
-					'oldPadId' => $oldPadId,
-					'newPadId' => $newPadId,
-					'exception' => $htmlRestoreError,
-				]);
-			}
-		}
-
-		$this->etherpadClient->setText($newPadId, $snapshot);
 	}
 
 	private function writeRestoredContent(File $file, string $updatedContent): void {

--- a/lib/Service/LifecycleService.php
+++ b/lib/Service/LifecycleService.php
@@ -308,7 +308,13 @@ class LifecycleService {
 		}
 
 		$accessMode = (string)$binding['access_mode'];
-		$newPadId = $this->provisionRestorePadId($accessMode, $oldPadId);
+		try {
+			$newPadId = $this->provisionRestorePadId($accessMode, $oldPadId);
+		} catch (\InvalidArgumentException) {
+			// Leaves the row in pending_delete for a repair rather than
+			// taking the file's own restore down with it.
+			return $this->buildSkippedResult('unknown_access_mode', $fileId, $oldPadId);
+		}
 		$restored = false;
 		$fileContentUpdated = false;
 		$currentContent = '';
@@ -531,12 +537,12 @@ class LifecycleService {
 		}
 	}
 
-	/** The names a pad gets when it is made to carry a restored snapshot. */
+	/** Make the pad a restored snapshot goes into; the names say so. */
 	private function provisionRestorePadId(string $accessMode, string $oldPadId): string {
 		return $this->padLifecycle->provisionFor(
 			$accessMode,
-			fn (): string => $this->buildPublicRestorePadId($oldPadId),
-			fn (): string => $this->buildProtectedRestorePadName(),
+			padId: fn (): string => $this->buildPublicRestorePadId($oldPadId),
+			groupPadName: fn (): string => $this->buildProtectedRestorePadName(),
 		);
 	}
 

--- a/lib/Service/ManagedPadLifecycle.php
+++ b/lib/Service/ManagedPadLifecycle.php
@@ -123,7 +123,8 @@ class ManagedPadLifecycle {
 	 * imported. The price is that `getText` afterwards returns what Etherpad
 	 * derived from that HTML rather than the string the snapshot held.
 	 *
-	 * @param array<string,mixed> $context added to the fallback's log line
+	 * @param array<string,mixed> $context extra keys for the fallback's log
+	 *   line; `app`, `padId` and `exception` are set here and win a collision
 	 */
 	public function seed(string $padId, string $text, string $html, array $context = []): void {
 		if (trim($html) !== '') {

--- a/lib/Service/ManagedPadLifecycle.php
+++ b/lib/Service/ManagedPadLifecycle.php
@@ -14,7 +14,8 @@ use OCA\EtherpadNextcloud\Util\PadId;
 use Psr\Log\LoggerInterface;
 
 /**
- * The one place that knows how to take an Etherpad pad away again.
+ * The one place that knows how to bring an Etherpad pad into being, and how
+ * to take it away again.
  *
  * A public pad is a pad. A protected pad is a pad inside a group, plus the
  * sessions that grant access to that group — and `deletePad` removes only
@@ -89,6 +90,58 @@ class ManagedPadLifecycle {
 			}
 			throw $e;
 		}
+	}
+
+	/**
+	 * Make the kind of pad an access mode calls for.
+	 *
+	 * The names come from the caller, because a name says where its pad came
+	 * from and that is the caller's business. They arrive unbuilt so that the
+	 * branch not taken draws no randomness.
+	 *
+	 * @param callable():string $padId the id a public pad is created under
+	 * @param callable():string $groupPadName the name a protected pad carries
+	 */
+	public function provisionFor(string $accessMode, callable $padId, callable $groupPadName): string {
+		if ($accessMode === BindingService::ACCESS_PUBLIC) {
+			$newPadId = $padId();
+			$this->provisionPad($newPadId);
+			return $newPadId;
+		}
+
+		if ($accessMode !== BindingService::ACCESS_PROTECTED) {
+			throw new \InvalidArgumentException('Unsupported access mode for pad provisioning.');
+		}
+
+		return $this->provisionGroupPad($groupPadName());
+	}
+
+	/**
+	 * Put a snapshot into a pad that has just been provisioned.
+	 *
+	 * setHTML first so formatting survives, and setText only where there is
+	 * no HTML or Etherpad refuses it. Never both: `setText` replaces the
+	 * content rather than appending, so it would wipe the HTML just
+	 * imported. The price is that `getText` afterwards returns what Etherpad
+	 * derived from that HTML rather than the string the snapshot held.
+	 *
+	 * @param array<string,mixed> $context added to the fallback's log line
+	 */
+	public function seed(string $padId, string $text, string $html, array $context = []): void {
+		if (trim($html) !== '') {
+			try {
+				$this->etherpadClient->setHTML($padId, $html);
+				return;
+			} catch (\Throwable $htmlError) {
+				$this->logger->warning('Could not import the HTML snapshot; falling back to plain text.', [
+					'app' => 'etherpad_nextcloud',
+					'padId' => $padId,
+					'exception' => $htmlError,
+				] + $context);
+			}
+		}
+
+		$this->etherpadClient->setText($padId, $text);
 	}
 
 	/**

--- a/lib/Service/ManagedPadLifecycle.php
+++ b/lib/Service/ManagedPadLifecycle.php
@@ -38,11 +38,9 @@ class ManagedPadLifecycle {
 	 *
 	 * The two steps are separate calls, so a failure between them strands a
 	 * group that nothing will ever look at again — invisible from Nextcloud
-	 * and never collected. Both provisioning paths, the first open of a
-	 * `.pad` and a restore from the trash, had that gap and the same cleanup
-	 * written out twice.
+	 * and never collected.
 	 */
-	public function provisionGroupPad(string $padName): string {
+	private function provisionGroupPad(string $padName): string {
 		$groupId = $this->etherpadClient->createGroup();
 		try {
 			return $this->etherpadClient->createGroupPad($groupId, $padName);
@@ -73,7 +71,7 @@ class ManagedPadLifecycle {
 	 * there. Random ids make that vanishingly unlikely, but the cost of
 	 * being wrong is deleting someone's live pad, so it is worth the check.
 	 */
-	public function provisionPad(string $padId): void {
+	private function provisionPad(string $padId): void {
 		try {
 			$this->etherpadClient->createPad($padId);
 		} catch (\Throwable $e) {

--- a/lib/Service/PadBootstrapService.php
+++ b/lib/Service/PadBootstrapService.php
@@ -29,47 +29,13 @@ class PadBootstrapService {
 	) {
 	}
 
-	/**
-	 * Seeds a freshly provisioned pad with content. Tries setHTML first so
-	 * formatting (headings, lists, bold/italic) survives, and falls back to
-	 * plain-text setText if the HTML import fails or no HTML snapshot is
-	 * available.
-	 *
-	 * We intentionally do NOT also call setText after a successful setHTML:
-	 * Etherpad's `setText` replaces the pad content rather than appending, so
-	 * doing both would wipe the formatted HTML we just imported. The minor
-	 * downside — `getText` returns plain text Etherpad derived from the HTML
-	 * rather than the exact string we put into the frontmatter snapshot — is
-	 * acceptable in exchange for keeping the rich formatting.
-	 */
-	public function pushInitialSnapshot(string $padId, string $text, string $html): void {
-		if (trim($html) !== '') {
-			try {
-				$this->etherpadClient->setHTML($padId, $html);
-				return;
-			} catch (\Throwable $htmlError) {
-				$this->logger->warning('Initial HTML push failed, falling back to plain text.', [
-					'app' => 'etherpad_nextcloud',
-					'padId' => $padId,
-					'exception' => $htmlError,
-				]);
-			}
-		}
-		$this->etherpadClient->setText($padId, $text);
-	}
-
+	/** The names a pad gets when it is made for a `.pad` file's first open. */
 	public function provisionPadId(string $accessMode): string {
-		if ($accessMode === BindingService::ACCESS_PUBLIC) {
-			$padId = 'nc-' . $this->secureRandom->generate(24, ISecureRandom::CHAR_LOWER . ISecureRandom::CHAR_DIGITS);
-			$this->padLifecycle->provisionPad($padId);
-			return $padId;
-		}
-
-		if ($accessMode !== BindingService::ACCESS_PROTECTED) {
-			throw new \InvalidArgumentException('Unsupported access mode for pad provisioning.');
-		}
-
-		return $this->padLifecycle->provisionGroupPad($this->buildProtectedPadName());
+		return $this->padLifecycle->provisionFor(
+			$accessMode,
+			fn (): string => 'nc-' . $this->secureRandom->generate(24, ISecureRandom::CHAR_LOWER . ISecureRandom::CHAR_DIGITS),
+			fn (): string => $this->buildProtectedPadName(),
+		);
 	}
 
 	/**

--- a/lib/Service/PadBootstrapService.php
+++ b/lib/Service/PadBootstrapService.php
@@ -29,12 +29,12 @@ class PadBootstrapService {
 	) {
 	}
 
-	/** The names a pad gets when it is made for a `.pad` file's first open. */
+	/** Make the pad a `.pad` file's first open needs; the names say so. */
 	public function provisionPadId(string $accessMode): string {
 		return $this->padLifecycle->provisionFor(
 			$accessMode,
-			fn (): string => 'nc-' . $this->secureRandom->generate(24, ISecureRandom::CHAR_LOWER . ISecureRandom::CHAR_DIGITS),
-			fn (): string => $this->buildProtectedPadName(),
+			padId: fn (): string => 'nc-' . $this->secureRandom->generate(24, ISecureRandom::CHAR_LOWER . ISecureRandom::CHAR_DIGITS),
+			groupPadName: fn (): string => $this->buildProtectedPadName(),
 		);
 	}
 

--- a/lib/Service/PadCreationService.php
+++ b/lib/Service/PadCreationService.php
@@ -365,7 +365,7 @@ class PadCreationService {
 
 		$padId = $this->padBootstrapService->provisionPadId($accessMode);
 		try {
-			$this->padBootstrapService->pushInitialSnapshot($padId, $resolvedText, $resolvedHtml);
+			$this->padLifecycle->seed($padId, $resolvedText, $resolvedHtml);
 			$padUrl = $this->etherpadClient->buildPadUrl($padId);
 
 			$content = $this->padFileService->buildInitialDocument(

--- a/lib/Service/PadCreationService.php
+++ b/lib/Service/PadCreationService.php
@@ -365,7 +365,7 @@ class PadCreationService {
 
 		$padId = $this->padBootstrapService->provisionPadId($accessMode);
 		try {
-			$this->padLifecycle->seed($padId, $resolvedText, $resolvedHtml);
+			$this->padLifecycle->seed($padId, $resolvedText, $resolvedHtml, ['fileId' => $fileId]);
 			$padUrl = $this->etherpadClient->buildPadUrl($padId);
 
 			$content = $this->padFileService->buildInitialDocument(

--- a/tests/e2e/specs/pad-snapshot-roundtrip.spec.ts
+++ b/tests/e2e/specs/pad-snapshot-roundtrip.spec.ts
@@ -15,8 +15,7 @@ import { uniqueName } from '../fixtures/nextcloud'
 /**
  * Content round-trip through the snapshot -> new-pad push that both the
  * restore and the "create new pad from this file" recovery flows rely on
- * (`LifecycleService::restoreSnapshotToManagedPad` ->
- * `EtherpadClient::setText/setHTML`).
+ * (`ManagedPadLifecycle::seed` -> `EtherpadClient::setText/setHTML`).
  *
  * This is the deterministic, credential-free way to prove "the .pad
  * content is correctly copied into the freshly provisioned pad" that a

--- a/tests/phpunit/unit/LifecycleServiceTest.php
+++ b/tests/phpunit/unit/LifecycleServiceTest.php
@@ -57,6 +57,42 @@ class LifecycleServiceTest extends TestCase {
 		$provision->invoke($service, BindingService::ACCESS_PROTECTED, 'nc-old');
 	}
 
+	/** An access mode nobody knows must not become an unprotected pad. */
+	public function testHandleRestoreRefusesABindingWithAnUnknownAccessMode(): void {
+		$fileId = 91;
+		$bindingService = $this->createMock(BindingService::class);
+		$bindingService->method('findByFileId')->with($fileId)->willReturn([
+			'file_id' => $fileId,
+			'pad_id' => 'old-pad',
+			'access_mode' => 'something-else',
+			'state' => BindingService::STATE_PENDING_DELETE,
+		]);
+
+		$etherpadClient = $this->createMock(EtherpadClient::class);
+		$etherpadClient->expects($this->never())->method('createPad');
+		$etherpadClient->expects($this->never())->method('createGroup');
+
+		$file = $this->createMock(File::class);
+		$file->method('getId')->willReturn($fileId);
+		$file->method('getName')->willReturn('Restored.pad');
+
+		$service = new LifecycleService(
+			$bindingService,
+			$this->createMock(PadFileService::class),
+			$etherpadClient,
+			new ManagedPadLifecycle($etherpadClient, $this->createMock(LoggerInterface::class)),
+			$this->buildDeleteOnTrashEnabledConfig(),
+			$this->createMock(LoggerInterface::class),
+			$this->createMock(ISecureRandom::class),
+			$this->createMock(UserNodeResolver::class),
+			$this->createMock(PathNormalizer::class),
+			new FixedClock(),
+		);
+
+		$this->expectException(\InvalidArgumentException::class);
+		$service->handleRestore($file);
+	}
+
 	public function testHandleTrashSkipsNonPadFiles(): void {
 		$bindingService = $this->createMock(BindingService::class);
 		$bindingService->expects($this->never())->method('findByFileId');
@@ -630,7 +666,7 @@ class LifecycleServiceTest extends TestCase {
 			$bindingService,
 			$padFileService,
 			$etherpadClient,
-			new ManagedPadLifecycle($etherpadClient, $this->createMock(LoggerInterface::class)),
+			new ManagedPadLifecycle($etherpadClient, $logger),
 			$config,
 			$logger,
 			$secureRandom,

--- a/tests/phpunit/unit/LifecycleServiceTest.php
+++ b/tests/phpunit/unit/LifecycleServiceTest.php
@@ -27,8 +27,12 @@ use OCA\EtherpadNextcloud\Tests\Support\FixedClock;
 
 class LifecycleServiceTest extends TestCase {
 
-	/** An access mode nobody knows must not become an unprotected pad. */
-	public function testHandleRestoreRefusesABindingWithAnUnknownAccessMode(): void {
+	/**
+	 * An access mode nobody knows must not become an unprotected pad - and
+	 * must not take the file's own restore down either, so it is skipped
+	 * the way every other unusable binding is.
+	 */
+	public function testHandleRestoreSkipsABindingWithAnUnknownAccessMode(): void {
 		$fileId = 91;
 		$bindingService = $this->createMock(BindingService::class);
 		$bindingService->method('findByFileId')->with($fileId)->willReturn([
@@ -59,7 +63,51 @@ class LifecycleServiceTest extends TestCase {
 			new FixedClock(),
 		);
 
-		$this->expectException(\InvalidArgumentException::class);
+		$result = $service->handleRestore($file);
+
+		$this->assertSame(LifecycleService::RESULT_SKIPPED, $result['status']);
+		$this->assertSame('unknown_access_mode', $result['reason']);
+	}
+
+	/**
+	 * A pad that could not be made must leave the row in pending_delete, so
+	 * the retry job still finds the old pad it names.
+	 */
+	public function testHandleRestoreLeavesTheRowPendingWhenTheNewPadCannotBeMade(): void {
+		$fileId = 87;
+		$bindingService = $this->createMock(BindingService::class);
+		$bindingService->method('findByFileId')->with($fileId)->willReturn([
+			'file_id' => $fileId,
+			'pad_id' => 'old-pad',
+			'access_mode' => BindingService::ACCESS_PUBLIC,
+			'state' => BindingService::STATE_PENDING_DELETE,
+		]);
+		$bindingService->expects($this->never())->method('markRestored');
+
+		$etherpadClient = $this->createMock(EtherpadClient::class);
+		$etherpadClient->method('createPad')->willThrowException(new \RuntimeException('Connection timed out'));
+
+		$secureRandom = $this->createMock(ISecureRandom::class);
+		$secureRandom->method('generate')->willReturn('abc123def456');
+
+		$file = $this->createMock(File::class);
+		$file->method('getId')->willReturn($fileId);
+		$file->method('getName')->willReturn('Restored.pad');
+
+		$service = new LifecycleService(
+			$bindingService,
+			$this->createMock(PadFileService::class),
+			$etherpadClient,
+			new ManagedPadLifecycle($etherpadClient, $this->createMock(LoggerInterface::class)),
+			$this->buildDeleteOnTrashEnabledConfig(),
+			$this->createMock(LoggerInterface::class),
+			$secureRandom,
+			$this->createMock(UserNodeResolver::class),
+			$this->createMock(PathNormalizer::class),
+			new FixedClock(),
+		);
+
+		$this->expectException(\RuntimeException::class);
 		$service->handleRestore($file);
 	}
 
@@ -406,13 +454,15 @@ class LifecycleServiceTest extends TestCase {
 			snapshotRev: -1,
 		);
 		$padFileService->method('readPad')->with('doc-before')->willReturn($parsedPad);
-		$padFileService->method('getSnapshotPartsFromBody')->with($parsedPad->body)->willReturn(['text' => 'plain text', 'html' => '']);
+		$padFileService->method('getSnapshotPartsFromBody')->with($parsedPad->body)->willReturn(['text' => 'plain text', 'html' => '<p>plain text</p>']);
 		$padFileService->method('withRestoredSnapshot')->willReturn('doc-after');
 
 		$etherpadClient = $this->createMock(EtherpadClient::class);
 		$etherpadClient->method('createGroup')->willReturn('g.NEWGROUPID12345');
 		$etherpadClient->method('createGroupPad')->willReturn($newPadId);
-		$etherpadClient->method('setText')->with($newPadId, 'plain text');
+		// The snapshot's formatting is what reaches the pad, not its text.
+		$etherpadClient->expects($this->once())->method('setHTML')->with($newPadId, '<p>plain text</p>');
+		$etherpadClient->expects($this->never())->method('setText');
 		$etherpadClient->method('buildPadUrl')->with($newPadId)->willReturn($newPadUrl);
 		$etherpadClient->expects($this->once())->method('listPads')->with('g.OLDGROUPID12345')->willReturn([$oldPadId]);
 		$etherpadClient->expects($this->once())->method('deleteGroup')->with('g.OLDGROUPID12345');

--- a/tests/phpunit/unit/LifecycleServiceTest.php
+++ b/tests/phpunit/unit/LifecycleServiceTest.php
@@ -26,36 +26,6 @@ use Psr\Log\LoggerInterface;
 use OCA\EtherpadNextcloud\Tests\Support\FixedClock;
 
 class LifecycleServiceTest extends TestCase {
-	public function testRestoreProvisioningRemovesTheGroupWhenItsPadCannotBeCreated(): void {
-		$etherpadClient = $this->createMock(EtherpadClient::class);
-		$etherpadClient->expects($this->once())->method('createGroup')->willReturn('g.ABCDEFGHIJKLMNOP');
-		$etherpadClient->expects($this->once())
-			->method('createGroupPad')
-			->willThrowException(new \RuntimeException('pad creation failed'));
-		$etherpadClient->expects($this->once())->method('deleteGroup')->with('g.ABCDEFGHIJKLMNOP');
-
-		$secureRandom = $this->createMock(ISecureRandom::class);
-		$secureRandom->method('generate')->willReturn('abcdefghijklmnopqrst');
-
-		$service = new LifecycleService(
-			$this->createMock(BindingService::class),
-			$this->createMock(PadFileService::class),
-			$etherpadClient,
-			new ManagedPadLifecycle($etherpadClient, $this->createMock(LoggerInterface::class)),
-			$this->buildDeleteOnTrashEnabledConfig(),
-			$this->createMock(LoggerInterface::class),
-			$secureRandom,
-			$this->createMock(UserNodeResolver::class),
-			$this->createMock(PathNormalizer::class),
-			new FixedClock(),
-		);
-
-		// provisionRestorePadId is private; reach it the way the restore path
-		// does, without standing up the whole restore.
-		$provision = new \ReflectionMethod($service, 'provisionRestorePadId');
-		$this->expectException(\RuntimeException::class);
-		$provision->invoke($service, BindingService::ACCESS_PROTECTED, 'nc-old');
-	}
 
 	/** An access mode nobody knows must not become an unprotected pad. */
 	public function testHandleRestoreRefusesABindingWithAnUnknownAccessMode(): void {
@@ -265,59 +235,6 @@ class LifecycleServiceTest extends TestCase {
 	}
 
 	/**
-	 * A binding only sits in `pending_delete` because its pad delete failed,
-	 * so on restore the old pad is usually still there — and `markRestored`
-	 * points the row at the new one, which was the last thing naming it. The
-	 * retry job walks `pending_delete` rows and will never see it again, so
-	 * for a protected pad a whole group and its sessions would be stranded.
-	 */
-	/** The restore's own provisioning leaks the same way a first open does. */
-	public function testHandleRestoreRemovesAPublicPadWhoseCreationFailedHalfway(): void {
-		$fileId = 86;
-		$oldPadId = 'old-pad';
-		$newPadId = 'r-old-pad-abc123def456';
-
-		$bindingService = $this->createMock(BindingService::class);
-		$bindingService->method('findByFileId')->with($fileId)->willReturn([
-			'file_id' => $fileId,
-			'pad_id' => $oldPadId,
-			'access_mode' => BindingService::ACCESS_PUBLIC,
-			'state' => BindingService::STATE_PENDING_DELETE,
-		]);
-		$bindingService->expects($this->never())->method('markRestored');
-
-		$etherpadClient = $this->createMock(EtherpadClient::class);
-		$etherpadClient->expects($this->once())
-			->method('createPad')
-			->with($newPadId)
-			->willThrowException(new \RuntimeException('Connection timed out'));
-		$etherpadClient->expects($this->once())->method('deletePad')->with($newPadId);
-
-		$secureRandom = $this->createMock(ISecureRandom::class);
-		$secureRandom->method('generate')->willReturn('abc123def456');
-
-		$file = $this->createMock(File::class);
-		$file->method('getId')->willReturn($fileId);
-		$file->method('getName')->willReturn('Restored.pad');
-
-		$service = new LifecycleService(
-			$bindingService,
-			$this->createMock(PadFileService::class),
-			$etherpadClient,
-			new ManagedPadLifecycle($etherpadClient, $this->createMock(LoggerInterface::class)),
-			$this->buildDeleteOnTrashEnabledConfig(),
-			$this->createMock(LoggerInterface::class),
-			$secureRandom,
-			$this->createMock(UserNodeResolver::class),
-			$this->createMock(PathNormalizer::class),
-			new FixedClock(),
-		);
-
-		$this->expectException(\RuntimeException::class);
-		$service->handleRestore($file);
-	}
-
-	/**
 	 * `markRestored` is the last step and can commit and still throw. By
 	 * then the file already names the new pad, so row, file and pad agree —
 	 * and the rollback would put the old content back and delete the pad
@@ -456,6 +373,13 @@ class LifecycleServiceTest extends TestCase {
 		$service->handleRestore($file);
 	}
 
+	/**
+	 * A binding only sits in `pending_delete` because its pad delete failed,
+	 * so on restore the old pad is usually still there — and `markRestored`
+	 * points the row at the new one, which was the last thing naming it. The
+	 * retry job walks `pending_delete` rows and will never see it again, so
+	 * for a protected pad a whole group and its sessions would be stranded.
+	 */
 	public function testHandleRestoreTakesTheSupersededGroupWithIt(): void {
 		$fileId = 84;
 		$oldPadId = 'g.OLDGROUPID12345$p-old';
@@ -558,6 +482,8 @@ class LifecycleServiceTest extends TestCase {
 		$padFileService->method('withRestoredSnapshot')->willReturn('doc-after');
 
 		$etherpadClient = $this->createMock(EtherpadClient::class);
+		$etherpadClient->expects($this->once())->method('createPad')->with($newPadId);
+		$etherpadClient->expects($this->once())->method('setText')->with($newPadId, 'plain text');
 		$etherpadClient->method('buildPadUrl')->willReturn('https://pad.example.test/p/' . $newPadId);
 		$etherpadClient->method('deletePad')->willReturnCallback(function (string $padId) use ($oldPadId): void {
 			if ($padId === $oldPadId) {
@@ -566,7 +492,10 @@ class LifecycleServiceTest extends TestCase {
 		});
 
 		$secureRandom = $this->createMock(ISecureRandom::class);
-		$secureRandom->method('generate')->willReturn('abc123def456');
+		$secureRandom->expects($this->once())
+			->method('generate')
+			->with(12, ISecureRandom::CHAR_LOWER . ISecureRandom::CHAR_DIGITS)
+			->willReturn('abc123def456');
 
 		$file = $this->createMock(File::class);
 		$file->method('getId')->willReturn($fileId);
@@ -589,97 +518,6 @@ class LifecycleServiceTest extends TestCase {
 
 		$result = $service->handleRestore($file);
 		$this->assertSame(LifecycleService::RESULT_RESTORED, $result['status']);
-	}
-
-	public function testHandleRestoreFallsBackToTextWhenHtmlRestoreFails(): void {
-		$fileId = 83;
-		$oldPadId = 'old-pad';
-		$newPadId = 'r-old-pad-abc123def456';
-		$newPadUrl = 'https://pad.example.test/p/' . rawurlencode($newPadId);
-
-		$bindingService = $this->createMock(BindingService::class);
-		$bindingService->expects($this->once())
-			->method('findByFileId')
-			->with($fileId)
-			->willReturn([
-				'file_id' => $fileId,
-				'pad_id' => $oldPadId,
-				'access_mode' => BindingService::ACCESS_PUBLIC,
-				'state' => BindingService::STATE_PENDING_DELETE,
-			]);
-		$bindingService->expects($this->once())
-			->method('markRestored')
-			->with($fileId, $newPadId);
-
-		$padFileService = $this->createMock(PadFileService::class);
-		$parsedPad = new ParsedPadFile(
-			frontmatter: [],
-			body: 'body',
-			padId: $oldPadId,
-			accessMode: BindingService::ACCESS_PUBLIC,
-			padUrl: '',
-			isExternal: false,
-			snapshotRev: -1,
-		);
-		$padFileService->method('readPad')->with('doc-before')->willReturn($parsedPad);
-		$padFileService->expects($this->once())->method('getSnapshotPartsFromBody')->with($parsedPad->body)->willReturn(['text' => 'plain text', 'html' => '<p>html text</p>']);
-		$padFileService->expects($this->once())
-			->method('withRestoredSnapshot')
-			->with(
-				$this->identicalTo($parsedPad),
-				'plain text',
-				'<p>html text</p>',
-				$newPadId,
-				$newPadUrl
-			)
-			->willReturn('doc-after');
-
-		$etherpadClient = $this->createMock(EtherpadClient::class);
-		$etherpadClient->expects($this->once())->method('createPad')->with($newPadId);
-		$etherpadClient->expects($this->once())
-			->method('setHTML')
-			->with($newPadId, '<p>html text</p>')
-			->willThrowException(new \RuntimeException('setHTML unsupported'));
-		$etherpadClient->expects($this->once())->method('setText')->with($newPadId, 'plain text');
-		$etherpadClient->expects($this->once())->method('buildPadUrl')->with($newPadId)->willReturn($newPadUrl);
-		// The pad the restore replaced: once markRestored points the row at
-		// the new one, nothing names the old one again.
-		$etherpadClient->expects($this->once())->method('deletePad')->with($oldPadId);
-
-		$config = $this->buildDeleteOnTrashEnabledConfig();
-		$secureRandom = $this->createMock(ISecureRandom::class);
-		$secureRandom->expects($this->once())
-			->method('generate')
-			->with(12, ISecureRandom::CHAR_LOWER . ISecureRandom::CHAR_DIGITS)
-			->willReturn('abc123def456');
-
-		$logger = $this->createMock(LoggerInterface::class);
-		$logger->expects($this->once())->method('warning');
-
-		$file = $this->createMock(File::class);
-		$file->method('getId')->willReturn($fileId);
-		$file->method('getName')->willReturn('Restored.pad');
-		$file->expects($this->once())->method('getContent')->willReturn('doc-before');
-		$file->expects($this->once())->method('putContent')->with('doc-after');
-
-		$service = new LifecycleService(
-			$bindingService,
-			$padFileService,
-			$etherpadClient,
-			new ManagedPadLifecycle($etherpadClient, $logger),
-			$config,
-			$logger,
-			$secureRandom,
-			$this->createMock(UserNodeResolver::class),
-			$this->createMock(PathNormalizer::class),
-			new FixedClock(),
-		);
-
-		$result = $service->handleRestore($file);
-		$this->assertSame(LifecycleService::RESULT_RESTORED, $result['status']);
-		$this->assertSame($fileId, $result['file_id']);
-		$this->assertSame($oldPadId, $result['old_pad_id']);
-		$this->assertSame($newPadId, $result['new_pad_id']);
 	}
 
 	public function testHandleRestoreWithoutBindingRecreatesManagedPublicPad(): void {

--- a/tests/phpunit/unit/ManagedPadLifecycleTest.php
+++ b/tests/phpunit/unit/ManagedPadLifecycleTest.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace OCA\EtherpadNextcloud\Tests\Unit;
 
+use OCA\EtherpadNextcloud\Service\BindingService;
 use OCA\EtherpadNextcloud\Service\EtherpadClient;
 use OCA\EtherpadNextcloud\Service\ManagedPadLifecycle;
 use PHPUnit\Framework\TestCase;
@@ -180,5 +181,85 @@ class ManagedPadLifecycleTest extends TestCase {
 		$client->expects($this->once())->method('deletePad')->with('nc-abcdef0123456789');
 
 		$this->lifecycle($client)->discardProvisioned('nc-abcdef0123456789');
+	}
+
+	public function testProvisionsAPublicPadUnderTheIdItWasGiven(): void {
+		$client = $this->createMock(EtherpadClient::class);
+		$client->expects($this->once())->method('createPad')->with('nc-abcdef0123456789');
+		$client->expects($this->never())->method('createGroup');
+
+		$padId = $this->lifecycle($client)->provisionFor(
+			BindingService::ACCESS_PUBLIC,
+			static fn (): string => 'nc-abcdef0123456789',
+			static fn (): string => self::fail('the group name was built for a public pad'),
+		);
+
+		$this->assertSame('nc-abcdef0123456789', $padId);
+	}
+
+	public function testProvisionsAProtectedPadAsAGroupPad(): void {
+		$client = $this->createMock(EtherpadClient::class);
+		$client->expects($this->once())->method('createGroup')->willReturn('g.ABCDEFGHIJKLMNOP');
+		$client->expects($this->once())
+			->method('createGroupPad')
+			->with('g.ABCDEFGHIJKLMNOP', 'p-abc123')
+			->willReturn('g.ABCDEFGHIJKLMNOP$p-abc123');
+		$client->expects($this->never())->method('createPad');
+
+		$padId = $this->lifecycle($client)->provisionFor(
+			BindingService::ACCESS_PROTECTED,
+			static fn (): string => self::fail('the public id was built for a protected pad'),
+			static fn (): string => 'p-abc123',
+		);
+
+		$this->assertSame('g.ABCDEFGHIJKLMNOP$p-abc123', $padId);
+	}
+
+	/** Falling through to the public branch would hand out an unprotected pad. */
+	public function testRefusesAnAccessModeItDoesNotKnow(): void {
+		$client = $this->createMock(EtherpadClient::class);
+		$client->expects($this->never())->method('createPad');
+		$client->expects($this->never())->method('createGroup');
+
+		$this->expectException(\InvalidArgumentException::class);
+		$this->lifecycle($client)->provisionFor(
+			'something-else',
+			static fn (): string => 'nc-abcdef0123456789',
+			static fn (): string => 'p-abc123',
+		);
+	}
+
+	public function testSeedsWithHtmlSoFormattingSurvives(): void {
+		$client = $this->createMock(EtherpadClient::class);
+		$client->expects($this->once())->method('setHTML')->with('nc-pad', '<p>text</p>');
+		$client->expects($this->never())->method('setText');
+
+		$this->lifecycle($client)->seed('nc-pad', 'text', '<p>text</p>');
+	}
+
+	public function testSeedsWithPlainTextWhenThereIsNoHtml(): void {
+		$client = $this->createMock(EtherpadClient::class);
+		$client->expects($this->never())->method('setHTML');
+		$client->expects($this->once())->method('setText')->with('nc-pad', 'text');
+
+		$this->lifecycle($client)->seed('nc-pad', 'text', '   ');
+	}
+
+	/** Never both: setText replaces, so it would wipe the HTML just imported. */
+	public function testSeedsWithPlainTextOnlyAfterTheHtmlIsRefused(): void {
+		$client = $this->createMock(EtherpadClient::class);
+		$client->expects($this->once())
+			->method('setHTML')
+			->willThrowException(new \RuntimeException('setHTML unsupported'));
+		$client->expects($this->once())->method('setText')->with('nc-pad', 'text');
+
+		$logger = $this->createMock(LoggerInterface::class);
+		$logger->expects($this->once())
+			->method('warning')
+			->with($this->anything(), $this->callback(
+				static fn (array $context): bool => ($context['padId'] ?? '') === 'nc-pad' && ($context['fileId'] ?? 0) === 7
+			));
+
+		(new ManagedPadLifecycle($client, $logger))->seed('nc-pad', 'text', '<p>text</p>', ['fileId' => 7]);
 	}
 }

--- a/tests/phpunit/unit/ManagedPadLifecycleTest.php
+++ b/tests/phpunit/unit/ManagedPadLifecycleTest.php
@@ -25,6 +25,14 @@ class ManagedPadLifecycleTest extends TestCase {
 		return new ManagedPadLifecycle($client, $this->createMock(LoggerInterface::class));
 	}
 
+	private function provisionPublic(EtherpadClient $client, string $padId): string {
+		return $this->lifecycle($client)->provisionFor(
+			BindingService::ACCESS_PUBLIC,
+			static fn (): string => $padId,
+			static fn (): string => 'p-unused',
+		);
+	}
+
 	public function testDeletesTheWholeGroupWhenItHoldsOnlyThisPad(): void {
 		$padId = 'g.ABCDEFGHIJKLMNOP$p-abc123';
 		$client = $this->createMock(EtherpadClient::class);
@@ -143,7 +151,7 @@ class ManagedPadLifecycleTest extends TestCase {
 		$client->expects($this->once())->method('deletePad')->with('nc-abcdef0123456789');
 
 		$this->expectException(\RuntimeException::class);
-		$this->lifecycle($client)->provisionPad('nc-abcdef0123456789');
+		$this->provisionPublic($client, 'nc-abcdef0123456789');
 	}
 
 	/**
@@ -156,7 +164,27 @@ class ManagedPadLifecycleTest extends TestCase {
 		$client->expects($this->never())->method('deletePad');
 
 		$this->expectException(\RuntimeException::class);
-		$this->lifecycle($client)->provisionPad('nc-abcdef0123456789');
+		$this->provisionPublic($client, 'nc-abcdef0123456789');
+	}
+
+	/**
+	 * A group with no pad in it is invisible to everything afterwards, so the
+	 * failure that leaves one has to clean up after itself.
+	 */
+	public function testRemovesTheGroupWhosePadCouldNotBeCreated(): void {
+		$client = $this->createMock(EtherpadClient::class);
+		$client->expects($this->once())->method('createGroup')->willReturn('g.ABCDEFGHIJKLMNOP');
+		$client->expects($this->once())
+			->method('createGroupPad')
+			->willThrowException(new \RuntimeException('pad creation failed'));
+		$client->expects($this->once())->method('deleteGroup')->with('g.ABCDEFGHIJKLMNOP');
+
+		$this->expectException(\RuntimeException::class);
+		$this->lifecycle($client)->provisionFor(
+			BindingService::ACCESS_PROTECTED,
+			static fn (): string => 'nc-unused',
+			static fn (): string => 'p-abc123',
+		);
 	}
 
 	/**

--- a/tests/phpunit/unit/PadBootstrapServiceTest.php
+++ b/tests/phpunit/unit/PadBootstrapServiceTest.php
@@ -423,7 +423,12 @@ class PadBootstrapServiceTest extends TestCase {
 		$etherpadClient->method('buildPadUrl')->willReturn('https://pad.example.test/p/nc-abcdefghijklmnopqrstuvwx');
 
 		$secureRandom = $this->createMock(ISecureRandom::class);
-		$secureRandom->method('generate')->willReturn('abcdefghijklmnopqrstuvwx');
+		// A public pad is reachable by anyone holding its id, so the length
+		// of that id is the whole of its protection.
+		$secureRandom->expects($this->once())
+			->method('generate')
+			->with(24, ISecureRandom::CHAR_LOWER . ISecureRandom::CHAR_DIGITS)
+			->willReturn('abcdefghijklmnopqrstuvwx');
 
 		$file = $this->createMock(File::class);
 		$file->method('getId')->willReturn(4321);

--- a/tests/phpunit/unit/PadBootstrapServiceTest.php
+++ b/tests/phpunit/unit/PadBootstrapServiceTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace OCA\EtherpadNextcloud\Tests\Unit;
 
 use OCA\EtherpadNextcloud\Exception\MissingFrontmatterException;
-use OCA\EtherpadNextcloud\Exception\PadFileFormatException;
 use OCA\EtherpadNextcloud\Exception\UnrecognisedPadContentException;
 use OCA\EtherpadNextcloud\Service\BindingService;
 use OCA\EtherpadNextcloud\Service\EtherpadClient;
@@ -158,39 +157,6 @@ class PadBootstrapServiceTest extends TestCase {
 
 		$this->expectException(\RuntimeException::class);
 		$service->initializeMissingFrontmatter('alice', $file, '');
-	}
-
-	/**
-	 * A group with no pad in it is invisible to everything afterwards, so the
-	 * failure that leaves one has to clean up after itself. Both provisioning
-	 * paths — this one and the restore — go through the same method now, so
-	 * this covers both.
-	 */
-	public function testProvisionRemovesTheGroupWhenItsPadCannotBeCreated(): void {
-		$etherpadClient = $this->createMock(EtherpadClient::class);
-		$etherpadClient->expects($this->once())->method('createGroup')->willReturn('g.ABCDEFGHIJKLMNOP');
-		$etherpadClient->expects($this->once())
-			->method('createGroupPad')
-			->willThrowException(new \RuntimeException('pad creation failed'));
-		$etherpadClient->expects($this->once())->method('deleteGroup')->with('g.ABCDEFGHIJKLMNOP');
-
-		$secureRandom = $this->createMock(ISecureRandom::class);
-		$secureRandom->method('generate')->willReturn('abcdefghijklmnopqrst');
-
-		$service = new PadBootstrapService(
-			$this->createMock(BindingService::class),
-			$this->createMock(PadFileService::class),
-			$etherpadClient,
-			new ManagedPadLifecycle($etherpadClient, $this->createMock(LoggerInterface::class)),
-			$secureRandom,
-			$this->createMock(LoggerInterface::class),
-			$this->createMock(\OCA\EtherpadNextcloud\Service\PadLegacyMigrationService::class),
-			$this->buildPadTypePolicy(true),
-			$this->resolverReturning(null),
-		);
-
-		$this->expectException(\RuntimeException::class);
-		$service->provisionPadId(BindingService::ACCESS_PROTECTED);
 	}
 
 	/**
@@ -571,35 +537,25 @@ class PadBootstrapServiceTest extends TestCase {
 	}
 
 	/**
-	 * A `createPad` that times out on the way back may still have made the
-	 * pad, and the caller never learns the id — `provisionPadId` throws
-	 * before returning it, so no rollback can name it. The public path had
-	 * no cleanup of its own; the protected one has had it since the group
-	 * was pulled into provisioning.
+	 * A row is written after the pad it names, never before: a row naming a
+	 * pad that was never made is a file nothing can open again.
 	 */
-	public function testRemovesAPublicPadWhoseCreationFailedHalfway(): void {
-		$fileId = 99;
-		$padId = 'nc-abcdefghijklmnopqrstuvwx';
-
+	public function testWritesNoBindingWhenTheProvisioningFails(): void {
 		$bindingService = $this->createMock(BindingService::class);
-		$bindingService->method('findByFileId')->with($fileId)->willReturn(null);
+		$bindingService->method('findByFileId')->willReturn(null);
 		$bindingService->expects($this->never())->method('createBinding');
 
 		$padFileService = $this->createMock(PadFileService::class);
 		$padFileService->method('parseLegacyOwnpadShortcut')->willReturn(null);
 
 		$etherpadClient = $this->createMock(EtherpadClient::class);
-		$etherpadClient->expects($this->once())
-			->method('createPad')
-			->with($padId)
-			->willThrowException(new \RuntimeException('Connection timed out'));
-		$etherpadClient->expects($this->once())->method('deletePad')->with($padId);
+		$etherpadClient->method('createPad')->willThrowException(new \RuntimeException('Connection timed out'));
 
 		$secureRandom = $this->createMock(ISecureRandom::class);
 		$secureRandom->method('generate')->willReturn('abcdefghijklmnopqrstuvwx');
 
 		$file = $this->createMock(File::class);
-		$file->method('getId')->willReturn($fileId);
+		$file->method('getId')->willReturn(99);
 
 		$service = new PadBootstrapService(
 			$bindingService,

--- a/tests/phpunit/unit/PadCreationServiceTest.php
+++ b/tests/phpunit/unit/PadCreationServiceTest.php
@@ -509,9 +509,6 @@ class PadCreationServiceTest extends TestCase {
 			->method('provisionPadId')
 			->with(BindingService::ACCESS_PROTECTED)
 			->willReturn('p-fresh');
-		$bootstrap->expects($this->once())
-			->method('pushInitialSnapshot')
-			->with('p-fresh', 'Datum: 18.05.2026', '');
 
 		$bindingService = $this->createMock(BindingService::class);
 		$bindingService->expects($this->once())
@@ -520,6 +517,8 @@ class PadCreationServiceTest extends TestCase {
 
 		$etherpadClient = $this->createMock(EtherpadClient::class);
 		$etherpadClient->method('buildPadUrl')->willReturn('https://pad.example.test/p/p-fresh');
+		// No HTML in this template, so seeding is the plain-text call.
+		$etherpadClient->expects($this->once())->method('setText')->with('p-fresh', 'Datum: 18.05.2026');
 
 		$user = $this->createMock(\OCP\IUser::class);
 		$user->method('getDisplayName')->willReturn('Alice');

--- a/tests/phpunit/unit/PadCreationServiceTest.php
+++ b/tests/phpunit/unit/PadCreationServiceTest.php
@@ -265,6 +265,9 @@ class PadCreationServiceTest extends TestCase {
 
 		$etherpadClient = $this->createMock(EtherpadClient::class);
 		$etherpadClient->method('buildPadUrl')->willReturn('https://pad.example.test/p/x');
+		// The template's formatting is what reaches the pad, not its text.
+		$etherpadClient->expects($this->once())->method('setHTML')->with('g.grp$pad', '<p>hello</p>');
+		$etherpadClient->expects($this->never())->method('setText');
 
 		$bindingService = $this->createMock(BindingService::class);
 		$bindingService->expects(self::once())


### PR DESCRIPTION
A pad is made in two steps: pick the Etherpad primitive the access mode calls for, then push the snapshot into what came back. Restore had its own copy of both, written out beside the creation path rather than shared with it.

## One way in

`ManagedPadLifecycle` already knew how to take a pad away again, and already held `provisionPad()` and `provisionGroupPad()`. It now holds the two steps that use them, as `provisionFor()` and `seed()`, and its docblock says so. Both were already injected where they are needed, so nothing new is wired up: `PadBootstrapService::provisionPadId()` and `LifecycleService::provisionRestorePadId()` shrink to the names their pads get, and `PadBootstrapService::pushInitialSnapshot()` is gone rather than left as a delegate.

The names stay with the callers, because a name says where its pad came from – `nc-` and `p-` for a first open, `r-<old id>-` and `restored-` for a restore. They are passed unbuilt, as closures, so the branch not taken draws no randomness. That is not cosmetic: building both eagerly calls `ISecureRandom::generate()` twice per pad and throws one away, and two existing tests said so before this was written. Both call sites name their arguments, since two adjacent `callable(): string` parameters are told apart by position alone.

`provisionPad()` and `provisionGroupPad()` are private now. `provisionFor()` is the only way in, so nothing can reach a primitive without passing the access-mode check on the way.

## The copies had drifted

Creation refused an access mode it did not recognise. Restore treated anything that was not `protected` as public, so a row naming a third thing would have been restored as an **unprotected** pad – losing the group, and with it the only thing standing between that pad and anyone who knows its id. The shared version refuses.

The restore skips rather than fails. Of the two ways to lose, taking the file's own trashbin restore down with it is the worse one: the restore errors, every retry errors identically, and nothing repairs the row. A skipped result leaves the binding in `pending_delete`, where the retry job still finds the pad it names, and reads like every other unusable binding the method already skips. Only `InvalidArgumentException` is caught, and only around the provisioning call, so an Etherpad failure still travels as before.

Nothing in the app can write such a row: `BindingService::createBinding()` calls `assertAccessMode()` on the way in, so a third value needs direct database access. This is consistency rather than a live bug – but of the two ways to be inconsistent, silently handing out an unprotected pad is the one worth removing.

The snapshot push was identical line for line; only the log message and its context differed. `seed()` takes the extra context as a parameter, so a restore's warning still names the file and the pad it superseded, and the template path now passes the file id it already had in hand. The base keys win a collision, so a caller cannot relabel the pad the line is about.

## Rules are tested where they live

The cleanup rules – a failed `createPad` removes the pad it may have made, a failed `createGroupPad` removes its group – were being asserted through their callers: a whole frontmatter init, a whole restore, and one of them through reflection on a private method. They belong to the class that provisions, and are tested there directly now, including the group case that had no direct test at all. The HTML-then-text fallback moved the same way.

Moving tests loses arguments even when it keeps behaviour, and it did here before review caught it. The deleted fallback test was pinning two things: the fallback itself, which moved, and the fact that a snapshot's HTML half reaches the pad at all, which did not. Seeding a pad as plain text – every heading, list and emphasis gone – passed the suite in between. Both restore and template paths now pin that argument in a test that already drives the flow, and the length of a public pad's random id is pinned too, since that id is the whole of an unprotected pad's protection.

What is still the caller's own is asserted with the caller: an init writes no binding row for a pad that was never made, and a restore whose pad cannot be made never marks the row restored. Neither is covered anywhere else, which is why both survived the consolidation rather than following their neighbours out.

Also fixed in passing: two docblocks stacked above one test, so PHP saw only the second and the first described a different test entirely; two more that called provisioning a name-building step; and an import with no user left.

## Out of scope

The larger overlap between first-open initialisation, template materialisation and recovery is unchanged – `recoverFromSnapshot` still mirrors `initializeMissingFrontmatter` in shape and rollback. That is #199.

The set of valid access modes is written out in four places that fail four different ways, and `provisionFor()` is the fourth. A `PadAccessMode` enum whose `tryFrom()` is the single check would collapse them and remove the layering inversion where the Etherpad wrapper reaches for a constant on the database mapper. It touches every `ACCESS_*` use in the app, so it wants its own change; this one at least adds no fifth place, since the skip above reads the answer out of the existing check rather than repeating it.

## Verification

1026 PHPUnit tests / 3263 assertions, Psalm 0 errors at `errorLevel=4` with `findUnusedCode=true`, 16 vitest files / 250 tests on Node 24.15.0, full Playwright suite 36 passed / 1 skipped against Nextcloud 34. `js/` is unchanged by a rebuild and `git diff --check` is clean.

Sixteen mutations were run against an isolated copy of the tree, each reverted before the next. Fifteen were caught: an unknown access mode falling through to public and, separately, throwing instead of skipping; `seed()` continuing after a successful `setHTML`; `seed()` reaching for HTML that is not there; both names built eagerly; creation not seeding; restore not seeding; either path seeding without the HTML half; a group left behind by a failed `createGroupPad`; a public pad left behind by a failed `createPad`; a shortened `nc-` suffix; a binding row claimed before its pad exists; and a swallowed provisioning failure on each of the two paths. The sixteenth – dropping the file id from the template path's log context – is deliberately uncovered: a unit test on a caller's log fields breaks on every rewording and guards little, and the mechanism itself is pinned where `seed()` is tested.

Three review rounds, one commit each, and the two regressions both came from moving tests rather than from writing code.
