### PR TITLE
Leave macOS extended attributes out of the release archive

### DIFF
--- a/scripts/build-release-tarball.sh
+++ b/scripts/build-release-tarball.sh
@@ -18,6 +18,11 @@
 #     extracted with stray `._*` files on Linux.
 #   - --no-mac-metadata (available on newer macOS tar) is set when
 #     supported as a second line of defence.
+#   - --no-xattrs drops extended attributes, which travel as pax
+#     headers rather than as sidecar files. macOS puts
+#     com.apple.provenance on everything it downloads, and neither of
+#     the two above removes it; GNU tar warns about each one it cannot
+#     read on extraction.
 
 set -euo pipefail
 
@@ -66,12 +71,14 @@ mkdir -p "$OUTPUT_DIR"
 ARTIFACT="$OUTPUT_DIR/$APP_ID-$VERSION.tar.gz"
 
 # Build the archive with macOS metadata-pollution defences enabled.
-# `--no-mac-metadata` is a BSD-tar extension; older `tar` builds
-# don't know it, so we try it first and fall back to the plain
-# COPYFILE_DISABLE=1 path.
+# The two flags are extensions that older `tar` builds do not know, so
+# each is tried and dropped in turn down to the plain COPYFILE_DISABLE=1
+# path. The checks below decide whether what came out is clean.
 cd "$STAGE_DIR"
-if ! COPYFILE_DISABLE=1 tar --no-mac-metadata -czf "$ARTIFACT" "$APP_ID" 2>/dev/null; then
-	COPYFILE_DISABLE=1 tar -czf "$ARTIFACT" "$APP_ID"
+if ! COPYFILE_DISABLE=1 tar --no-mac-metadata --no-xattrs -czf "$ARTIFACT" "$APP_ID" 2>/dev/null; then
+	if ! COPYFILE_DISABLE=1 tar --no-mac-metadata -czf "$ARTIFACT" "$APP_ID" 2>/dev/null; then
+		COPYFILE_DISABLE=1 tar -czf "$ARTIFACT" "$APP_ID"
+	fi
 fi
 
 # Verify: zero AppleDouble or .DS_Store entries in the published
@@ -82,6 +89,19 @@ LEAKED="$(tar -tzf "$ARTIFACT" | grep -E '(^|/)\._|(^|/)\.DS_Store$' || true)"
 if [[ -n "$LEAKED" ]]; then
 	echo "ERROR: tarball contains macOS metadata files:" >&2
 	echo "$LEAKED" >&2
+	exit 1
+fi
+
+# Extended attributes carry no file of their own, so the listing above
+# cannot see them. They are in the byte stream as pax headers.
+#
+# Counted rather than matched: `grep -q` stops at the first hit, which
+# closes the pipe under the decompressor, and `pipefail` then reads that
+# as a failed pipeline - so the test would say "clean" for exactly the
+# archives it is meant to catch.
+XATTR_HEADERS="$(gzip -dc "$ARTIFACT" | grep -ac -e 'LIBARCHIVE.xattr' -e 'SCHILY.xattr' || true)"
+if [[ "$XATTR_HEADERS" != "0" ]]; then
+	echo "ERROR: tarball carries extended attributes as pax headers ($XATTR_HEADERS)." >&2
 	exit 1
 fi
 


### PR DESCRIPTION
Extracting the 1.1.0-alpha.5 archive on a Linux host prints a warning per file:

```
tar: Ignoring unknown extended header keyword 'LIBARCHIVE.xattr.com.apple.provenance'
```

macOS puts `com.apple.provenance` on everything it downloads, and an extended attribute travels as a pax header rather than as a file of its own. The existing defences do not reach it: `COPYFILE_DISABLE=1` suppresses AppleDouble sidecars, `--no-mac-metadata` suppresses the resource fork, and the guard that follows lists entries, which a header is not. The published archive carried 484 of them and was 13 KB larger than the files inside it.

`--no-xattrs` drops them. It joins the same probe-and-fall-back chain as the flag before it, since both are extensions an older `tar` will not know, and the checks decide whether what came out is clean rather than the flags being assumed to work.

## The check had to be written twice

The first version was `gzip -dc "$ARTIFACT" | grep -qa 'LIBARCHIVE.xattr'`, and it reported a clean archive for a polluted one. `grep -q` exits at the first match, which closes the pipe under the decompressor; `set -o pipefail` then reads the pipeline as failed, and the `if` takes that as "nothing found". Counting instead of matching reads the whole stream, so there is no early exit to trip over.

Verified by removing `--no-xattrs` and running the script: it now stops with `ERROR: tarball carries extended attributes as pax headers (484).` and exit 1, where the first version printed `Built:` and exit 0.

## The app files are unchanged

Rebuilt with the fix and extracted next to the published archive: `diff -r` reports no difference in any of the 242 entries. Only the headers are gone - 818,931 bytes to 805,672.
