### PR TITLE
Release 1.1.0-alpha.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,48 @@
 # Changelog
 
+## 1.1.0-alpha.5 — 2026-09-07
+
+Fifth public-review release. Focus: a view-only share of a protected pad that is view-only on the pad server too, live read-only content, Etherpad session cleanup, Nextcloud 34, and one implementation each for creating, provisioning and opening a pad.
+
+### Added
+
+- **Live read-only view.** A reader without write permission sees the pad as it reads now, fetched from Etherpad, instead of the snapshot last written into the `.pad` file. It refreshes in place and its HTML is sanitised before it is rendered. (#218)
+- **Nextcloud 34.** Declared and tested range is now 31 through 34. (#227)
+- **Expired Etherpad sessions are collected** in the background, and logging out of Nextcloud revokes the user's active Etherpad sessions. (#213, #214)
+- **A public share addresses its pad by file id.** Renaming or moving a shared file no longer breaks the link, and `A+B.pad` can no longer open the pad belonging to `A B.pad`. An id that disagrees with the path, points outside the share or cannot be used is refused rather than falling back to the path. (#235)
+
+### Security
+
+- **A view-only share of a protected pad is view-only on the pad server too.** Until now it opened in the editor: nothing on the authenticated path asked whether the recipient may write, so a "can view" share was issued an ordinary Etherpad session. A protected pad now renders without a session, a public one gets Etherpad's read-only URL - presentation rather than enforcement, since a public pad is reachable by anyone holding its id - and `readOnly` asks the share and the mount it was reached through. (#217, #235)
+- **Frontmatter that would be read back as something else is refused.** Unsafe line breaks and NUL bytes are rejected instead of being silently altered or parsed as further keys. (#229, #231)
+- Live content responses are not cached, and permissions and binding are checked on every request rather than only at open time. (#218)
+- An external pad's export is capped at 5 MiB and follows no redirects, alongside the existing SSRF protections. (#218)
+- DOMPurify 3.4.14, bundles rebuilt. (#202)
+- The `child-src` override was removed: it is obsolete, interferes with Nextcloud's workers and is incompatible with Nextcloud 34. (#227)
+
+### Changed
+
+- **One way to create a file.** Creation, initialisation and rollback work from a file's identity and its expected content rather than from a path or a node object handed over earlier, so a concurrent move, replacement or duplicate request can no longer make them act on the wrong file. (#219, #220, #221, #222)
+- **One way to provision a pad.** A first open and a restore from the trash pick the Etherpad primitive and seed the snapshot through the same path; an access mode neither of them recognises is refused rather than turned into an unprotected pad. (#236)
+- **One way to read an open response.** The Viewer and the embed share the missing-metadata check, the payload validation, the read-only decision and the sync interval, which the embed had been taking unbounded. (#237)
+- **A `.pad` file is parsed once** and passed through opening and initialisation as structured data. (#230)
+- The frontend reads stable error codes such as `missing_frontmatter` instead of matching an English sentence. (#223)
+- Time-dependent services read the clock through `ITimeFactory`. (#232)
+
+### Fixed
+
+- **A public-share click on an unhandled type falls back again.** `Viewer.open()` can reject asynchronously, and every rejection was being swallowed, leaving nothing to fall back to after `preventDefault()`. (#228)
+- **Existing `.pad` files get their mime *part* repaired** during upgrade, and a folder named `Archive.pad` is no longer rewritten as a pad file. (#233)
+- **`.PAD` is a pad file**, including through a DAV link, and every rule about the suffix, the extension, the mime type and the Files address has one home. (#234)
+- The `window.OCA.Files.fileActions` registration was removed: the API exists on none of the supported majors, and Nextcloud's own Viewer answers the click. (#228)
+
+### Tooling / tests / CI
+
+- End-to-end coverage for view-only shares, live content, public shares by id, session collection and logout revocation. (#213, #214, #217, #218, #235)
+- The CI and e2e matrices cover Nextcloud 34, and `scripts/check-nextcloud-range.py` holds seven files to the range `info.xml` declares. (#227)
+- Node `^24.15.0` and npm `^11.0.0` are required and enforced by `npm ci --engine-strict`; on Node 20 two jsdom-pinned suites fail to load while the summary reads as a near miss. (#234)
+- `fast-uri`, `browserslist` and `happy-dom` updated. (#215, #216, #224)
+
 ## 1.1.0-alpha.4 — 2026-08-31
 
 Fourth public-review release. Focus: one pad-creation entry point with shared templates, a clearer admin surface, protected-pad session and lifecycle correctness, and a disposable end-to-end stack that runs the browser suite across three Nextcloud and two Etherpad majors.

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -5,7 +5,7 @@
 	<name>Etherpad Integration for Nextcloud</name>
 	<summary>Standalone Etherpad integration for Nextcloud</summary>
 	<description>Standalone Etherpad integration for Nextcloud with binding-based lifecycle and secure viewer flows.</description>
-	<version>1.1.0-alpha.4</version>
+	<version>1.1.0-alpha.5</version>
 	<licence>agpl</licence>
 	<author>Jacob Bühler</author>
 	<author>John McLear</author>

--- a/js/api-client-Cv5Zp3Sw.chunk.mjs.license
+++ b/js/api-client-Cv5Zp3Sw.chunk.mjs.license
@@ -3,5 +3,5 @@ SPDX-FileCopyrightText: etherpad-nextcloud developers
 
 This file is generated from multiple sources. Included packages:
 - etherpad-nextcloud
-	- version: 1.1.0-alpha.4
+	- version: 1.1.0-alpha.5
 	- license: AGPL-3.0-or-later

--- a/js/etherpad_nextcloud-admin-settings.mjs.license
+++ b/js/etherpad_nextcloud-admin-settings.mjs.license
@@ -3,5 +3,5 @@ SPDX-FileCopyrightText: etherpad-nextcloud developers
 
 This file is generated from multiple sources. Included packages:
 - etherpad-nextcloud
-	- version: 1.1.0-alpha.4
+	- version: 1.1.0-alpha.5
 	- license: AGPL-3.0-or-later

--- a/js/etherpad_nextcloud-embed-create-main.mjs.license
+++ b/js/etherpad_nextcloud-embed-create-main.mjs.license
@@ -3,5 +3,5 @@ SPDX-FileCopyrightText: etherpad-nextcloud developers
 
 This file is generated from multiple sources. Included packages:
 - etherpad-nextcloud
-	- version: 1.1.0-alpha.4
+	- version: 1.1.0-alpha.5
 	- license: AGPL-3.0-or-later

--- a/js/etherpad_nextcloud-embed-main.mjs.license
+++ b/js/etherpad_nextcloud-embed-main.mjs.license
@@ -3,5 +3,5 @@ SPDX-FileCopyrightText: etherpad-nextcloud developers
 
 This file is generated from multiple sources. Included packages:
 - etherpad-nextcloud
-	- version: 1.1.0-alpha.4
+	- version: 1.1.0-alpha.5
 	- license: AGPL-3.0-or-later

--- a/js/etherpad_nextcloud-files-main.mjs.license
+++ b/js/etherpad_nextcloud-files-main.mjs.license
@@ -3,5 +3,5 @@ SPDX-FileCopyrightText: etherpad-nextcloud developers
 
 This file is generated from multiple sources. Included packages:
 - etherpad-nextcloud
-	- version: 1.1.0-alpha.4
+	- version: 1.1.0-alpha.5
 	- license: AGPL-3.0-or-later

--- a/js/etherpad_nextcloud-viewer-main.mjs.license
+++ b/js/etherpad_nextcloud-viewer-main.mjs.license
@@ -3,5 +3,5 @@ SPDX-FileCopyrightText: etherpad-nextcloud developers
 
 This file is generated from multiple sources. Included packages:
 - etherpad-nextcloud
-	- version: 1.1.0-alpha.4
+	- version: 1.1.0-alpha.5
 	- license: AGPL-3.0-or-later

--- a/js/fetch-helpers-B3mjX2Zx.chunk.mjs.license
+++ b/js/fetch-helpers-B3mjX2Zx.chunk.mjs.license
@@ -3,5 +3,5 @@ SPDX-FileCopyrightText: etherpad-nextcloud developers
 
 This file is generated from multiple sources. Included packages:
 - etherpad-nextcloud
-	- version: 1.1.0-alpha.4
+	- version: 1.1.0-alpha.5
 	- license: AGPL-3.0-or-later

--- a/js/pad-open-flow-Det1f8ig.chunk.mjs.license
+++ b/js/pad-open-flow-Det1f8ig.chunk.mjs.license
@@ -8,5 +8,5 @@ This file is generated from multiple sources. Included packages:
 	- version: 3.4.14
 	- license: (MPL-2.0 OR Apache-2.0)
 - etherpad-nextcloud
-	- version: 1.1.0-alpha.4
+	- version: 1.1.0-alpha.5
 	- license: AGPL-3.0-or-later

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "etherpad-nextcloud",
-	"version": "1.1.0-alpha.4",
+	"version": "1.1.0-alpha.5",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "etherpad-nextcloud",
-			"version": "1.1.0-alpha.4",
+			"version": "1.1.0-alpha.5",
 			"license": "AGPL-3.0-or-later",
 			"dependencies": {
 				"dompurify": "^3.4.14"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "etherpad-nextcloud",
-	"version": "1.1.0-alpha.4",
+	"version": "1.1.0-alpha.5",
 	"private": true,
 	"license": "AGPL-3.0-or-later",
 	"type": "module",


### PR DESCRIPTION
Version bump to 1.1.0-alpha.5 across `appinfo/info.xml`, `package.json` and the lock, plus the changelog entry written from the 24 pull requests merged since `v1.1.0-alpha.4`. No code changes.

What the release is about: a view-only share of a protected pad that is view-only on the pad server too, a read-only view that shows the pad as it reads now, Etherpad sessions that are collected and revoked, Nextcloud 34, and one implementation each for creating a file, provisioning a pad and reading an open response.

All 24 merges are accounted for in the entry, none twice. Four claims were checked against the code rather than the pull request titles: the 5 MiB cap is `ExternalPadExportFetcher::EXTERNAL_EXPORT_MAX_BYTES` and applies to an external pad's export rather than to content responses in general; `scripts/check-nextcloud-range.py` holds seven files to the declared range, not two; the frontmatter guard rejects a carriage return or NUL per line on read and a line terminator or NUL per value on write, so "line breaks on read" would have overstated it; and the view-only fix is scoped to protected pads, since Etherpad's read-only URL for a public pad is presentation rather than enforcement.

The view-only entry says what the behaviour was before, not only that it is better now: a share without write permission opened a protected pad in the editor, because nothing on the authenticated path asked whether the recipient may write. The release notes carry the same in the upgrade section, where someone who shared a pad read-only can act on it.

## Verification

`scripts/check-nextcloud-range.py` passes, and `info.xml`, `package.json` and `package-lock.json` agree on the version. 1026 PHPUnit tests / 3263 assertions, Psalm 0 errors, 17 vitest files / 273 tests on Node 24.15.0. The Playwright suite was not re-run for this branch: it changes a version string and a changelog, and it ran green on `main` at this commit.
