### PR TITLE
Give an open pad six hours, and a shared one three

### DIFF
--- a/docs/etherpad-integration.md
+++ b/docs/etherpad-integration.md
@@ -215,7 +215,8 @@ away itself:
   every socket message and keeps the session id it was handed when the pad
   connected – read in 2.7.3, 3.0.0 and 3.3.3 – so a session that expires
   mid-edit rejects the next keystroke, and no later cookie reaches that
-  socket. What bounds the window is revocation, not a shorter lifetime.
+  socket. Revocation fires on an explicit logout and nowhere else, and is
+  capped, so for most sessions the lifetime is what bounds the window.
 - Expired sessions are left to the background sweep described below. Only
   what is expired by both clocks counts as expired: Etherpad judges
   `validUntil` with its own, so a session ours calls dead may still be

--- a/lib/Service/PadOpenService.php
+++ b/lib/Service/PadOpenService.php
@@ -155,7 +155,7 @@ class PadOpenService {
 
 		$cookieHeader = '';
 		if ($accessMode === BindingService::ACCESS_PROTECTED) {
-			$openContext = $this->padSessionService->createProtectedOpenContext($uid, $displayName, $padId, 3600);
+			$openContext = $this->padSessionService->createProtectedOpenContext($uid, $displayName, $padId);
 			$url = $openContext['url'];
 			$cookieHeader = $this->padSessionService->buildSetCookieHeader($openContext['cookie']);
 		} else {

--- a/lib/Service/PadSessionService.php
+++ b/lib/Service/PadSessionService.php
@@ -41,6 +41,13 @@ class PadSessionService {
 	 */
 	public const MAX_SESSION_IDS = 25;
 
+	/**
+	 * How long a session an authenticated open mints stays valid. Chosen,
+	 * not derived: revocation fires on an explicit logout and nowhere else,
+	 * so for most sessions this is the bound.
+	 */
+	public const SESSION_TTL_SECONDS = 21600;
+
 	/** `lax` (default) or `none`; see sameSiteMode(). */
 	public const SAME_SITE_KEY = 'etherpad_session_cookie_samesite';
 	public const SAME_SITE_LAX = 'Lax';
@@ -69,7 +76,7 @@ class PadSessionService {
 	}
 
 	/** @return array{url:string,cookie:array{name:string,value:string,expires:int,path:string,domain:string,secure:bool,http_only:bool,same_site:string}} */
-	public function createProtectedOpenContext(string $uid, string $displayName, string $padId, int $ttlSeconds = 3600): array {
+	public function createProtectedOpenContext(string $uid, string $displayName, string $padId, int $ttlSeconds = self::SESSION_TTL_SECONDS): array {
 		$groupId = $this->extractGroupId($padId);
 		$effectiveDisplayName = trim($displayName) !== '' ? $displayName : $uid;
 		$safeTtlSeconds = max(60, $ttlSeconds);

--- a/lib/Service/PublicPadOpenService.php
+++ b/lib/Service/PublicPadOpenService.php
@@ -20,7 +20,12 @@ use OCA\EtherpadNextcloud\Exception\EtherpadClientException;
  */
 class PublicPadOpenService {
 	private const PUBLIC_SHARE_AUTHOR_NAME = 'Public share';
-	private const PUBLIC_SHARE_SESSION_TTL_SECONDS = 3600;
+	/**
+	 * Nothing revokes this one - a visitor never logs out - so it is the
+	 * whole lifetime of a withdrawn share's write access. Shorter than an
+	 * authenticated session for that reason.
+	 */
+	private const PUBLIC_SHARE_SESSION_TTL_SECONDS = 10800;
 
 	public function __construct(
 		private EtherpadClient $etherpadClient,

--- a/tests/phpunit/unit/PadSessionServiceTest.php
+++ b/tests/phpunit/unit/PadSessionServiceTest.php
@@ -281,12 +281,11 @@ class PadSessionServiceTest extends TestCase {
 	}
 
 	/**
-	 * Strictly longer than the new session's hour, so this cannot pass with
-	 * the expiry taken from the new session alone — and cannot fail because
-	 * a second ticked between two FixedClock::NOW calls.
+	 * Derived from the TTL rather than a literal: it has to outlast the new
+	 * session whatever that is, or the expiry could come from it alone.
 	 */
 	public function testTheCookieOutlivesEveryIdItCarries(): void {
-		$longer = FixedClock::NOW + 7200;
+		$longer = FixedClock::NOW + PadSessionService::SESSION_TTL_SECONDS + 3600;
 		$other = $this->sid('other');
 
 		$cookie = $this->openContextCookie(

--- a/tests/phpunit/unit/PublicPadOpenServiceTest.php
+++ b/tests/phpunit/unit/PublicPadOpenServiceTest.php
@@ -35,7 +35,7 @@ class PublicPadOpenServiceTest extends TestCase {
 		$sessions = $this->createMock(PadSessionService::class);
 		$sessions->expects($this->once())
 			->method('createProtectedOpenContext')
-			->with('public-share:token', 'Public share', 'g.group$pad', 3600)
+			->with('public-share:token', 'Public share', 'g.group$pad', self::shareTtl())
 			->willReturn(['url' => 'https://pad.example/p/g.group$pad', 'cookie' => ['name' => 'sessionID']]);
 		$sessions->expects($this->once())
 			->method('buildSetCookieHeader')
@@ -154,5 +154,23 @@ class PublicPadOpenServiceTest extends TestCase {
 			$externalPadExportFetcher ?? $this->createMock(ExternalPadExportFetcher::class),
 			$padSessionService ?? $this->createMock(PadSessionService::class),
 		);
+	}
+
+	/**
+	 * Nothing revokes a share session, so its length is the whole exposure
+	 * of a withdrawn share. Both numbers are pinned, not just their order:
+	 * "shorter than the other" is satisfied by values far too long.
+	 */
+	public function testTheSessionLifetimesAreWhatWasChosen(): void {
+		$this->assertSame(10800, self::shareTtl());
+		$this->assertSame(21600, PadSessionService::SESSION_TTL_SECONDS);
+		$this->assertLessThan(PadSessionService::SESSION_TTL_SECONDS, self::shareTtl());
+	}
+
+	private static function shareTtl(): int {
+		$ttl = (new \ReflectionClass(PublicPadOpenService::class))
+			->getConstant('PUBLIC_SHARE_SESSION_TTL_SECONDS');
+		self::assertIsInt($ttl);
+		return $ttl;
 	}
 }


### PR DESCRIPTION
An authenticated session lasts six hours, and a public share's session three. Both were an hour before. The numbers are chosen rather than derived – a pad open across a morning should not have to be reopened – and what follows is what bounds them.

### What bounds an authenticated session

Its lifetime, for most sessions. `UserLoggedOutListener` answers `UserLoggedOutEvent` alone, so closing a tab, closing a laptop or letting a Nextcloud session lapse revokes nothing. A deliberate logout stops at `MAX_PER_REQUEST` – 25 deletes, taken from a cookie-capacity constant – or two seconds, whichever comes first. Sessions accumulate per *open* rather than per pad, because every open deliberately mints a fresh one, so an active day can leave more of them than a logout can clear. `docs/etherpad-integration.md` says this where it previously credited revocation with the bound.

### What bounds a share session

Only its lifetime. Nothing revokes it: `shouldPersistAuthorState()` excludes `public-share:` uids from the author cache, and that cache is what a revoke walks. Three hours is therefore the entire time a withdrawn share stays writable for whoever kept the pad address, which is why it is shorter than an authenticated session.

### What the tests hold

Both values, not only their order. "Shorter than the other" is satisfied by values far too long: the share session passes at 43199 seconds under an order-only assertion, which is the outcome the constant exists to prevent. Both numbers are pinned, and a test asserting that the cookie outlives every session id it carries derives its comparison from the constant rather than spelling an hour.

### What this does not change

Losing access any way other than logging out – an unshared file, a permission downgrade, a disabled or deleted account – revokes nothing, as `docs/etherpad-integration.md` states. The accumulation per open and the revoke ceiling are unchanged. Longer lifetimes make each of those matter more in degree, not in kind, and each wants a change of its own.
